### PR TITLE
Add conversion utilities

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,7 @@ First, ensure that you have Python 3.7 or later. Then, you can download the pack
    source/xrpl.clients
    source/xrpl.models
    source/xrpl.core
+   source/xrpl.utils
    source/xrpl
 
 

--- a/docs/source/xrpl.utils.rst
+++ b/docs/source/xrpl.utils.rst
@@ -1,0 +1,7 @@
+XRPL Utilities
+==============
+
+.. automodule:: xrpl.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/tests/utils/test_time_conversions.py
+++ b/tests/utils/test_time_conversions.py
@@ -36,18 +36,19 @@ class TestMain(TestCase):
             time.strptime("1999-01-01T00:00 UTC", "%Y-%m-%dT%M:%S %Z")
         )
         with self.assertRaises(xrpl.utils.XRPLTimeRangeException):
-            xrpl.utils.datetime_to_ripple_time(year_1999)
+            xrpl.utils.posix_to_ripple_time(year_1999)
 
     def test_datetime_overflow(self):
-        # "Ripple Epoch" time has the "Year 2038 problem", but 30 years later
-        year_2069 = datetime(2069, 1, 1, 0, 0, tzinfo=timezone.utc)
+        # "Ripple Epoch" time's eqvualent to the "Year 2038 problem", isn't until
+        # 2136 because it uses an *unsigned* 32-bit int starting 30 years after
+        # UNIX time's signed 32-bit int.
+        year_2137 = datetime(2137, 1, 1, 0, 0, tzinfo=timezone.utc)
         with self.assertRaises(xrpl.utils.XRPLTimeRangeException):
-            xrpl.utils.datetime_to_ripple_time(year_2069)
+            xrpl.utils.datetime_to_ripple_time(year_2137)
 
     def test_posix_overflow(self):
