### PR TITLE
Fix path serialization bug

### DIFF
--- a/tests/integration/reqs/test_submit_only.py
+++ b/tests/integration/reqs/test_submit_only.py
@@ -8,7 +8,6 @@ from xrpl.core.binarycodec import encode
 from xrpl.models.amounts import IssuedCurrencyAmount
 from xrpl.models.requests import SubmitOnly
 from xrpl.models.transactions import OfferCreate
-from xrpl.transaction import transaction_json_to_binary_codec_form
 
 TX = OfferCreate(
     account=WALLET.classic_address,
@@ -27,7 +26,7 @@ class TestSubmitOnly(IntegrationTestCase):
     @test_async_and_sync(globals())
     async def test_basic_functionality(self, client):
         transaction = await safe_sign_and_autofill_transaction_async(TX, WALLET, client)
-        tx_json = transaction_json_to_binary_codec_form(transaction.to_dict())
+        tx_json = transaction.to_xrpl()
         tx_blob = encode(tx_json)
         response = await client.request(
             SubmitOnly(

--- a/tests/unit/models/test_base_model.py
+++ b/tests/unit/models/test_base_model.py
@@ -18,6 +18,7 @@ from xrpl.models.requests import (
 from xrpl.models.transactions import (
     CheckCreate,
     Memo,
+    Payment,
     Signer,
     SignerEntry,
     SignerListSet,
@@ -25,7 +26,6 @@ from xrpl.models.transactions import (
     TrustSetFlag,
 )
 from xrpl.models.transactions.transaction import Transaction
-from xrpl.transaction import transaction_json_to_binary_codec_form
 
 currency = "BTC"
 value = "100"
@@ -79,6 +79,8 @@ class TestBaseModel(TestCase):
 
 
 class TestFromDict(TestCase):
+    maxDiff = 2000
+
     def test_from_dict_basic(self):
         amount = IssuedCurrencyAmount.from_dict(amount_dict)
         self.assertEqual(amount, IssuedCurrencyAmount(**amount_dict))
@@ -392,11 +394,11 @@ class TestFromDict(TestCase):
                 r_json = test["rjson"]
                 with self.subTest(json=x_json):
                     tx = Transaction.from_xrpl(x_json)
-                    translated_tx = transaction_json_to_binary_codec_form(tx.to_dict())
+                    translated_tx = tx.to_xrpl()
                     self.assertEqual(x_json, translated_tx)
                 with self.subTest(json=r_json):
                     tx = Transaction.from_xrpl(r_json)
-                    translated_tx = transaction_json_to_binary_codec_form(tx.to_dict())
+                    translated_tx = tx.to_xrpl()
                     self.assertEqual(r_json, translated_tx)
 
     def test_from_xrpl_signers(self):
@@ -501,3 +503,67 @@ class TestFromDict(TestCase):
             ),
         )
         self.assertEqual(Transaction.from_xrpl(tx), expected)
+
+    def test_to_xrpl_paths(self):
+        paths_json = [
+            [
+                {"account": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B", "type": 1},
+                {
+                    "currency": "USD",
+                    "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+                    "type": 48,
+                },
+                {"account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q", "type": 1},
+                {"account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "type": 1},
+            ],
+        ]
+
+        p = Payment(
+            account="rweYz56rfmQ98cAdRaeTxQS9wVMGnrdsFp",
+            amount=IssuedCurrencyAmount(
+                currency="USD",
+                issuer="rweYz56rfmQ98cAdRaeTxQS9wVMGnrdsFp",
+                value="0.0001",
+            ),
+            destination="rweYz56rfmQ98cAdRaeTxQS9wVMGnrdsFp",
+            send_max=IssuedCurrencyAmount(
+                currency="BTC",
+                issuer="rweYz56rfmQ98cAdRaeTxQS9wVMGnrdsFp",
+                value="0.0000002831214446",
+            ),
+            paths=paths_json,
+            sequence=290,
+        )
+        tx_json = p.to_xrpl()
+
+        expected = {
+            "Account": "rweYz56rfmQ98cAdRaeTxQS9wVMGnrdsFp",
+            "TransactionType": "Payment",
+            "Sequence": 290,
+            "Flags": 0,
+            "SigningPubKey": "",
+            "Amount": {
+                "currency": "USD",
+                "issuer": "rweYz56rfmQ98cAdRaeTxQS9wVMGnrdsFp",
+                "value": "0.0001",
+            },
+            "Destination": "rweYz56rfmQ98cAdRaeTxQS9wVMGnrdsFp",
+            "Paths": [
+                [
+                    {"account": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B", "type": 1},
+                    {
+                        "currency": "USD",
+                        "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+                        "type": 48,
+                    },
+                    {"account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q", "type": 1},
+                    {"account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "type": 1},
+                ]
+            ],
+            "SendMax": {
+                "currency": "BTC",
+                "issuer": "rweYz56rfmQ98cAdRaeTxQS9wVMGnrdsFp",
+                "value": "0.0000002831214446",
+            },
+        }
+        self.assertEqual(tx_json, expected)

--- a/xrpl/models/transactions/transaction.py
+++ b/xrpl/models/transactions/transaction.py
@@ -40,10 +40,23 @@ def _key_to_tx_json(key: str) -> str:
     return re.sub(r"Unl", r"UNL", re.sub(r"Id", r"ID", snaked))
 
 
+def _is_path(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    return (
+        len(value) == 0
+        or "issuer" in value
+        or "account" in value
+        or "currency" in value
+    )
+
+
 def _value_to_tx_json(value: Any) -> Any:
     # IssuedCurrencyAmount is a special case and should not be snake cased
     if IssuedCurrencyAmount.is_dict_of_model(value):
         return {key: _value_to_tx_json(sub_value) for (key, sub_value) in value.items()}
+    if _is_path(value):
+        return value
     if isinstance(value, dict):
         return transaction_json_to_binary_codec_form(value)
     if isinstance(value, list):


### PR DESCRIPTION
## High Level Overview of Change

This PR fixes a bug with path serializations and adds a test to ensure this doesn't crop up again. Also cleaned up some other tests.

### Context of Change

On a Twitch stream on 6/9, @hammertoe and @mDuo13 ran into a bug with the serialization of paths. Some failing sample code: https://gist.github.com/mDuo13/35358346ebb3d4dd8b5ea3757f0ed7a6#file-test_instantiate-py

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

Added a test that previously failed.

<!--
## Future Tasks
For future tasks related to PR.
-->
