### PR TITLE
replace randbytes with token_bytes

### DIFF
--- a/tests/keypairs/test_main.py
+++ b/tests/keypairs/test_main.py
@@ -8,8 +8,8 @@ DUMMY_BYTES = b"\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10"
 
 class TestMain(TestCase):
     # unfortunately, this patching is very brittle; it depends on the syntax
-    # used to import random within the calling module.
-    @patch("xrpl.keypairs.main.randbytes", autospec=True, return_value=DUMMY_BYTES)
+    # used to import secrets within the calling module.
+    @patch("xrpl.keypairs.main.token_bytes", autospec=True, return_value=DUMMY_BYTES)
     def test_generate_seed_no_params(self, _randbytes):
         output = keypairs.generate_seed()
         self.assertEqual(output, "sEdSKaCy2JT7JaM7v95H9SxkhP9wS2r")

--- a/xrpl/keypairs/main.py
+++ b/xrpl/keypairs/main.py
@@ -1,5 +1,5 @@
 """Public interface for keypairs module."""
-from random import randbytes
+from secrets import token_bytes
 from typing import Any, Dict, Final, Optional, Tuple
 
 from xrpl import CryptoAlgorithm, addresscodec
@@ -33,7 +33,7 @@ def generate_seed(
     returns: a seed suitable for use with derive
     """
     if entropy is None:
-        parsed_entropy = randbytes(addresscodec.SEED_LENGTH)
+        parsed_entropy = token_bytes(addresscodec.SEED_LENGTH)
     else:
         parsed_entropy = bytes(entropy, "UTF-8")[: addresscodec.SEED_LENGTH]
     return addresscodec.encode_seed(parsed_entropy, algorithm)


### PR DESCRIPTION
## High Level Overview of Change

`random.randbytes` is 3.9+. Replace it with `secrets.token_bytes` which is supported at least back to 3.6

### Context of Change
version support

### Type of Change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release