-        # "Ripple Epoch" time has the "Year 2038 problem", but 30 years later
-        year_2069 = time.mktime(
-            time.strptime("2069-01-01T00:00 UTC", "%Y-%m-%dT%M:%S %Z")
+        year_2137 = time.mktime(
+            time.strptime("2137-01-01T00:00 UTC", "%Y-%m-%dT%M:%S %Z")
         )
         with self.assertRaises(xrpl.utils.XRPLTimeRangeException):
-            xrpl.utils.datetime_to_ripple_time(year_2069)
+            xrpl.utils.posix_to_ripple_time(year_2137)

--- a/tests/utils/test_time_conversions.py
+++ b/tests/utils/test_time_conversions.py
@@ -1,0 +1,53 @@
+import time
+from datetime import datetime, timezone
+from unittest import TestCase
+
+import xrpl.utils
+
+
+class TestMain(TestCase):
+    def test_posix_round_trip(self):
+        current_time = time.time()
+        time_whole_seconds = int(current_time)
+        ripple_time = xrpl.utils.posix_to_ripple_time(current_time)
+        round_trip_time = xrpl.utils.ripple_time_to_posix(ripple_time)
+        self.assertEqual(time_whole_seconds, round_trip_time)
+
+    def test_datetime_round_trip(self):
+        now = datetime.now(timezone.utc)
+        now_whole_seconds = now.replace(microsecond=0)
+        ripple_time = xrpl.utils.datetime_to_ripple_time(now)
+        round_trip_time = xrpl.utils.ripple_time_to_datetime(ripple_time)
+        self.assertEqual(now_whole_seconds, round_trip_time)
+
+    def test_ripple_epoch(self):
+        dt = xrpl.utils.ripple_time_to_datetime(0)
+        self.assertEqual(dt.isoformat(), "2000-01-01T00:00:00+00:00")
+
+    def test_datetime_underflow(self):
+        # "Ripple Epoch" time starts in the year 2000
+        year_1999 = datetime(1999, 1, 1, 0, 0, tzinfo=timezone.utc)
+        with self.assertRaises(xrpl.utils.XRPLTimeRangeException):
+            xrpl.utils.datetime_to_ripple_time(year_1999)
+
+    def test_posix_underflow(self):
+        # "Ripple Epoch" time starts in the year 2000
+        year_1999 = time.mktime(
+            time.strptime("1999-01-01T00:00 UTC", "%Y-%m-%dT%M:%S %Z")
+        )
+        with self.assertRaises(xrpl.utils.XRPLTimeRangeException):
+            xrpl.utils.datetime_to_ripple_time(year_1999)
+
+    def test_datetime_overflow(self):
+        # "Ripple Epoch" time has the "Year 2038 problem", but 30 years later
+        year_2069 = datetime(2069, 1, 1, 0, 0, tzinfo=timezone.utc)
+        with self.assertRaises(xrpl.utils.XRPLTimeRangeException):
+            xrpl.utils.datetime_to_ripple_time(year_2069)
+
+    def test_posix_overflow(self):
+        # "Ripple Epoch" time has the "Year 2038 problem", but 30 years later
+        year_2069 = time.mktime(
+            time.strptime("2069-01-01T00:00 UTC", "%Y-%m-%dT%M:%S %Z")
+        )
+        with self.assertRaises(xrpl.utils.XRPLTimeRangeException):
+            xrpl.utils.datetime_to_ripple_time(year_2069)

--- a/tests/utils/test_xrp_conversions.py
+++ b/tests/utils/test_xrp_conversions.py
@@ -12,7 +12,7 @@ class TestMain(TestCase):
         self.assertEqual(xrpl.utils.xrp_to_drops(0), "0")
 
     def test_min_xrp(self):
-        self.assertEqual(xrpl.utils.xrp_to_drops(0.000001), "1")
+        self.assertEqual(xrpl.utils.xrp_to_drops(Decimal("0.000001")), "1")
 
     def test_max_xrp(self):
         self.assertEqual(xrpl.utils.xrp_to_drops(10 ** 11), "100000000000000000")
@@ -27,22 +27,30 @@ class TestMain(TestCase):
 
     def test_nan_xrp(self):
         with self.assertRaises(xrpl.utils.XRPRangeException):
-            xrpl.utils.xrp_to_drops("NaN")
+            xrpl.utils.xrp_to_drops(Decimal("NaN"))
+
+    def test_str_xrp(self):
+        with self.assertRaises(TypeError):
+            xrpl.utils.xrp_to_drops("1000000")
 
     def test_1_drop(self):
-        self.assertEqual(xrpl.utils.drops_to_xrp("1"), Decimal(1000000))
+        self.assertEqual(xrpl.utils.drops_to_xrp("1"), Decimal("0.000001"))
 
     def test_0_drops(self):
         self.assertEqual(xrpl.utils.drops_to_xrp("0"), Decimal(0))
 
     def test_1mil_drops(self):
-        self.assertEqual(xrpl.utils.drops_to_xrp("1000000"), Decimal(1000000))
+        self.assertEqual(xrpl.utils.drops_to_xrp("1000000"), Decimal(1))
 
     def test_1mil_drops_with_exponent(self):
-        self.assertEqual(xrpl.utils.drops_to_xrp("10e7"), Decimal(1000000))
+        self.assertEqual(xrpl.utils.drops_to_xrp("1e6"), Decimal(1))
 
     def test_max_drops(self):
         self.assertEqual(xrpl.utils.drops_to_xrp(str(10 ** 17)), Decimal(10 ** 11))
+
+    def test_float_drops(self):
+        with self.assertRaises(TypeError):
+            xrpl.utils.drops_to_xrp(10.1)
 
     def test_nan_drops(self):
         with self.assertRaises(xrpl.utils.XRPRangeException):

--- a/tests/utils/test_xrp_conversions.py
+++ b/tests/utils/test_xrp_conversions.py
@@ -1,0 +1,61 @@
+from decimal import Decimal
+from unittest import TestCase
+
+import xrpl.utils
+
+
+class TestMain(TestCase):
+    def test_1_xrp(self):
+        self.assertEqual(xrpl.utils.xrp_to_drops(1), "1000000")
+
+    def test_0_xrp(self):
+        self.assertEqual(xrpl.utils.xrp_to_drops(0), "0")
+
+    def test_min_xrp(self):
+        self.assertEqual(xrpl.utils.xrp_to_drops(0.000001), "1")
+
+    def test_max_xrp(self):
+        self.assertEqual(xrpl.utils.xrp_to_drops(10 ** 11), "100000000000000000")
+
+    def test_too_small_xrp(self):
+        with self.assertRaises(xrpl.utils.XRPRangeException):
+            xrpl.utils.xrp_to_drops(Decimal(0.0000001))
+
+    def test_too_big_xrp(self):
+        with self.assertRaises(xrpl.utils.XRPRangeException):
+            xrpl.utils.xrp_to_drops(10 ** 11 + 1)
+
+    def test_nan_xrp(self):
+        with self.assertRaises(xrpl.utils.XRPRangeException):
+            xrpl.utils.xrp_to_drops("NaN")
+
+    def test_1_drop(self):
+        self.assertEqual(xrpl.utils.drops_to_xrp("1"), Decimal(1000000))
+
+    def test_0_drops(self):
+        self.assertEqual(xrpl.utils.drops_to_xrp("0"), Decimal(0))
+
+    def test_1mil_drops(self):
+        self.assertEqual(xrpl.utils.drops_to_xrp("1000000"), Decimal(1000000))
+
+    def test_1mil_drops_with_exponent(self):
+        self.assertEqual(xrpl.utils.drops_to_xrp("10e7"), Decimal(1000000))
+
+    def test_max_drops(self):
+        self.assertEqual(xrpl.utils.drops_to_xrp(str(10 ** 17)), Decimal(10 ** 11))
+
+    def test_nan_drops(self):
+        with self.assertRaises(xrpl.utils.XRPRangeException):
+            xrpl.utils.drops_to_xrp("NaN")
+
+    def test_emptystring_drops(self):
+        with self.assertRaises(xrpl.utils.XRPRangeException):
+            xrpl.utils.drops_to_xrp("")
+
+    def test_too_many_drops(self):
+        with self.assertRaises(xrpl.utils.XRPRangeException):
+            xrpl.utils.drops_to_xrp(str(10 ** 17 + 1))
+
+    def test_negative_drops(self):
+        with self.assertRaises(xrpl.utils.XRPRangeException):
+            xrpl.utils.drops_to_xrp("-1")

--- a/xrpl/utils/__init__.py
+++ b/xrpl/utils/__init__.py
@@ -1,0 +1,21 @@
+"""Convenience utilities for the XRP Ledger"""
+
+from xrpl.utils.time_conversions import (
+    XRPLTimeRangeException,
+    datetime_to_ripple_time,
+    posix_to_ripple_time,
+    ripple_time_to_datetime,
+    ripple_time_to_posix,
+)
+from xrpl.utils.xrp_conversions import XRPRangeException, drops_to_xrp, xrp_to_drops
+
+__all__ = [
+    "xrp_to_drops",
+    "drops_to_xrp",
+    "ripple_time_to_datetime",
+    "datetime_to_ripple_time",
+    "ripple_time_to_posix",
+    "posix_to_ripple_time",
+    "XRPRangeException",
+    "XRPLTimeRangeException",
+]

--- a/xrpl/utils/time_conversions.py
+++ b/xrpl/utils/time_conversions.py
@@ -6,10 +6,14 @@ data types
 from datetime import datetime, timezone
 from typing import Union
 
+from typing_extensions import Final
+
 from xrpl import XRPLException
 
-RIPPLE_EPOCH = 946684800  #: The "Ripple Epoch" of 2000-01-01T00:00:00 UTC
-MAX_XRPL_TIME = 2 ** 32  #: The maximum time that can be expressed on the XRPL
+RIPPLE_EPOCH: Final[int] = 946684800  #: The "Ripple Epoch" of 2000-01-01T00:00:00 UTC
+MAX_XRPL_TIME: Final[int] = (
+    2 ** 32
+)  #: The maximum time that can be expressed on the XRPL
 
 
 def ripple_time_to_datetime(ripple_time: int) -> datetime:

--- a/xrpl/utils/time_conversions.py
+++ b/xrpl/utils/time_conversions.py
@@ -1,0 +1,130 @@
+"""
+Conversions between the XRP Ledger's 'Ripple Epoch' time and native time
+data types
+"""
+
+from datetime import datetime, timezone
+from typing import Union
+
+from xrpl import XRPLException
+
+RIPPLE_EPOCH = 946684800  #: The "Ripple Epoch" of 2000-01-01T00:00:00 UTC
+MAX_XRPL_TIME = 2 ** 32  #: The maximum time that can be expressed on the XRPL
+
+
+def ripple_time_to_datetime(ripple_time: int) -> datetime:
+    """
+    Convert from XRP Ledger 'Ripple Epoch' time to a UTC `datetime
+    <https://docs.python.org/3/library/datetime.html#datetime-objects>`_ object.
+
+    Args:
+        ripple_time: Whole seconds since the Ripple Epoch of 2001-01-01T00:00Z
+
+    Returns:
+        The equivalent time as a ``datetime`` instance.
+
+    Raises:
+        XRPLTimeRangeException: if the given ``ripple_time`` is not valid
+    """
+    if ripple_time < 0:
+        raise XRPLTimeRangeException(f"{ripple_time} is before the Ripple Epoch.")
+    if ripple_time > MAX_XRPL_TIME:
+        raise XRPLTimeRangeException(
+            f"{ripple_time} is larger than any time that can be expressed on"
+            f"the XRP Ledger."
+        )
+    timestamp = ripple_time + RIPPLE_EPOCH
+    return datetime.fromtimestamp(timestamp, timezone.utc)
+
+
+def datetime_to_ripple_time(dt: datetime) -> int:
+    """
+    Convert from a `datetime
+    <https://docs.python.org/3/library/datetime.html#datetime-objects>`_ object
+    to an XRP Ledger 'Ripple Epoch' time.
+
+    Args:
+        dt: The datetime to convert
+
+    Returns:
+        The equivalent time in whole seconds since the Ripple Epoch of
+        2001-01-01T00:00Z
+
+    Raises:
+        XRPLTimeRangeException: if the time is outside the range that can be
+                                represented in Ripple Epoch time
+    """
+    ripple_time = int(dt.timestamp() - RIPPLE_EPOCH)
+    if ripple_time < 0:
+        raise XRPLTimeRangeException(f"Datetime {dt} is before the Ripple Epoch")
+    if ripple_time > MAX_XRPL_TIME:
+        raise XRPLTimeRangeException(
+            f"{dt} is later than any time that can be expressed on" f"the XRP Ledger."
+        )
+    return ripple_time
+
+
+def ripple_time_to_posix(ripple_time: int) -> int:
+    """
+    Convert from XRP Ledger 'Ripple Epoch' time to a POSIX-like integer
+    timestamp.
+
+    Args:
+        ripple_time: A timestamp as the number of whole seconds since the
+                     Ripple Epoch of 2001-01-01T00:00Z
+
+    Returns:
+        The equivalent time in whole seconds since the UNIX epoch of
+        1970-01-01T00:00Z
+
+    Raises:
+        XRPLTimeRangeException: if the given ``ripple_time`` is not valid
+    """
+    if ripple_time < 0:
+        raise XRPLTimeRangeException(f"{ripple_time} is before the Ripple Epoch.")
+    if ripple_time > MAX_XRPL_TIME:
+        raise XRPLTimeRangeException(
+            f"{ripple_time} is larger than any time that can be expressed on"
+            f"the XRP Ledger."
+        )
+    timestamp = ripple_time + RIPPLE_EPOCH
+    return timestamp
+
+
+def posix_to_ripple_time(timestamp: Union[int, float]) -> int:
+    """
+    Convert from a POSIX-like timestamp such as one returned by `time.time()
+    <https://docs.python.org/3/library/time.html#time.time>`_ to an XRP Ledger
+    'Ripple Epoch' time.
+
+    Args:
+        timestamp: An integer or floating-point timestamp such as one returned
+                   by ``time.time()``.
+
+    Returns:
+        The equivalent time in whole seconds since the Ripple Epoch of
+        2001-01-01T00:00Z
+
+    Raises:
+        XRPLTimeRangeException: if the time is outside the range that can be
+                                represented in Ripple Epoch time
+
+
+    """
+    ripple_time = int(timestamp - RIPPLE_EPOCH)
+    if ripple_time < 0:
+        raise XRPLTimeRangeException(
+            f"Timestamp {timestamp} is before the Ripple Epoch."
+        )
+    if ripple_time > MAX_XRPL_TIME:
+        raise XRPLTimeRangeException(
+            f"{timestamp} is later than any time that can be expressed on"
+            f"the XRP Ledger."
+        )
+    return ripple_time
+
+
+class XRPLTimeRangeException(XRPLException):
+    """Exception for invalid XRP Ledger time data."""
+
+    pass

--- a/xrpl/utils/xrp_conversions.py
+++ b/xrpl/utils/xrp_conversions.py
@@ -1,18 +1,20 @@
 """Conversions between XRP drops and native number types."""
 
 from decimal import Context, Decimal, InvalidOperation, setcontext
-from re import match
+from re import fullmatch
 from typing import Union
+
+from typing_extensions import Final
 
 from xrpl import XRPLException
 
-ONE_DROP = Decimal("0.000001")  #: Indivisible unit of XRP
-MAX_XRP = Decimal(10 ** 11)  #: 100 billion decimal XRP
-MAX_DROPS = Decimal(10 ** 17)  #: Maximum possible number of drops of XRP
+ONE_DROP: Final[Decimal] = Decimal("0.000001")  #: Indivisible unit of XRP
+MAX_XRP: Final[Decimal] = Decimal(10 ** 11)  #: 100 billion decimal XRP
+MAX_DROPS: Final[Decimal] = Decimal(10 ** 17)  #: Maximum possible drops of XRP
 
 # Drops should be an integer string. MAY have (positive) exponent.
 # See also: https://xrpl.org/currency-formats.html#string-numbers
-_DROPS_REGEX = r"^\s*([1-9][0-9Ee-]{0,17}|0)\s*$"
+_DROPS_REGEX = r"[1-9][0-9Ee-]{0,17}|0"
 
 _DROPS_CONTEXT = Context(prec=18, Emin=0, Emax=18)
 
@@ -28,33 +30,35 @@ def xrp_to_drops(xrp: Union[int, float, Decimal]) -> str:
         Equivalent amount in drops of XRP
 
     Raises:
-        XRPTypeException: if ``xrp`` is given as a string
+        TypeError: if ``xrp`` is given as a string
         XRPRangeException: if the given amount of XRP is invalid
     """
     if type(xrp) == str:  # type: ignore
         # This protects people from passing drops to this function and getting
         # a million times as many drops back.
-        raise XRPTypeException(
-            "XRP provided as a string. Use a number format"
-            "like ``Decimal`` or ``int``."
+        raise TypeError(
+            "XRP provided as a string. Use a number format" "like Decimal or int."
         )
     setcontext(_DROPS_CONTEXT)
     try:
         xrp_d = Decimal(xrp)
-
-        if xrp_d < ONE_DROP and xrp_d != 0:
-            raise XRPRangeException(f"XRP amount {xrp} is too small.")
-        if xrp_d > MAX_XRP:
-            raise XRPRangeException(f"XRP amount {xrp} is too large.")
     except InvalidOperation:
         raise XRPRangeException(f"Not a valid amount of XRP: '{xrp}'")
 
+    if not xrp_d.is_finite():  # NaN or an Infinity
+        raise XRPRangeException(f"Not a valid amount of XRP: '{xrp}'")
+
+    if xrp_d < ONE_DROP and xrp_d != 0:
+        raise XRPRangeException(f"XRP amount {xrp} is too small.")
+    if xrp_d > MAX_XRP:
+        raise XRPRangeException(f"XRP amount {xrp} is too large.")
+
     drops_amount = (xrp_d / ONE_DROP).quantize(Decimal(1))
-    drops_str = str(drops_amount)
+    drops_str = str(drops_amount).strip()
 
     # This should never happen, but is a precaution against Decimal doing
     # something unexpected.
-    if not match(_DROPS_REGEX, drops_str):
+    if not fullmatch(_DROPS_REGEX, drops_str):
         raise XRPRangeException(
             f"xrp_to_drops failed sanity check. Value "
             f"'{drops_str}' does not match the drops regex"
@@ -74,10 +78,14 @@ def drops_to_xrp(drops: str) -> Decimal:
         Decimal representation of the same amount of XRP
 
     Raises:
+        TypeError: if ``drops`` not given as a string
         XRPRangeException: if the given number of drops is invalid
     """
+    if type(drops) != str:
+        raise TypeError(f"Drops must be provided as string (got {type(drops)})")
+    drops = drops.strip()
     setcontext(_DROPS_CONTEXT)
-    if not match(_DROPS_REGEX, drops):
+    if not fullmatch(_DROPS_REGEX, drops):
         raise XRPRangeException(f"Not a valid amount of drops: '{drops}'")
     try:
         drops_d = Decimal(drops)
@@ -91,11 +99,5 @@ def drops_to_xrp(drops: str) -> Decimal:
 
 class XRPRangeException(XRPLException):
     """Exception for invalid XRP amounts."""
-
-    pass
-
-
-class XRPTypeException(XRPLException):
-    """Exception for string XRP amounts (use a Decimal for decimal XRP)."""
 
     pass

--- a/xrpl/utils/xrp_conversions.py
+++ b/xrpl/utils/xrp_conversions.py
@@ -1,0 +1,101 @@
+"""Conversions between XRP drops and native number types."""
+
+from decimal import Context, Decimal, InvalidOperation, setcontext
+from re import match
+from typing import Union
+
+from xrpl import XRPLException
+
+ONE_DROP = Decimal("0.000001")  #: Indivisible unit of XRP
+MAX_XRP = Decimal(10 ** 11)  #: 100 billion decimal XRP
+MAX_DROPS = Decimal(10 ** 17)  #: Maximum possible number of drops of XRP
+
+# Drops should be an integer string. MAY have (positive) exponent.
+# See also: https://xrpl.org/currency-formats.html#string-numbers
+_DROPS_REGEX = r"^\s*([1-9][0-9Ee-]{0,17}|0)\s*$"
+
+_DROPS_CONTEXT = Context(prec=18, Emin=0, Emax=18)
+
+
+def xrp_to_drops(xrp: Union[int, float, Decimal]) -> str:
+    """
+    Convert a numeric XRP amount to drops of XRP.
+
+    Args:
+        xrp: Numeric representation of whole XRP
+
+    Returns:
+        Equivalent amount in drops of XRP
+
+    Raises:
+        XRPTypeException: if ``xrp`` is given as a string
+        XRPRangeException: if the given amount of XRP is invalid
+    """
+    if type(xrp) == str:  # type: ignore
+        # This protects people from passing drops to this function and getting
+        # a million times as many drops back.
+        raise XRPTypeException(
+            "XRP provided as a string. Use a number format"
+            "like ``Decimal`` or ``int``."
+        )
+    setcontext(_DROPS_CONTEXT)
+    try:
+        xrp_d = Decimal(xrp)
+
+        if xrp_d < ONE_DROP and xrp_d != 0:
+            raise XRPRangeException(f"XRP amount {xrp} is too small.")
+        if xrp_d > MAX_XRP:
+            raise XRPRangeException(f"XRP amount {xrp} is too large.")
+    except InvalidOperation:
+        raise XRPRangeException(f"Not a valid amount of XRP: '{xrp}'")
+
+    drops_amount = (xrp_d / ONE_DROP).quantize(Decimal(1))
+    drops_str = str(drops_amount)
+
+    # This should never happen, but is a precaution against Decimal doing
+    # something unexpected.
+    if not match(_DROPS_REGEX, drops_str):
+        raise XRPRangeException(
+            f"xrp_to_drops failed sanity check. Value "
+            f"'{drops_str}' does not match the drops regex"
+        )
+
+    return drops_str
+
+
+def drops_to_xrp(drops: str) -> Decimal:
+    """
+    Convert from drops to decimal XRP.
+
+    Args:
+        drops: String representing indivisible drops of XRP
+
+    Returns:
+        Decimal representation of the same amount of XRP
+
+    Raises:
+        XRPRangeException: if the given number of drops is invalid
+    """
+    setcontext(_DROPS_CONTEXT)
+    if not match(_DROPS_REGEX, drops):
+        raise XRPRangeException(f"Not a valid amount of drops: '{drops}'")
+    try:
+        drops_d = Decimal(drops)
+    except InvalidOperation:
+        raise XRPRangeException(f"Not a valid amount of drops: '{drops}'")
+    xrp_d = drops_d * ONE_DROP
+    if xrp_d > MAX_XRP:
+        raise XRPRangeException(f"Drops amount {drops} is too large.")
+    return xrp_d
+
+
+class XRPRangeException(XRPLException):
+    """Exception for invalid XRP amounts."""
+
+    pass
+
+
+class XRPTypeException(XRPLException):
+    """Exception for string XRP amounts (use a Decimal for decimal XRP)."""
+
+    pass


### PR DESCRIPTION
Adds some conversion utilities for feature-parity with ripple-lib:

- Convert from decimal (`int`, `float`, or `decimal.Decimal`) XRP to drops of XRP and back (to Decimal)
- Convert from XRP Ledger's "Ripple Epoch" time format to Python-native time types and back.

# Type of Change

- [x] New Feature
- [x] Tests
- [x] Documentation