### PR TITLE
Fixes `to_dict` method in `Request` model

### DIFF
--- a/xrpl/models/requests/request.py
+++ b/xrpl/models/requests/request.py
@@ -45,7 +45,7 @@ class Request(BaseModel):
     method: RequestMethod = field(init=False)
     id: Optional[int] = None
 
-    def to_dict(self: BaseModel) -> Dict[str, Any]:
+    def to_dict(self: Request) -> Dict[str, Any]:
         """
         Returns the dictionary representation of a Request.
 


### PR DESCRIPTION
## High Level Overview of Change
This PR fixes the `to_dict` method in `Request` subclasses by overriding it in the `Request` class so that it correctly serializes its `method` field, which is an enum.

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
Tests still pass. Request objects getting tested in `ripplex-py` repo integration tests
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
