### PR TITLE
Included binary, min_ledger and max_ledger for get_transaction_from_hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pseudo-transaction models.
 - Instance method in `Transaction` objects to calculate their hashes locally
 - Option for `Transaction.flags` to be a `List` of `int`s instead of just an `int`
+- Optional parameters for `get_transaction_from_hash`: `binary`, `min_ledger` and `max_ledger`
 
 ## [1.0.0] - 2021-03-31
 ### Added

--- a/tests/integration/sugar/test_transaction.py
+++ b/tests/integration/sugar/test_transaction.py
@@ -8,10 +8,10 @@ from xrpl.clients import XRPLRequestFailureException
 from xrpl.models.transactions import AccountSet, Payment
 from xrpl.transaction import (
     XRPLReliableSubmissionException,
+    get_transaction_from_hash,
     safe_sign_and_autofill_transaction,
     safe_sign_transaction,
     send_reliable_submission,
-    get_transaction_from_hash
 )
 
 ACCOUNT = WALLET.classic_address
@@ -97,10 +97,14 @@ class TestTransaction(TestCase):
 
     def test_get_transaction_from_hash(self):
         # GIVEN a new transaction (payment)
-        payment_transaction = Payment(account=WALLET.classic_address, amount="100", destination=DESTINATION)
+        payment_transaction = Payment(
+            account=WALLET.classic_address, amount="100", destination=DESTINATION
+        )
 
         # WHEN we sign locally and autofill the transaction
-        signed_payment_transaction = safe_sign_and_autofill_transaction(payment_transaction, WALLET, JSON_RPC_CLIENT)
+        signed_payment_transaction = safe_sign_and_autofill_transaction(
+            payment_transaction, WALLET, JSON_RPC_CLIENT
+        )
 
         # AND submit the transaction
         response = send_reliable_submission(signed_payment_transaction, JSON_RPC_CLIENT)
@@ -108,7 +112,7 @@ class TestTransaction(TestCase):
         # THEN we expect to retrieve this transaction from its hash
         payment = get_transaction_from_hash(response.result["hash"], JSON_RPC_CLIENT)
 
-        # AND we expect the result Account to be the same as the original payment Account
+        # AND we expect the result Account to be the same as the original payment Acct
         self.assertEqual(payment.result["Account"], ACCOUNT)
         # AND we expect the response to be successful (200)
         self.assertTrue(payment.is_successful())
@@ -117,16 +121,21 @@ class TestTransaction(TestCase):
 
     def test_get_transaction_from_hash_with_binary(self):
         # GIVEN a new transaction (payment)
-        payment_transaction = Payment(account=WALLET.classic_address, amount="100", destination=DESTINATION)
-        
+        payment_transaction = Payment(
+            account=WALLET.classic_address, amount="100", destination=DESTINATION
+        )
+
         # WHEN we sign locally and autofill the transaction
-        signed_payment_transaction = safe_sign_and_autofill_transaction(payment_transaction, WALLET, JSON_RPC_CLIENT)
+        signed_payment_transaction = safe_sign_and_autofill_transaction(
+            payment_transaction, WALLET, JSON_RPC_CLIENT
+        )
 
         # AND submit the transaction
         response = send_reliable_submission(signed_payment_transaction, JSON_RPC_CLIENT)
         payment_hash = response.result["hash"]
 
-        # THEN we expect to retrieve this transaction from its hash with the binary parameter set to true
+        # THEN we expect to retrieve this transaction from its hash with the
+        # binary parameter set to true
         payment = get_transaction_from_hash(payment_hash, JSON_RPC_CLIENT, True)
 
         # AND we expect the result hash to be the same as the original payment hash
@@ -138,20 +147,31 @@ class TestTransaction(TestCase):
 
     def test_get_transaction_from_hash_with_min_max_ledgers(self):
         # GIVEN a new transaction (payment)
-        payment_transaction = Payment(account=WALLET.classic_address, amount="100", destination=DESTINATION)
-        
+        payment_transaction = Payment(
+            account=WALLET.classic_address, amount="100", destination=DESTINATION
+        )
+
         # WHEN we sign locally and autofill the transaction
