### PR TITLE
Fix `InvoiceId` type for this `CheckCreate` field

### DIFF
--- a/xrpl/models/transactions/check_create.py
+++ b/xrpl/models/transactions/check_create.py
@@ -28,5 +28,5 @@ class CheckCreate(Transaction):
     send_max: Amount = REQUIRED
     destination_tag: Optional[int] = None
     expiration: Optional[int] = None
-    invoice_id: Optional[int] = None
+    invoice_id: Optional[str] = None
     transaction_type: TransactionType = TransactionType.CHECK_CREATE


### PR DESCRIPTION
## High Level Overview of Change
During integration tests, found that `InvoiceId` had been mis-typed as `Optional[int]` when it's an `Optional[str]`.

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
