### PR TITLE
Change assert statement when not for invariant in mypy check, include development node recommendation

### DIFF
--- a/xrpl/core/keypairs/__init__.py
+++ b/xrpl/core/keypairs/__init__.py
@@ -13,10 +13,11 @@ from xrpl.core.keypairs.main import (
     sign,
 )
 
-assert (
-    "ripemd160" in algorithms_available
-), """Your OpenSSL implementation does not include the RIPEMD160 algorithm,
-    which is required by XRPL"""
+if "ripemd160" not in algorithms_available:
+    raise ImportError(
+        "Your OpenSSL implementation does not include the RIPEMD160 algorithm,"
+        " which is required by XRPL."
+    )
 
 __all__ = [
     "derive_classic_address",


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

Closes #270


### Context of Change
See #270.


When running [this script](https://gist.github.com/yyolk/42b67ec5f1b1a17e273b5497e9eaad88#file-02__xrpl-py__xrpl_stat_table-py):

closing (with <kbd>^C</kbd>, a `KeyboardInterrupt` closes the socket as quickly as the implementation using `websockets` when running `python -O ...` but not as quick when running `python ...`. 

This may result in sending another `KeyboardInterrupt` which isn't what you want to do.


<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Refactor (non-breaking change that only restructures code)

## Before / After

### Before
- An assert statement that is used for raising when an import doesn't have a requirement
- no runtime recommendations

### After
- An `assert` in a `__init__` was also dropped for `ImportError` as it is an error as a result of an `import` :D
- runtime recommendation to include `-O` in production or in development when running locally with CPython, `assert` statements are dropped with [`-O`](https://docs.python.org/3/using/cmdline.html#cmdoption-o)

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

- use the test suite as-is for the ImportError change
- feedback on relevant documentation changes.

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