-        signed_payment_transaction = safe_sign_and_autofill_transaction(payment_transaction, WALLET, JSON_RPC_CLIENT)
+        signed_payment_transaction = safe_sign_and_autofill_transaction(
+            payment_transaction, WALLET, JSON_RPC_CLIENT
+        )
 
         # AND submit the transaction
         response = send_reliable_submission(signed_payment_transaction, JSON_RPC_CLIENT)
         payment_hash = response.result["hash"]
         payment_ledger_index = response.result["ledger_index"]
 
-        # THEN we expect to retrieve this transaction from its hash with min_ledger and max_ledger parameters
-        payment = get_transaction_from_hash(payment_hash, JSON_RPC_CLIENT, False, payment_ledger_index - 500, payment_ledger_index + 500)
+        # THEN we expect to retrieve this transaction from its hash with
+        # min_ledger and max_ledger parameters
+        payment = get_transaction_from_hash(
+            payment_hash,
+            JSON_RPC_CLIENT,
+            False,
+            payment_ledger_index - 500,
+            payment_ledger_index + 500,
+        )
 
-        # AND we expect the result Account to be the same as the original payment Account
+        # AND we expect the result Account to be the same as the original payment Acct
         self.assertEqual(payment.result["Account"], ACCOUNT)
         # AND we expect the response to be successful (200)
         self.assertTrue(payment.is_successful())

--- a/tests/integration/sugar/test_transaction.py
+++ b/tests/integration/sugar/test_transaction.py
@@ -11,6 +11,7 @@ from xrpl.transaction import (
     safe_sign_and_autofill_transaction,
     safe_sign_transaction,
     send_reliable_submission,
+    get_transaction_from_hash
 )
 
 ACCOUNT = WALLET.classic_address
@@ -93,3 +94,66 @@ class TestTransaction(TestCase):
         with self.assertRaises(XRPLRequestFailureException):
             send_reliable_submission(signed_payment_transaction, JSON_RPC_CLIENT)
         WALLET.sequence -= 1
+
+    def test_get_transaction_from_hash(self):
+        # GIVEN a new transaction (payment)
+        payment_transaction = Payment(account=WALLET.classic_address, amount="100", destination=DESTINATION)
+
+        # WHEN we sign locally and autofill the transaction
+        signed_payment_transaction = safe_sign_and_autofill_transaction(payment_transaction, WALLET, JSON_RPC_CLIENT)
+
+        # AND submit the transaction
+        response = send_reliable_submission(signed_payment_transaction, JSON_RPC_CLIENT)
+
+        # THEN we expect to retrieve this transaction from its hash
+        payment = get_transaction_from_hash(response.result["hash"], JSON_RPC_CLIENT)
+
+        # AND we expect the result Account to be the same as the original payment Account
+        self.assertEqual(payment.result["Account"], ACCOUNT)
+        # AND we expect the response to be successful (200)
+        self.assertTrue(payment.is_successful())
+
+        WALLET.sequence += 1
+
+    def test_get_transaction_from_hash_with_binary(self):
+        # GIVEN a new transaction (payment)
+        payment_transaction = Payment(account=WALLET.classic_address, amount="100", destination=DESTINATION)
+        
+        # WHEN we sign locally and autofill the transaction
+        signed_payment_transaction = safe_sign_and_autofill_transaction(payment_transaction, WALLET, JSON_RPC_CLIENT)
+
+        # AND submit the transaction
+        response = send_reliable_submission(signed_payment_transaction, JSON_RPC_CLIENT)
+        payment_hash = response.result["hash"]
+
+        # THEN we expect to retrieve this transaction from its hash with the binary parameter set to true
+        payment = get_transaction_from_hash(payment_hash, JSON_RPC_CLIENT, True)
+
+        # AND we expect the result hash to be the same as the original payment hash
+        self.assertEqual(payment.result["hash"], payment_hash)
+        # AND we expect the response to be successful (200)
+        self.assertTrue(payment.is_successful())
+
+        WALLET.sequence += 1
+
+    def test_get_transaction_from_hash_with_min_max_ledgers(self):
+        # GIVEN a new transaction (payment)
+        payment_transaction = Payment(account=WALLET.classic_address, amount="100", destination=DESTINATION)
+        
+        # WHEN we sign locally and autofill the transaction
+        signed_payment_transaction = safe_sign_and_autofill_transaction(payment_transaction, WALLET, JSON_RPC_CLIENT)
+
+        # AND submit the transaction
+        response = send_reliable_submission(signed_payment_transaction, JSON_RPC_CLIENT)
+        payment_hash = response.result["hash"]
+        payment_ledger_index = response.result["ledger_index"]
+
+        # THEN we expect to retrieve this transaction from its hash with min_ledger and max_ledger parameters
+        payment = get_transaction_from_hash(payment_hash, JSON_RPC_CLIENT, False, payment_ledger_index - 500, payment_ledger_index + 500)
+
+        # AND we expect the result Account to be the same as the original payment Account
+        self.assertEqual(payment.result["Account"], ACCOUNT)
+        # AND we expect the response to be successful (200)
+        self.assertTrue(payment.is_successful())
+
+        WALLET.sequence += 1

