### PR TITLE
Improve Transaction model doc strings

### DIFF
--- a/docs/source/xrpl.models.rst
+++ b/docs/source/xrpl.models.rst
@@ -1,6 +1,9 @@
 XRPL Models
 ===========
 
+Use these classes to validate the formats for all types of data coming from or
+going to the XRP Ledger.
+
 .. toctree::
    :maxdepth: 1
    :titlesonly:

--- a/docs/source/xrpl.models.transactions.rst
+++ b/docs/source/xrpl.models.transactions.rst
@@ -1,6 +1,20 @@
 XRPL Transaction Models
 =======================
 
+Use these models to prepare or process XRP Ledger transactions.
+
+Base Transaction Model
+----------------------
+
+.. automodule:: xrpl.models.transactions.transaction
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :inherited-members:
+
+Specific Transaction Types
+--------------------------
+
 .. automodule:: xrpl.models.transactions
    :members:
    :undoc-members:

--- a/xrpl/models/base_model.py
+++ b/xrpl/models/base_model.py
@@ -17,20 +17,19 @@ class BaseModel(ABC):
     @classmethod
     def is_dict_of_model(cls: Type[BaseModel], dictionary: Dict[str, Any]) -> bool:
         """
-        Returns True if the input dictionary was derived by the `to_dict`
-        method of an instance of this class. In other words, True if this is
-        a dictionary representation of an instance of this class.
+        Checks whether the provided ``dictionary`` is a dictionary representation
+        of this class.
 
-        NOTE: does not account for model inheritance, IE will only return True
-        if dictionary represents an instance of this class, but not if
-        dictionary represents an instance of a subclass of this class.
+        **Note:** This only checks the exact model, and does not count model
+        inheritance. This method returns ``False`` if the dictionary represents
+        a subclass of this class.
 
         Args:
             dictionary: The dictionary to check.
 
         Returns:
             True if dictionary is a dict representation of an instance of this
-            class.
+            class; False if not.
         """
         return isinstance(dictionary, dict) and set(get_type_hints(cls).keys()) == set(
             dictionary.keys()

--- a/xrpl/models/base_model.py
+++ b/xrpl/models/base_model.py
@@ -28,7 +28,7 @@ class BaseModel(ABC):
             dictionary: The dictionary to check.
 
         Returns:
-            True if dictionary is a dict representation of an instance of this
+            True if dictionary is a ``dict`` representation of an instance of this
             class; False if not.
         """
         return isinstance(dictionary, dict) and set(get_type_hints(cls).keys()) == set(

--- a/xrpl/models/transactions/__init__.py
+++ b/xrpl/models/transactions/__init__.py
@@ -1,4 +1,7 @@
-"""Model objects representing different types of transactions on the XRPL ledger."""
+"""
+Model objects for specific `types of Transactions
+<https://xrpl.org/transaction-types.html>`_ in the XRP Ledger.
+"""
 
 from xrpl.models.transactions.account_delete import AccountDelete
 from xrpl.models.transactions.account_set import AccountSet

--- a/xrpl/models/transactions/account_delete.py
+++ b/xrpl/models/transactions/account_delete.py
@@ -1,13 +1,5 @@
-"""
-Represents an AccountDelete transaction on the XRP Ledger.
+"""Model for AccountDelete transaction type."""
 
-An AccountDelete transaction deletes an account and any objects it owns in the XRP
-Ledger, if possible, sending the account's remaining XRP to a specified destination
-account. See Deletion of Accounts for the requirements to delete an account.
-
-`See AccountDelete <https://xrpl.org/accountdelete.html>`_
-`See Deletion of Accounts <https://xrpl.org/accounts.html#deletion-of-accounts>`_
-"""
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -20,19 +12,25 @@ from xrpl.models.utils import require_kwargs_on_init
 @dataclass(frozen=True)
 class AccountDelete(Transaction):
     """
-    Represents an AccountDelete transaction on the XRP Ledger.
+    Represents an `AccountDelete transaction
+    <https://xrpl.org/accountdelete.html>`_, which deletes an account and any
+    objects it owns in the XRP Ledger, if possible, sending the account's remaining
+    XRP to a specified destination account.
 
-    An AccountDelete transaction deletes an account and any objects it owns in the XRP
-    Ledger, if possible, sending the account's remaining XRP to a specified destination
-    account. See Deletion of Accounts for the requirements to delete an account.
-
-    `See AccountDelete <https://xrpl.org/accountdelete.html>`_
-    `See Deletion of Accounts <https://xrpl.org/accounts.html#deletion-of-accounts>`_
+    See `Deletion of Accounts
+    <https://xrpl.org/accounts.html#deletion-of-accounts>`_ for the requirements to
+    delete an account.
     """
 
+    #: The address of the account to send any remaining XRP to.
     #: This field is required.
     destination: str = REQUIRED  # type: ignore
+
+    #: The `destination tag
+    #: <https://xrpl.org/source-and-destination-tags.html>`_ at the
+    #: ``destination`` account where funds should be sent.
     destination_tag: Optional[int] = None
+
     transaction_type: TransactionType = field(
         default=TransactionType.ACCOUNT_DELETE,
         init=False,

--- a/xrpl/models/transactions/account_set.py
+++ b/xrpl/models/transactions/account_set.py
@@ -45,7 +45,7 @@ class AccountSet(Transaction):
     set_flag: Optional[int] = None
 
     #: Set the transfer fee to use for tokens issued by this account. See
-    #: `TransferRate <https://xrpl.org/accountset.html#transferrate`_ for
+    #: `TransferRate <https://xrpl.org/accountset.html#transferrate>`_ for
     #: details.
     transfer_rate: Optional[int] = None
 

--- a/xrpl/models/transactions/account_set.py
+++ b/xrpl/models/transactions/account_set.py
@@ -1,10 +1,4 @@
-"""
-Represents an AccountSet transaction on the XRP Ledger.
-
-An AccountSet transaction modifies the properties of an account in the XRP Ledger.
-
-`See AccountSet <https://xrpl.org/accountset.html>`_
-"""
+"""Model for AccountSet transaction type."""
 from __future__ import annotations  # Requires Python 3.7+
 
 from dataclasses import dataclass, field
@@ -28,20 +22,38 @@ _DISABLE_TICK_SIZE: Final[int] = 0
 @dataclass(frozen=True)
 class AccountSet(Transaction):
     """
-    Represents an AccountSet transaction on the XRP Ledger.
-
-    An AccountSet transaction modifies the properties of an account in the XRP Ledger.
-
-    `See AccountSet <https://xrpl.org/accountset.html>`_
+    Represents an `AccountSet transaction <https://xrpl.org/accountset.html>`_,
+    which modifies the properties of an account in the XRP Ledger.
     """
 
+    #: Disable a specific `AccountSet Flag
+    #: <https://xrpl.org/accountset.html#accountset-flags>`_
     clear_flag: Optional[int] = None
+
+    #: Set the DNS domain of the account owner.
     domain: Optional[str] = None
+
+    #: Set the MD5 Hash to be used for generating an avatar image for this
+    #: account.
     email_hash: Optional[str] = None
+
+    #: Set a public key for sending encrypted messages to this account.
     message_key: Optional[str] = None
+
+    #: Enable a specific `AccountSet Flag
+    #: <https://xrpl.org/accountset.html#accountset-flags>`_
     set_flag: Optional[int] = None
+
+    #: Set the transfer fee to use for tokens issued by this account. See
+    #: `TransferRate <https://xrpl.org/accountset.html#transferrate`_ for
+    #: details.
     transfer_rate: Optional[int] = None
+
+    #: Set the tick size to use when trading tokens issued by this account in
+    #: the decentralized exchange. See `Tick Size
+    #: <https://xrpl.org/ticksize.html>`_ for details.
     tick_size: Optional[int] = None
+
     transaction_type: TransactionType = field(
         default=TransactionType.ACCOUNT_SET,
         init=False,

--- a/xrpl/models/transactions/check_cancel.py
+++ b/xrpl/models/transactions/check_cancel.py
@@ -1,12 +1,4 @@
-"""
-Represents a CheckCancel transaction on the XRP ledger. A CheckCancel
-transaction cancels an unredeemed Check, removing it from the ledger
-without sending any money. The source or the destination of the check
-can cancel a Check at any time using this transaction type. If the
-Check has expired, any address can cancel it.
-
-`See CheckCancel <https://xrpl.org/checkcancel.html>`_
-"""
+"""Model for CheckCancel transaction type."""
 from dataclasses import dataclass, field
 
 from xrpl.models.required import REQUIRED
@@ -18,17 +10,18 @@ from xrpl.models.utils import require_kwargs_on_init
 @dataclass(frozen=True)
 class CheckCancel(Transaction):
     """
-    Represents a CheckCancel transaction on the XRP ledger. A CheckCancel
-    transaction cancels an unredeemed Check, removing it from the ledger
+    Represents a `CheckCancel <https://xrpl.org/checkcancel.html>`_ transaction,
+    which cancels an unredeemed Check, removing it from the ledger
     without sending any money. The source or the destination of the check
     can cancel a Check at any time using this transaction type. If the
     Check has expired, any address can cancel it.
-
-    `See CheckCancel <https://xrpl.org/checkcancel.html>`_
     """
 
-    #: This field is required.
+    #: The ID of the `Check ledger object
+    #: <https://xrpl.org/check.html>`_ to cancel, as a 64-character
+    #: hexadecimal string. This field is required.
     check_id: str = REQUIRED  # type: ignore
+
     transaction_type: TransactionType = field(
         default=TransactionType.CHECK_CANCEL,
         init=False,

--- a/xrpl/models/transactions/check_cash.py
+++ b/xrpl/models/transactions/check_cash.py
@@ -1,18 +1,4 @@
-"""
-Represents a CheckCash transaction on the XRP ledger. CheckCash transactions
-attempt to redeem a Check object in the ledger to receive up to the amount
-authorized by the corresponding CheckCreate transaction. Only the Destination
-address of a Check can cash it with a CheckCash transaction. Cashing a check
-this way is similar to executing a Payment initiated by the destination.
-
-Since the funds for a check are not guaranteed, redeeming a Check can fail
-because the sender does not have a high enough balance or because there is
-not enough liquidity to deliver the funds. If this happens, the Check remains
-in the ledger and the destination can try to cash it again later, or for a
-different amount.
-
-`See CheckCash <https://xrpl.org/checkcash.html>`_
-"""
+"""Model for CheckCash transaction type."""
 from __future__ import annotations  # Requires Python 3.7+
 
 from dataclasses import dataclass, field
@@ -28,25 +14,27 @@ from xrpl.models.utils import require_kwargs_on_init
 @dataclass(frozen=True)
 class CheckCash(Transaction):
     """
-    Represents a CheckCash transaction on the XRP ledger. CheckCash transactions
-    attempt to redeem a Check object in the ledger to receive up to the amount
-    authorized by the corresponding CheckCreate transaction. Only the Destination
-    address of a Check can cash it with a CheckCash transaction. Cashing a check
-    this way is similar to executing a Payment initiated by the destination.
-
-    Since the funds for a check are not guaranteed, redeeming a Check can fail
-    because the sender does not have a high enough balance or because there is
-    not enough liquidity to deliver the funds. If this happens, the Check remains
-    in the ledger and the destination can try to cash it again later, or for a
-    different amount.
-
-    `See CheckCash <https://xrpl.org/checkcash.html>`_
+    Represents a `CheckCash transaction <https://xrpl.org/checkcash.html>`_,
+    which redeems a Check object to receive up to the amount authorized by the
+    corresponding CheckCreate transaction. Only the Destination address of a
+    Check can cash it.
     """
 
-    #: This field is required.
+    #: The ID of the `Check ledger object
+    #: <https://xrpl.org/check.html>`_ to cash, as a 64-character
+    #: hexadecimal string. This field is required.
     check_id: str = REQUIRED  # type: ignore
+
+    #: Redeem the Check for exactly this amount, if possible. The currency must
+    #: match that of the SendMax of the corresponding CheckCreate transaction.
+    #: You must provide either this field or ``DeliverMin``.
     amount: Optional[Amount] = None
+
+    #: Redeem the Check for at least this amount and for as much as possible.
+    #: The currency must match that of the ``SendMax`` of the corresponding
+    #: CheckCreate transaction. You must provide either this field or ``Amount``.
     deliver_min: Optional[Amount] = None
+
     transaction_type: TransactionType = field(
         default=TransactionType.CHECK_CASH,
         init=False,

--- a/xrpl/models/transactions/check_create.py
+++ b/xrpl/models/transactions/check_create.py
@@ -18,8 +18,9 @@ class CheckCreate(Transaction):
     transaction is the sender of the Check.
     """
 
-    #: The address of the `account <https://xrpl.org/accounts.html>`_ that can
-    #: cash the Check. This field is required.
+    #: The address of the `account
+    #: <https://xrpl.org/accounts.html>`_ that can cash the Check. This field is
+    #: required.
     destination: str = REQUIRED  # type: ignore
 
     #: Maximum amount of source token the Check is allowed to debit the
@@ -28,8 +29,9 @@ class CheckCreate(Transaction):
     #: non-XRP tokens). This field is required.
     send_max: Amount = REQUIRED  # type: ignore
 
-    #: Arbitrary `tag <https://xrpl.org/source-and-destination-tags.html>`_
-    #: that identifies the reason for the Check, or a hosted recipient to pay.
+    #: An arbitrary `destination tag
+    #: <https://xrpl.org/source-and-destination-tags.html>`_ that
+    #: identifies the reason for the Check, or a hosted recipient to pay.
     destination_tag: Optional[int] = None
 
     #: Time after which the Check is no longer valid, in seconds since the

--- a/xrpl/models/transactions/check_create.py
+++ b/xrpl/models/transactions/check_create.py
@@ -1,11 +1,4 @@
-"""
-Represents a CheckCreate transaction on the XRP ledger, which
-creates a Check object. A Check object is a deferred payment
-that can be cashed by its intended destination. The sender of this
-transaction is the sender of the Check.
-
-`See CheckCreate <https://xrpl.org/checkcreate.html>`_
-"""
+"""Model for CheckCreate transaction type."""
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -19,21 +12,34 @@ from xrpl.models.utils import require_kwargs_on_init
 @dataclass(frozen=True)
 class CheckCreate(Transaction):
     """
-    Represents a CheckCreate transaction on the XRP ledger, which
-    creates a Check object. A Check object is a deferred payment
+    Represents a `CheckCreate <https://xrpl.org/checkcreate.html>`_ transaction,
+    which creates a Check object. A Check object is a deferred payment
     that can be cashed by its intended destination. The sender of this
     transaction is the sender of the Check.
-
-    `See CheckCreate <https://xrpl.org/checkcreate.html>`_
     """
 
-    #: This field is required.
+    #: The address of the `account <https://xrpl.org/accounts.html>`_ that can
+    #: cash the Check. This field is required.
     destination: str = REQUIRED  # type: ignore
-    #: This field is required.
+
+    #: Maximum amount of source token the Check is allowed to debit the
+    #: sender, including transfer fees on non-XRP tokens. The Check can only
+    #: credit the destination with the same token (from the same issuer, for
+    #: non-XRP tokens). This field is required.
     send_max: Amount = REQUIRED  # type: ignore
+
+    #: Arbitrary `tag <https://xrpl.org/source-and-destination-tags.html>`_
+    #: that identifies the reason for the Check, or a hosted recipient to pay.
     destination_tag: Optional[int] = None
+
+    #: Time after which the Check is no longer valid, in seconds since the
+    #: Ripple Epoch.
     expiration: Optional[int] = None
+
+    #: Arbitrary 256-bit hash representing a specific reason or identifier for
+    #: this Check.
     invoice_id: Optional[str] = None
+
     transaction_type: TransactionType = field(
         default=TransactionType.CHECK_CREATE,
         init=False,

--- a/xrpl/models/transactions/deposit_preauth.py
+++ b/xrpl/models/transactions/deposit_preauth.py
@@ -1,12 +1,4 @@
-"""
-Represents a DepositPreauth transaction on the XRP Ledger.
-
-A DepositPreauth transaction gives another account pre-approval to deliver payments
-to the sender of this transaction.
-
-`See Deposit Authorization <https://xrpl.org/depositauth.html>`_
-`See DepositPreauth <https://xrpl.org/depositauth.html>`_
-"""
+"""Model for DepositPreauth transaction type."""
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -20,17 +12,20 @@ from xrpl.models.utils import require_kwargs_on_init
 @dataclass(frozen=True)
 class DepositPreauth(Transaction):
     """
-    Represents a DepositPreauth transaction on the XRP Ledger.
-
-    A DepositPreauth transaction gives another account pre-approval to deliver payments
-    to the sender of this transaction.
-
-    `See Deposit Authorization <https://xrpl.org/depositauth.html>`_
-    `See DepositPreauth <https://xrpl.org/depositauth.html>`_
+    Represents a `DepositPreauth <https://xrpl.org/depositpreauth.html>`_
+    transaction, which gives another account pre-approval to deliver payments to
+    the sender of this transaction, if this account is using
+    `Deposit Authorization <https://xrpl.org/depositauth.html>`_.
     """
 
+    #: Grant preauthorization to this address. You must provide this OR
+    #: ``unauthorize`` but not both.
     authorize: Optional[str] = None
+
+    #: Revoke preauthorization from this address. You must provide this OR
+    #: ``authorize`` but not both.
     unauthorize: Optional[str] = None
+
     transaction_type: TransactionType = field(
         default=TransactionType.DEPOSIT_PREAUTH,
         init=False,

--- a/xrpl/models/transactions/escrow_cancel.py
+++ b/xrpl/models/transactions/escrow_cancel.py
@@ -1,10 +1,4 @@
-"""
-Represents an EscrowCancel transaction on the XRP Ledger.
-
-An EscrowCancel transaction returns escrowed XRP to the sender.
-
-`See EscrowCancel <https://xrpl.org/escrowcancel.html>`_
-"""
+"""Model for EscrowCancel transaction type."""
 
 from dataclasses import dataclass, field
 
@@ -17,17 +11,17 @@ from xrpl.models.utils import require_kwargs_on_init
 @dataclass(frozen=True)
 class EscrowCancel(Transaction):
     """
-    Represents an EscrowCancel transaction on the XRP Ledger.
-
-    An EscrowCancel transaction returns escrowed XRP to the sender.
-
-    `See EscrowCancel <https://xrpl.org/escrowcancel.html>`_
+    Represents an `EscrowCancel <https://xrpl.org/escrowcancel.html>`_
+    transaction, which returns escrowed XRP to the sender after the Escrow has
+    expired.
     """
 
-    #: This field is required.
+    #: The address of the account that funded the Escrow. This field is required.
     owner: str = REQUIRED  # type: ignore
-    #: This field is required.
+    #: Transaction sequence (or Ticket number) of the EscrowCreate transaction
+    #: that created the Escrow. This field is required.
     offer_sequence: int = REQUIRED  # type: ignore
+
     transaction_type: TransactionType = field(
         default=TransactionType.ESCROW_CANCEL,
         init=False,

--- a/xrpl/models/transactions/escrow_create.py
+++ b/xrpl/models/transactions/escrow_create.py
@@ -26,8 +26,9 @@ class EscrowCreate(Transaction):
     #: condition is met. This field is required.
     destination: str = REQUIRED  # type: ignore
 
-    #: Arbitrary `tag <https://xrpl.org/source-and-destination-tags.html>`_
-    #: that identifies the reason for the Escrow, or a hosted recipient to pay.
+    #: An arbitrary `destination tag
+    #: <https://xrpl.org/source-and-destination-tags.html>`_ that
+    #: identifies the reason for the Escrow, or a hosted recipient to pay.
     destination_tag: Optional[int] = None
 
     #: The time, in seconds since the Ripple Epoch, when this escrow expires.

--- a/xrpl/models/transactions/escrow_create.py
+++ b/xrpl/models/transactions/escrow_create.py
@@ -1,11 +1,4 @@
-"""
-Represents an EscrowCreate transaction on the XRP Ledger.
-
-An EscrowCreate transaction sequesters XRP until the escrow process either finishes or
-is canceled.
-
-`See EscrowCreate <https://xrpl.org/escrowcreate.html>`_
-"""
+"""Model for EscrowCreate transaction type."""
 from __future__ import annotations  # Requires Python 3.7+
 
 from dataclasses import dataclass, field
@@ -21,22 +14,38 @@ from xrpl.models.utils import require_kwargs_on_init
 @dataclass(frozen=True)
 class EscrowCreate(Transaction):
     """
-    Represents an EscrowCreate transaction on the XRP Ledger.
-
-    An EscrowCreate transaction sequesters XRP until the escrow process either finishes
-    or is canceled.
-
-    `See EscrowCreate <https://xrpl.org/escrowcreate.html>`_
+    Represents an `EscrowCreate <https://xrpl.org/escrowcreate.html>`_
+    transaction, which locks up XRP until a specific time or condition is met.
     """
 
-    #: This field is required.
+    #: Amount of XRP, in drops, to deduct from the sender's balance and set
+    #: aside in escrow. This field is required.
     amount: Amount = REQUIRED  # type: ignore
-    #: This field is required.
+
+    #: The address that should receive the escrowed XRP when the time or
+    #: condition is met. This field is required.
     destination: str = REQUIRED  # type: ignore
+
+    #: Arbitrary `tag <https://xrpl.org/source-and-destination-tags.html>`_
+    #: that identifies the reason for the Escrow, or a hosted recipient to pay.
     destination_tag: Optional[int] = None
+
+    #: The time, in seconds since the Ripple Epoch, when this escrow expires.
+    #: This value is immutable; the funds can only be returned the sender after
+    #: this time.
     cancel_after: Optional[int] = None
+
+    #: The time, in seconds since the Ripple Epoch, when the escrowed XRP can
+    #: be released to the recipient. This value is immutable; the funds cannot
+    #: move until this time is reached.
     finish_after: Optional[int] = None
+
+    #: Hex value representing a `PREIMAGE-SHA-256 crypto-condition
+    #: <https://tools.ietf.org/html/draft-thomas-crypto-conditions-04#section-8.1.>`_
+    #: The funds can only be delivered to the recipient if this condition is
+    #: fulfilled.
     condition: Optional[str] = None
+
     transaction_type: TransactionType = field(
         default=TransactionType.ESCROW_CREATE,
         init=False,

--- a/xrpl/models/transactions/escrow_finish.py
+++ b/xrpl/models/transactions/escrow_finish.py
@@ -1,10 +1,4 @@
-"""
-Represents an EscrowFinish transaction on the XRP Ledger.
-
-An EscrowFinish transaction delivers XRP from a held payment to the recipient.
-
-`See EscrowFinish <https://xrpl.org/escrowfinish.html>`_
-"""
+"""Model for EscrowFinish transaction type."""
 from __future__ import annotations  # Requires Python 3.7+
 
 from dataclasses import dataclass, field
@@ -19,19 +13,27 @@ from xrpl.models.utils import require_kwargs_on_init
 @dataclass(frozen=True)
 class EscrowFinish(Transaction):
     """
-    Represents an EscrowFinish transaction on the XRP Ledger.
-
-    An EscrowFinish transaction delivers XRP from a held payment to the recipient.
-
-    `See EscrowFinish <https://xrpl.org/escrowfinish.html>`_
+    Represents an `EscrowFinish <https://xrpl.org/escrowfinish.html>`_
+    transaction, delivers XRP from a held payment to the recipient.
     """
 
-    #: This field is required.
+    #: The source account that funded the Escrow. This field is required.
     owner: str = REQUIRED  # type: ignore
-    #: This field is required.
+
+    #: Transaction sequence (or Ticket number) of the EscrowCreate transaction
+    #: that created the Escrow. This field is required.
     offer_sequence: int = REQUIRED  # type: ignore
+
+    #: The previously-supplied `PREIMAGE-SHA-256 crypto-condition
+    #: <https://tools.ietf.org/html/draft-thomas-crypto-conditions-04#section-8.1.>`_
+    #: of the Escrow, if any, as hexadecimal.
     condition: Optional[str] = None
+
+    #: The `PREIMAGE-SHA-256 crypto-condition fulfillment
+    #: <https://tools.ietf.org/html/draft-thomas-crypto-conditions-04#section-8.1.4.>`_
+    #: matching the Escrow's condition, if any, as hexadecimal.
     fulfillment: Optional[str] = None
+
     transaction_type: TransactionType = field(
         default=TransactionType.ESCROW_FINISH,
         init=False,

--- a/xrpl/models/transactions/offer_cancel.py
+++ b/xrpl/models/transactions/offer_cancel.py
@@ -1,10 +1,4 @@
-"""
-Represents an OfferCancel transaction on the XRP Ledger.
-
-An OfferCancel transaction removes an Offer object from the XRP Ledger.
-
-`See OfferCancel <https://xrpl.org/offercancel.html>`_
-"""
+"""Model for OfferCancel transaction type."""
 from dataclasses import dataclass, field
 
 from xrpl.models.required import REQUIRED
@@ -16,14 +10,17 @@ from xrpl.models.utils import require_kwargs_on_init
 @dataclass(frozen=True)
 class OfferCancel(Transaction):
     """
-    Represents an OfferCancel transaction on the XRP Ledger.
-
-    An OfferCancel transaction removes an Offer object from the XRP Ledger.
-
-    See https://xrpl.org/offercancel.html.
+    Represents an `OfferCancel <https://xrpl.org/offercancel.html>`_ transaction,
+    which removes an Offer object from the `decentralized exchange
+    <https://xrpl.org/decentralized-exchange.html>`_.
     """
 
+    #: The Sequence number (or Ticket number) of a previous OfferCreate
+    #: transaction. If specified, cancel any Offer object in the ledger that was
+    #: created by that transaction. It is not considered an error if the Offer
+    #: specified does not exist.
     offer_sequence: int = REQUIRED  # type: ignore
+
     transaction_type: TransactionType = field(
         default=TransactionType.OFFER_CANCEL,
         init=False,

--- a/xrpl/models/transactions/offer_create.py
+++ b/xrpl/models/transactions/offer_create.py
@@ -1,10 +1,4 @@
-"""
-Represents an OfferCreate transaction on the XRP Ledger. An OfferCreate transaction is
-effectively a limit order. It defines an intent to exchange currencies, and creates an
-Offer object if not completely fulfilled when placed. Offers can be partially fulfilled.
-
-`See OfferCreate <https://xrpl.org/offercreate.html>`_
-"""
+"""Model for OfferCreate transaction type."""
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -18,20 +12,28 @@ from xrpl.models.utils import require_kwargs_on_init
 @dataclass(frozen=True)
 class OfferCreate(Transaction):
     """
-    Represents an OfferCreate transaction on the XRP Ledger. An OfferCreate
-    transaction is effectively a limit order. It defines an intent to exchange
-    currencies, and creates an Offer object if not completely fulfilled when
-    placed. Offers can be partially fulfilled.
-
-    `See OfferCreate <https://xrpl.org/offercreate.html>`_
+    Represents an `OfferCreate <https://xrpl.org/offercreate.html>`_ transaction,
+    which executes a limit order in the `decentralized exchange
+    <https://xrpl.org/decentralized-exchange.html>`_. If the specified exchange
+    cannot be completely fulfilled, it creates an Offer object for the remainder.
+    Offers can be partially fulfilled.
     """
 
-    #: This field is required.
+    #: The amount and type of currency being provided by the sender of this
+    #: transaction. This field is required.
     taker_gets: Amount = REQUIRED  # type: ignore
-    #: This field is required.
+    #: The amount and type of currency the sender of this transaction wants in
+    #: exchange for the full ``taker_gets`` amount. This field is required.
     taker_pays: Amount = REQUIRED  # type: ignore
+
+    #: Time after which the offer is no longer active, in seconds since the
+    #: Ripple Epoch.
     expiration: Optional[int] = None
+
+    #: The Sequence number (or Ticket number) of a previous OfferCreate to cancel
+    #: when placing this Offer.
     offer_sequence: Optional[int] = None
+
     transaction_type: TransactionType = field(
         default=TransactionType.OFFER_CREATE,
         init=False,

--- a/xrpl/models/transactions/payment.py
+++ b/xrpl/models/transactions/payment.py
@@ -45,8 +45,9 @@ class Payment(Transaction):
     #: The address of the account receiving the payment. This field is required.
     destination: str = REQUIRED  # type: ignore
 
-    #: Arbitrary `tag <https://xrpl.org/source-and-destination-tags.html>`_
-    #: that identifies the reason for the payment, or a hosted recipient to pay.
+    #: An arbitrary `destination tag
+    #: <https://xrpl.org/source-and-destination-tags.html>`_ that
+    #: identifies the reason for the Payment, or a hosted recipient to pay.
     destination_tag: Optional[int] = None
 
     #: Arbitrary 256-bit hash representing a specific reason or identifier for

--- a/xrpl/models/transactions/payment.py
+++ b/xrpl/models/transactions/payment.py
@@ -1,14 +1,4 @@
-"""
-Represents a Payment transaction on the XRP Ledger.
-
-A Payment transaction represents a transfer of value from one account to another.
-(Depending on the path taken, this can involve additional exchanges of value, which
-occur atomically.) This transaction type can be used for several types of payments.
-
-Payments are also the only way to create accounts.
-
-`See Payment <https://xrpl.org/payment.html>`_
-"""
+"""Model for Payment transaction type and related flags."""
 from __future__ import annotations  # Requires Python 3.7+
 
 from dataclasses import dataclass, field
@@ -38,26 +28,47 @@ class PaymentFlag(int, Enum):
 @dataclass(frozen=True)
 class Payment(Transaction):
     """
-    Represents a Payment transaction on the XRP Ledger.
+    Represents a Payment <https://xrpl.org/payment.html>`_ transaction, which
+    sends value from one account to another. (Depending on the path taken, this
+    can involve additional exchanges of value, which occur atomically.) This
+    transaction type can be used for several `types of payments
+    <http://xrpl.local/payment.html#types-of-payments>`_.
 
-    A Payment transaction represents a transfer of value from one account to another.
-    (Depending on the path taken, this can involve additional exchanges of value, which
-    occur atomically.) This transaction type can be used for several types of payments.
-
-    Payments are also the only way to create accounts.
-
-    `See Payment <https://xrpl.org/payment.html>`_
+    Payments are also the only way to `create accounts
+    <http://xrpl.local/payment.html#creating-accounts>`_.
     """
 
-    #: This field is required.
+    #: The amount of currency to deliver. If the Partial Payment flag is set,
+    #: deliver *up to* this amount instead. This field is required.
     amount: Amount = REQUIRED  # type: ignore
-    #: This field is required.
+
+    #: The address of the account receiving the payment. This field is required.
     destination: str = REQUIRED  # type: ignore
+
+    #: Arbitrary `tag <https://xrpl.org/source-and-destination-tags.html>`_
+    #: that identifies the reason for the payment, or a hosted recipient to pay.
     destination_tag: Optional[int] = None
+
+    #: Arbitrary 256-bit hash representing a specific reason or identifier for
+    #: this Check.
     invoice_id: Optional[str] = None  # TODO: should be a 256 bit hash
+
+    #: Array of payment paths to be used (for a cross-currency payment). Must be
+    #: omitted for XRP-to-XRP transactions.
     paths: Optional[List[Any]] = None
+
+    #: Maximum amount of source currency this transaction is allowed to cost,
+    #: including `transfer fees <http://xrpl.local/transfer-fees.html>`_,
+    #: exchange rates, and slippage. Does not include the XRP destroyed as a
+    #: cost for submitting the transaction. Must be supplied for cross-currency
+    #: or cross-issue payments. Must be omitted for XRP-to-XRP payments.
     send_max: Optional[Amount] = None
+
+    #: Minimum amount of destination currency this transaction should deliver.
+    #: Only valid if this is a partial payment. If omitted, any positive amount
+    #: is considered a success.
     deliver_min: Optional[Amount] = None
+
     transaction_type: TransactionType = field(
         default=TransactionType.PAYMENT,
         init=False,

--- a/xrpl/models/transactions/payment_channel_claim.py
+++ b/xrpl/models/transactions/payment_channel_claim.py
@@ -1,11 +1,4 @@
-"""
-Represents a PaymentChannelClaim transaction on the XRP Ledger.
-A PaymentChannelClaim transaction claims XRP from a payment channel, adjusts
-the payment channel's expiration, or both. This transaction can be used differently
-depending on the transaction sender's role in the specified channel.
-
-`See PaymentChannelClaim <https://xrpl.org/paymentchannelclaim.html>`_
-"""
+"""Model for PaymentChannelClaim transaction type."""
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -18,20 +11,36 @@ from xrpl.models.utils import require_kwargs_on_init
 @dataclass(frozen=True)
 class PaymentChannelClaim(Transaction):
     """
-    Represents a PaymentChannelClaim transaction on the XRP Ledger.
-    A PaymentChannelClaim transaction claims XRP from a payment channel, adjusts
-    the payment channel's expiration, or both. This transaction can be used differently
+    Represents a `PaymentChannelClaim <https://xrpl.org/paymentchannelclaim.html>`_
+    transaction, which claims XRP from a `payment channel
+    <https://xrpl.org/payment-channels.html>`_, adjusts
+    channel's expiration, or both. This transaction can be used differently
     depending on the transaction sender's role in the specified channel.
-
-    `See PaymentChannelClaim <https://xrpl.org/paymentchannelclaim.html>`_
     """
 
-    #: This field is required.
+    #: The unique ID of the payment channel, as a 64-character hexadecimal
+    #: string. This field is required.
     channel: str = REQUIRED  # type: ignore
+
+    #: The cumulative amount of XRP to have delivered through this channel after
+    #: processing this claim. Required unless closing the channel.
     balance: Optional[str] = None
+
+    #: The cumulative amount of XRP that has been authorized to deliver by the
+    #: attached claim signature. Required unless closing the channel.
     amount: Optional[str] = None
+
+    #: The signature of the claim, as hexadecimal. This signature must be
+    #: verifiable for the this channel and the given ``public_key`` and ``amount``
+    #: values. May be omitted if closing the channel or if the sender of this
+    #: transaction is the source address of the channel; required otherwise.
     signature: Optional[str] = None
+
+    #: The public key that should be used to verify the attached signature. Must
+    #: match the `PublicKey` that was provided when the channel was created.
+    #: Required if ``signature`` is provided.
     public_key: Optional[str] = None
+
     transaction_type: TransactionType = field(
         default=TransactionType.PAYMENT_CHANNEL_CLAIM,
         init=False,

--- a/xrpl/models/transactions/payment_channel_create.py
+++ b/xrpl/models/transactions/payment_channel_create.py
@@ -1,11 +1,4 @@
-"""
-Represents a PaymentChannelCreate transaction on the XRP Ledger.
-A PaymentChannelCreate transaction creates a unidirectional channel and
-funds it with XRP. The address sending this transaction becomes the
-"source address" of the payment channel.
-
-`See PaymentChannelCreate <https://xrpl.org/paymentchannelcreate.html>`_
-"""
+"""Model for PaymentChannelCreate transaction type."""
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -19,24 +12,41 @@ from xrpl.models.utils import require_kwargs_on_init
 @dataclass(frozen=True)
 class PaymentChannelCreate(Transaction):
     """
-    Represents a PaymentChannelCreate transaction on the XRP Ledger.
-    A PaymentChannelCreate transaction creates a unidirectional channel and
-    funds it with XRP. The address sending this transaction becomes the
-    "source address" of the payment channel.
-
-    `See PaymentChannelCreate <https://xrpl.org/paymentchannelcreate.html>`_
+    Represents a `PaymentChannelCreate
+    <https://xrpl.org/paymentchannelcreate.html>`_ transaction, which creates a
+    `payment channel <https://xrpl.org/payment-channels.html>`_ and funds it with
+    XRP. The sender of this transaction is the "source address" of the payment
+    channel.
     """
 
-    #: This field is required.
+    #: The amount of XRP, in drops, to set aside in this channel. This field is
+    #: required.
     amount: Amount = REQUIRED  # type: ignore
+
+    #: The account that can receive XRP from this channel, also known as the
+    #: "destination address" of the channel. Cannot be the same as the sender.
     #: This field is required.
     destination: str = REQUIRED  # type: ignore
-    #: This field is required.
+
+    #: The amount of time, in seconds, the source address must wait between
+    #: requesting to close the channel and fully closing it. This field is
+    #: required.
     settle_delay: int = REQUIRED  # type: ignore
-    #: This field is required.
+
+    #: The public key of the key pair that the source will use to authorize
+    #: claims against this  channel, as hexadecimal. This can be any valid
+    #: secp256k1 or Ed25519 public key. This field is required.
     public_key: str = REQUIRED  # type: ignore
+
+    #: An immutable expiration time for the channel, in seconds since the Ripple
+    #: Epoch. The channel can be closed sooner than this but cannot remain open
+    #: later than this time.
     cancel_after: Optional[int] = None
+
+    #: Arbitrary `tag <https://xrpl.org/source-and-destination-tags.html>`_
+    #: that identifies the reason for the channel, or a hosted recipient to pay.
     destination_tag: Optional[int] = None
+
     transaction_type: TransactionType = field(
         default=TransactionType.PAYMENT_CHANNEL_CREATE,
         init=False,

--- a/xrpl/models/transactions/payment_channel_create.py
+++ b/xrpl/models/transactions/payment_channel_create.py
@@ -43,8 +43,9 @@ class PaymentChannelCreate(Transaction):
     #: later than this time.
     cancel_after: Optional[int] = None
 
-    #: Arbitrary `tag <https://xrpl.org/source-and-destination-tags.html>`_
-    #: that identifies the reason for the channel, or a hosted recipient to pay.
+    #: An arbitrary `destination tag
+    #: <https://xrpl.org/source-and-destination-tags.html>`_ that
+    #: identifies the reason for the Payment Channel, or a hosted recipient to pay.
     destination_tag: Optional[int] = None
 
     transaction_type: TransactionType = field(

--- a/xrpl/models/transactions/payment_channel_fund.py
+++ b/xrpl/models/transactions/payment_channel_fund.py
@@ -1,11 +1,4 @@
-"""
-Represents a PaymentChannelFund transaction on the XRP Ledger.
-A PaymentChannelFund transaction adds additional XRP to an open payment channel,
-and optionally updates the expiration time of the channel. Only the source address
-of the channel can use this transaction.
-
-`See PaymentChannelFund <https://xrpl.org/paymentchannelfund.html>`_
-"""
+"""Model for a PaymentChannelFund transaction type."""
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -18,19 +11,27 @@ from xrpl.models.utils import require_kwargs_on_init
 @dataclass(frozen=True)
 class PaymentChannelFund(Transaction):
     """
-    Represents a PaymentChannelFund transaction on the XRP Ledger.
-    A PaymentChannelFund transaction adds additional XRP to an open payment channel,
-    and optionally updates the expiration time of the channel. Only the source address
+    Represents a `PaymentChannelFund <https://xrpl.org/paymentchannelfund.html>`_
+    transaction, adds additional XRP to an open `payment channel
+    <https://xrpl.org/payment-channels.html>`_, and optionally updates the
+    expiration time of the channel. Only the source address
     of the channel can use this transaction.
-
-    `See PaymentChannelFund <https://xrpl.org/paymentchannelfund.html>`_
     """
 
-    #: This field is required.
+    #: The unique ID of the payment channel, as a 64-character hexadecimal
+    #: string. This field is required.
     channel: str = REQUIRED  # type: ignore
-    #: This field is required.
+
+    #: The amount of XRP, in drops, to add to the channel. This field is
+    #: required.
     amount: str = REQUIRED  # type: ignore
+
+    #: A new mutable expiration time to set for the channel, in seconds since the
+    #: Ripple Epoch. This must be later than the existing expiration time of the
+    #: channel or later than the current time plus the settle delay of the channel.
+    #: This is separate from the immutable ``cancel_after`` time.
     expiration: Optional[int] = None
+
     transaction_type: TransactionType = field(
         default=TransactionType.PAYMENT_CHANNEL_FUND,
         init=False,

--- a/xrpl/models/transactions/set_regular_key.py
+++ b/xrpl/models/transactions/set_regular_key.py
@@ -1,14 +1,4 @@
-"""
-Represents a SetRegularKey transaction on the XRP Ledger.
-
-A SetRegularKey transaction assigns, changes, or removes the regular key pair
-associated with an account. You can protect your account by assigning a regular key
-pair to it and using it instead of the master key pair to sign transactions whenever
-possible. If your regular key pair is compromised, but your master key pair is not, you
-can use a SetRegularKey transaction to regain control of your account.
-
-`See SetRegularKey <https://xrpl.org/setregularkey.html>`_
-"""
+"""Model for SetRegularKey transaction type."""
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -20,19 +10,16 @@ from xrpl.models.utils import require_kwargs_on_init
 @dataclass(frozen=True)
 class SetRegularKey(Transaction):
     """
-    Represents a SetRegularKey transaction on the XRP Ledger.
-
-    A SetRegularKey transaction assigns, changes, or removes the regular key pair
-    associated with an account.You can protect your account by assigning a regular key
-    pair to it and using it instead of the master key pair to sign transactions
-    whenever possible. If your regular key pair is compromised, but your master key
-    pair is not, you can use a SetRegularKey transaction to regain control of your
-    account.
-
-    `See SetRegularKey <https://xrpl.org/setregularkey.html>`_
+    Represents a `SetRegularKey <https://xrpl.org/setregularkey.html>`_
+    transaction, which assigns, changes, or removes a secondary "regular" key pair
+    associated with an account.
     """
 
+    #: The classic address derived from the key pair to authorize for this
+    #: account. If omitted, removes any existing regular key pair from the
+    #: account. Must not match the account's master key pair.
     regular_key: Optional[str] = None
+
     transaction_type: TransactionType = field(
         default=TransactionType.SET_REGULAR_KEY,
         init=False,

--- a/xrpl/models/transactions/signer_list_set.py
+++ b/xrpl/models/transactions/signer_list_set.py
@@ -1,13 +1,4 @@
-"""
-Represents a SignerListSet transaction on the XRP Ledger.
-
-The SignerListSet transaction creates, replaces, or removes a list of signers that can
-be used to multi-sign a transaction. This transaction type was introduced by the
-MultiSign amendment.
-
-`See SignerListSet <https://xrpl.org/signerlistset.html>`_
-`See MultiSign Amendment <https://xrpl.org/known-amendments.html#multisign>`_
-"""
+"""Model for SignerListSet transaction type."""
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -22,10 +13,7 @@ from xrpl.models.utils import require_kwargs_on_init
 @require_kwargs_on_init
 @dataclass(frozen=True)
 class SignerEntry(BaseModel):
-    """
-    Each member of the SignerEntries field is an object that describes that
-    signer in the list.
-    """
+    """Represents one entry in a list of multi-signers authorized to an account."""
 
     #: This field is required.
     account: str = REQUIRED  # type: ignore
@@ -70,14 +58,10 @@ class SignerEntry(BaseModel):
 @dataclass(frozen=True)
 class SignerListSet(Transaction):
     """
-    Represents a SignerListSet transaction on the XRP Ledger.
-
-    The SignerListSet transaction creates, replaces, or removes a list of signers that
-    can be used to multi-sign a transaction. This transaction type was introduced by the
-    MultiSign amendment.
-
-    `See SignerListSet <https://xrpl.org/signerlistset.html>`_
-    `See MultiSign Amendment <https://xrpl.org/known-amendments.html#multisign>`_
+    Represents a `SignerListSet <https://xrpl.org/signerlistset.html>`_
+    transaction, which creates, replaces, or removes a list of signers that
+    can be used to `multi-sign a transaction
+    <https://xrpl.org/multi-signing.html>`_.
     """
 
     #: This field is required.

--- a/xrpl/models/transactions/transaction.py
+++ b/xrpl/models/transactions/transaction.py
@@ -153,7 +153,7 @@ class Transaction(BaseModel):
     #: multi-signing.
     signers: Optional[List[Signer]] = None
 
-    #: An arbitrary tag `source tag
+    #: An arbitrary `source tag
     #: <https://xrpl.org/source-and-destination-tags.html>`_ representing a
     #: hosted user or specific purpose at the sending account where this
     #: transaction comes from.


### PR DESCRIPTION
- [x] Base Transaction class
- [x] AccountDelete
- [x] AccountSet
- [x] CheckCancel
- [x] CheckCash
- [x] CheckCreate
- [x] DepositPreauth
- [x] EscrowCancel
- [x] EscrowCreate
- [x] EscrowFinish
- [x] OfferCancel
- [x] OfferCreate
- [x] Payment
- [x] PaymentChannelClaim
- [x] PaymentChannelCreate
- [x] PaymentChannelFund
- [x] SetRegularKey
- [x] SignerListSet
- [x] TrustSet
- [x] Fix formatting that'ss glitching out (like on CheckCreate and all the destination tag descriptions). Turns out it was probably a Sphinx glitch.