### PR TITLE
Implements `is_valid_classic_address` in `addresscodec`

### DIFF
--- a/tests/addresscodec/test_main.py
+++ b/tests/addresscodec/test_main.py
@@ -127,3 +127,27 @@ class TestMain(unittest.TestCase):
             None,
             False,
         )
+
+    def test_is_valid_classic_address_secp256k1(self):
+        classic_address = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1"
+
+        result = addresscodec.is_valid_classic_address(classic_address)
+        self.assertTrue(result)
+
+    def test_is_valid_classic_address_ed25519(self):
+        classic_address = "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD"
+
+        result = addresscodec.is_valid_classic_address(classic_address)
+        self.assertTrue(result)
+
+    def test_is_valid_classic_address_invalid(self):
+        classic_address = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw2"
+
+        result = addresscodec.is_valid_classic_address(classic_address)
+        self.assertFalse(result)
+
+    def test_is_valid_classic_address_empty(self):
+        classic_address = ""
+
+        result = addresscodec.is_valid_classic_address(classic_address)
+        self.assertFalse(result)

--- a/xrpl/addresscodec/main.py
+++ b/xrpl/addresscodec/main.py
@@ -135,5 +135,5 @@ def is_valid_classic_address(classic_address):
     try:
         decode_classic_address(classic_address)
         return True
-    except XRPLAddressCodecException:
+    except (XRPLAddressCodecException, ValueError):
         return False


### PR DESCRIPTION
## High Level Overview of Change

Implements `ripple-address-codec::codec::isValidClassicAddress` in Python, so users can confirm whether a string is a valid classic address or not. 

### Context of Change

`ripple-address-codec` in Python

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

`ripple-address-codec::codec::isValidClassicAddress` is now implemented in Python

## Test Plan

Tests copied from `ripple-address-codec::codec.test`