--- a/xrpl/transaction/ledger.py
+++ b/xrpl/transaction/ledger.py
@@ -1,22 +1,36 @@
 """High-level methods that fetch transaction information from the XRP Ledger."""
 
-from typing import Any, Dict, cast
+from typing import Any, Dict, Optional, cast
 
 from xrpl.clients import Client, XRPLRequestFailureException
 from xrpl.models.requests import Tx
 from xrpl.models.response import Response
 
 
-def get_transaction_from_hash(tx_hash: str, client: Client, binary: bool = False, min_ledger: int = None, max_ledger: int = None) -> Response:
+def get_transaction_from_hash(
+    tx_hash: str,
+    client: Client,
+    binary: bool = False,
+    min_ledger: Optional[int] = None,
+    max_ledger: Optional[int] = None,
+) -> Response:
     """
     Given a transaction hash, fetch the corresponding transaction from the ledger.
 
     Args:
         tx_hash: the transaction hash.
         client: the network client used to communicate with a rippled node.
-        binary: (Optional) If true, return transaction data and metadata as binary serialized to hexadecimal strings. If false, return transaction data and metadata as JSON. The default is false.
-        min_ledger: (Optional) Use this with max_ledger to specify a range of up to 1000 ledger indexes, starting with this ledger (inclusive). If the server cannot find the transaction, it confirms whether it was able to search all the ledgers in this range.
-        max_ledger: (Optional) Use this with min_ledger to specify a range of up to 1000 ledger indexes, ending with this ledger (inclusive). If the server cannot find the transaction, it confirms whether it was able to search all the ledgers in the requested range.
+        binary: (Optional) If true, return transaction data and metadata as binary
+            serialized to hexadecimal strings. If false, return transaction data and
+            metadata as JSON. The default is false.
+        min_ledger: (Optional) Use this with max_ledger to specify a range of up to
+            1000 ledger indexes, starting with this ledger (inclusive). If the server
+            cannot find the transaction, it confirms whether it was able to search all
+            the ledgers in this range.
+        max_ledger: (Optional) Use this with min_ledger to specify a range of up to
+            1000 ledger indexes, ending with this ledger (inclusive). If the server
+            cannot find the transaction, it confirms whether it was able to search
+            all the ledgers in the requested range.
 
     Returns:
         The Response object containing the transaction info.
@@ -24,7 +38,14 @@ def get_transaction_from_hash(tx_hash: str, client: Client, binary: bool = False
     Raises:
         XRPLRequestFailureException: if the transaction fails.
     """
-    response = client.request(Tx(transaction=tx_hash, binary=binary, max_ledger=max_ledger, min_ledger=min_ledger))
+    response = client.request(
+        Tx(
+            transaction=tx_hash,
+            binary=binary,
+            max_ledger=max_ledger,
+            min_ledger=min_ledger,
+        )
+    )
     if not response.is_successful():
         result = cast(Dict[str, Any], response.result)
         raise XRPLRequestFailureException(result)

