### PR TITLE
Fixes `Memo` dictionary handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expose `xrpl.accounts.get_account_root`
 - Invalid X-Addresses in the XRPL Binary Codec now error with `XRPLBinaryCodecException` instead of `ValueError`
 - Issue with calculating IOU precision
-- Issue with converting certain dictionaries to a model using `BaseModel.from_dict`
+- Issues with converting certain dictionaries to/from a model using `BaseModel.from_dict`
 
 ## [1.0.0] - 2021-03-31
 ### Added

--- a/tests/unit/models/test_base_model.py
+++ b/tests/unit/models/test_base_model.py
@@ -14,6 +14,7 @@ from xrpl.models.requests import (
 )
 from xrpl.models.transactions import (
     CheckCreate,
+    Memo,
     SignerEntry,
     SignerListSet,
     TrustSet,
@@ -292,6 +293,46 @@ class TestBaseModel(TestCase):
                     tx = Transaction.from_xrpl(r_json)
                     translated_tx = transaction_json_to_binary_codec_form(tx.to_dict())
                     self.assertEqual(r_json, translated_tx)
+
+    def test_from_xrpl_memos(self):
+        memo_type = "687474703a2f2f6578616d706c652e636f6d2f6d656d6f2f67656e65726963"
+        tx = {
+            "Account": "rnoGkgSpt6AX1nQxZ2qVGx7Fgw6JEcoQas",
+            "TransactionType": "TrustSet",
+            "Fee": "10",
+            "Sequence": 17892983,
+            "Flags": 131072,
+            "Memos": [
+                {
+                    "Memo": {
+                        "MemoType": memo_type,
+                        "MemoData": "72656e74",
+                    }
+                }
+            ],
+            "SigningPubKey": "",
+            "LimitAmount": {
+                "currency": "USD",
+                "issuer": "rBPvTKisx7UCGLDtiUZ6mDssXNREuVuL8Y",
+                "value": "10",
+            },
+        }
+        expected = TrustSet(
+            account="rnoGkgSpt6AX1nQxZ2qVGx7Fgw6JEcoQas",
+            fee="10",
+            sequence=17892983,
+            flags=131072,
+            memos=[
+                Memo(
+                    memo_type=memo_type,
+                    memo_data="72656e74",
+                )
+            ],
+            limit_amount=IssuedCurrencyAmount(
+                currency="USD", issuer="rBPvTKisx7UCGLDtiUZ6mDssXNREuVuL8Y", value="10"
+            ),
+        )
+        self.assertEqual(Transaction.from_xrpl(tx), expected)
 
     def test_is_dict_of_model_when_true(self):
         self.assertTrue(

--- a/xrpl/asyncio/clients/exceptions.py
+++ b/xrpl/asyncio/clients/exceptions.py
@@ -17,7 +17,7 @@ class XRPLRequestFailureException(XRPLException):
             result: the error result returned by the ledger.
         """
         self.error = result["error"]
-        if "error_message" in result:
+        if "error_message" in result and result["error_message"] is not None:
             self.error_message = result["error_message"]
         elif "error_exception" in result:
             self.error_message = result["error_exception"]

--- a/xrpl/asyncio/clients/exceptions.py
+++ b/xrpl/asyncio/clients/exceptions.py
@@ -17,6 +17,7 @@ class XRPLRequestFailureException(XRPLException):
             result: the error result returned by the ledger.
         """
         self.error = result["error"]
+        self.error_message = None
         if "error_message" in result and result["error_message"] is not None:
             self.error_message = result["error_message"]
         elif "error_exception" in result:

--- a/xrpl/models/transactions/transaction.py
+++ b/xrpl/models/transactions/transaction.py
@@ -91,6 +91,33 @@ class Memo(BaseModel):
             errors["Memo"] = "Memo must contain at least one field"
         return errors
 
+    @classmethod
+    def from_dict(cls: Type[Memo], value: Dict[str, Any]) -> Memo:
+        """
+        Construct a new Memo from a dictionary of parameters.
+
+        Args:
+            value: The value to construct the Memo from.
+
+        Returns:
+            A new Memo object, constructed using the given parameters.
+
+        Raises:
+            XRPLModelException: If the dictionary provided is invalid.
+        """
+        if "memo" not in value:
+            return cast(Memo, super(Memo, cls).from_dict(value))
+        return cast(Memo, super(Memo, cls).from_dict(value["memo"]))
+
+    def to_dict(self: Memo) -> Dict[str, Any]:
+        """
+        Returns the dictionary representation of a Memo.
+
+        Returns:
+            The dictionary representation of a Memo.
+        """
+        return {"memo": super().to_dict()}
+
 
 @require_kwargs_on_init
 @dataclass(frozen=True)


### PR DESCRIPTION
## High Level Overview of Change

This PR fixes a bug in the `Memo` model, where it doesn't properly provide memos in the format that the XRPL expects them in. It also makes the exception messages a little better.

The XRPL expects memos to be in the following format:
```python
{
    "Memo": {
        "MemoType": "687474703a2f2f6578616d706c652e636f6d2f6d656d6f2f67656e65726963",
        "MemoData": "72656e74"
    }
}
```
The library had been providing them like this:
```python
{
    "MemoType": "687474703a2f2f6578616d706c652e636f6d2f6d656d6f2f67656e65726963",
    "MemoData": "72656e74"
}
```

### Context of Change

Fixes #247

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

Added a unit test. CI passes.

<!--
## Future Tasks
For future tasks related to PR.
-->
