### PR TITLE
fix: UInt64.from_value() accepts lower case hex

### DIFF
--- a/tests/unit/core/binarycodec/test_main.py
+++ b/tests/unit/core/binarycodec/test_main.py
@@ -240,8 +240,8 @@ class TestMainSimple(TestCase):
             },
             "LowNode": "0",
             "PreviousTxnID": (
-                "06FC7DE374089D50F81AAE13E7BBF3D0E694769331E14F55351B38D0148018EA",
-            ),
+                "06FC7DE374089D50F81AAE13E7BBF3D0E694769331E14F55351B38D0148018EA"
+            ).lower(),
             "PreviousTxnLgrSeq": 32253063,
             "index": "000319BAE0A618A7D3BB492F17E98E5D92EA0C6458AFEBED44206B5B4798A840",
         }

--- a/tests/unit/core/binarycodec/test_main.py
+++ b/tests/unit/core/binarycodec/test_main.py
@@ -209,10 +209,47 @@ class TestMainSimple(TestCase):
             "Balance": "10000000000",
         }
 
+        lowerCaseIntBinary = (
+            "11007222001100002501EC24873700000000000000003800000000000000A35506"
+            "FC7DE374089D50F81AAE13E7BBF3D0E694769331E14F55351B38D0148018EA62D4"
+            "4BF89AC2A40B800000000000000000000000004A50590000000000000000000000"
+            "000000000000000000000000000166D6C38D7EA4C6800000000000000000000000"
+            "00004A5059000000000047C1258B4B79774B28176324068F759EDE226F68678000"
+            "0000000000000000000000000000000000004A505900000000005BBC0F22F61D92"
+            "24A110650CFE21CC0C4BE13098"
+        )
+
+        lowerCaseIntJson = {
+            "Balance": {
+                "currency": "JPY",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "0.3369568318",
+            },
+            "Flags": 1114112,
+            "HighLimit": {
+                "currency": "JPY",
+                "issuer": "r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN",
+                "value": "0",
+            },
+            "HighNode": "a3",
+            "LedgerEntryType": "RippleState",
+            "LowLimit": {
+                "currency": "JPY",
+                "issuer": "rfYQMgj3g3Qp8VLoZNvvU35mEuuJC8nCmY",
+                "value": "1000000000",
+            },
+            "LowNode": "0",
+            "PreviousTxnID":
+                "06FC7DE374089D50F81AAE13E7BBF3D0E694769331E14F55351B38D0148018EA",
+            "PreviousTxnLgrSeq": 32253063,
+            "index": "000319BAE0A618A7D3BB492F17E98E5D92EA0C6458AFEBED44206B5B4798A840",
+        }
+
         self.assertEqual(decode(lower), decode(s))
         self.assertEqual(encode(decode(lower)), s)
         self.assertEqual(encode(json_dict), binary)
         self.assertEqual(decode(encode(json_dict)), json_upper)
+        self.assertEqual(encode(lowerCaseIntJson), lowerCaseIntBinary)
 
     def test_pseudo_transaction(self):
         json_dict = {

--- a/tests/unit/core/binarycodec/test_main.py
+++ b/tests/unit/core/binarycodec/test_main.py
@@ -239,8 +239,9 @@ class TestMainSimple(TestCase):
                 "value": "1000000000",
             },
             "LowNode": "0",
-            "PreviousTxnID":
+            "PreviousTxnID": (
                 "06FC7DE374089D50F81AAE13E7BBF3D0E694769331E14F55351B38D0148018EA",
+            ),
             "PreviousTxnLgrSeq": 32253063,
             "index": "000319BAE0A618A7D3BB492F17E98E5D92EA0C6458AFEBED44206B5B4798A840",
         }

--- a/xrpl/core/binarycodec/types/uint64.py
+++ b/xrpl/core/binarycodec/types/uint64.py
@@ -15,7 +15,7 @@ from xrpl.core.binarycodec.types.uint import UInt
 
 _WIDTH: Final[int] = 8  # 64 / 8
 
-_HEX_REGEX: Final[re.Pattern[str]] = re.compile("^[A-F0-9]{16}$")
+_HEX_REGEX: Final[re.Pattern[str]] = re.compile("^[a-fA-F0-9]{1,16}$")
 
 
 class UInt64(UInt):
@@ -72,6 +72,7 @@ class UInt64(UInt):
         if isinstance(value, str):
             if not _HEX_REGEX.fullmatch(value):
                 raise XRPLBinaryCodecException("{value} is not a valid hex string")
+            value = value.rjust(16, "0")
             value_bytes = bytes.fromhex(value)
             return cls(value_bytes)
 


### PR DESCRIPTION
## High Level Overview of Change
Allow for `UInt64.from_value()` to accept lower case hex w/ length 1-16.

### Context of Change
This PR allows for parsing lower case hex strings w/ length 1-16. It does this w/ an `rjust`, which pads the string `value` w/ leading zeros until it is length 16. This allows for it to be encoded like normal. 

Also, the `HEX_REGEX` was adjusted to allow for lower case hex strings.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan
Added a test to verify that encoding would work on both hex-strings w/ lowercase letters and hex-strings w/ length <16.