--- a/xrpl/transaction/ledger.py
+++ b/xrpl/transaction/ledger.py
@@ -20,14 +20,14 @@ def get_transaction_from_hash(
     Args:
         tx_hash: the transaction hash.
         client: the network client used to communicate with a rippled node.
-        binary: (Optional) If true, return transaction data and metadata as binary
+        binary: If true, return transaction data and metadata as binary
             serialized to hexadecimal strings. If false, return transaction data and
             metadata as JSON. The default is false.
-        min_ledger: (Optional) Use this with max_ledger to specify a range of up to
+        min_ledger: Use this with max_ledger to specify a range of up to
             1000 ledger indexes, starting with this ledger (inclusive). If the server
             cannot find the transaction, it confirms whether it was able to search all
             the ledgers in this range.
-        max_ledger: (Optional) Use this with min_ledger to specify a range of up to
+        max_ledger: Use this with min_ledger to specify a range of up to
             1000 ledger indexes, ending with this ledger (inclusive). If the server
             cannot find the transaction, it confirms whether it was able to search
             all the ledgers in the requested range.

--- a/xrpl/transaction/ledger.py
+++ b/xrpl/transaction/ledger.py
@@ -7,13 +7,16 @@ from xrpl.models.requests import Tx
 from xrpl.models.response import Response
 
 
-def get_transaction_from_hash(tx_hash: str, client: Client) -> Response:
+def get_transaction_from_hash(tx_hash: str, client: Client, binary: bool = False, min_ledger: int = None, max_ledger: int = None) -> Response:
     """
     Given a transaction hash, fetch the corresponding transaction from the ledger.
 
     Args:
         tx_hash: the transaction hash.
         client: the network client used to communicate with a rippled node.
+        binary: (Optional) If true, return transaction data and metadata as binary serialized to hexadecimal strings. If false, return transaction data and metadata as JSON. The default is false.
+        min_ledger: (Optional) Use this with max_ledger to specify a range of up to 1000 ledger indexes, starting with this ledger (inclusive). If the server cannot find the transaction, it confirms whether it was able to search all the ledgers in this range.
+        max_ledger: (Optional) Use this with min_ledger to specify a range of up to 1000 ledger indexes, ending with this ledger (inclusive). If the server cannot find the transaction, it confirms whether it was able to search all the ledgers in the requested range.
 
     Returns:
         The Response object containing the transaction info.
@@ -21,7 +24,7 @@ def get_transaction_from_hash(tx_hash: str, client: Client) -> Response:
     Raises:
         XRPLRequestFailureException: if the transaction fails.
     """
-    response = client.request(Tx(transaction=tx_hash))
+    response = client.request(Tx(transaction=tx_hash, binary=binary, max_ledger=max_ledger, min_ledger=min_ledger))
     if not response.is_successful():
         result = cast(Dict[str, Any], response.result)
         raise XRPLRequestFailureException(result)


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

In this PR I added the `binary`, `min_ledger` and `max_ledger` of the `tx` method as described in https://xrpl.org/tx.html#tx

I also added some tests in `tests/integration/sugar/test_transaction.py`.

It solves this issue: https://github.com/XRPLF/xrpl-py/issues/191

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [X] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

The `get_transaction_from_hash` method now accepts `binary`, `min_ledger` and `max_ledger` parameters.

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

I included three new tests:
1. We submit a simple payment and then retrieve this transaction with `get_transaction_from_hash` without using the new parameters.
2. We submit a simple payment and then retrieve this transaction with `get_transaction_from_hash` with `binary=true`. We make sure the response includes a `hash` field.
3. We submit a simple payment and then retrieve this transaction with `get_transaction_from_hash` with `binary=false`, `min_ledger=payment ledger index - 500` and `max_ledger=payment ledger index + 500`.

<!--
## Future Tasks
For future tasks related to PR.
-->
