### PR TITLE
Workaround for ripemd160 not being available on Google Colab

### DIFF
--- a/xrpl/core/keypairs/__init__.py
+++ b/xrpl/core/keypairs/__init__.py
@@ -2,7 +2,6 @@
 Low-level functions for creating and using cryptographic keys with the XRP
 Ledger.
 """
-
 from xrpl.core.keypairs.exceptions import XRPLKeypairsException
 from xrpl.core.keypairs.main import (
     derive_classic_address,
@@ -11,7 +10,6 @@ from xrpl.core.keypairs.main import (
     is_valid_message,
     sign,
 )
-
 
 __all__ = [
     "derive_classic_address",

--- a/xrpl/core/keypairs/__init__.py
+++ b/xrpl/core/keypairs/__init__.py
@@ -2,7 +2,6 @@
 Low-level functions for creating and using cryptographic keys with the XRP
 Ledger.
 """
-from hashlib import algorithms_available
 
 from xrpl.core.keypairs.exceptions import XRPLKeypairsException
 from xrpl.core.keypairs.main import (
@@ -13,10 +12,6 @@ from xrpl.core.keypairs.main import (
     sign,
 )
 
-assert (
-    "ripemd160" in algorithms_available
-), """Your OpenSSL implementation does not include the RIPEMD160 algorithm,
-    which is required by XRPL"""
 
 __all__ = [
     "derive_classic_address",

--- a/xrpl/core/keypairs/helpers.py
+++ b/xrpl/core/keypairs/helpers.py
@@ -43,6 +43,6 @@ def get_account_id(public_key: bytes) -> bytes:
     """
     sha_hash = hashlib.sha256(public_key).digest()
     if RIPEMD160_IN_HASHLIB:
-        return bytes(RIPEMD.new(sha_hash).digest())
-    else:
         return hashlib.new("ripemd160", sha_hash).digest()
+    else:
+        return bytes(RIPEMD.new(sha_hash).digest())

--- a/xrpl/core/keypairs/helpers.py
+++ b/xrpl/core/keypairs/helpers.py
@@ -3,15 +3,15 @@ import hashlib
 
 
 if "ripemd160" in hashlib.algorithms_available:
-    ripemd160 = lambda x: hashlib.new("ripemd160", x).digest()
+    def ripemd160(x): return hashlib.new("ripemd160", x).digest()
 else:
     try:
         from Crypto.Hash import RIPEMD
-        ripemd160 = lambda x: RIPEMD.new(x).digest()
+        def ripemd160(x): return RIPEMD.new(x).digest()
     except ImportError:
-        raise ImportError("""Your OpenSSL implementation does not include the RIPEMD160 """
-                          """algorithm, which is required by XRPL, or pycrypto """
-                          """needs installing""")
+        raise ImportError("""Your OpenSSL implementation does not include """
+                          """the RIPEMD160 algorithm, which is required """
+                          """by XRPL, or pycrypto needs installing""")
 
 
 def sha512_first_half(message: bytes) -> bytes:

--- a/xrpl/core/keypairs/helpers.py
+++ b/xrpl/core/keypairs/helpers.py
@@ -2,15 +2,11 @@
 import hashlib
 
 if "ripemd160" in hashlib.algorithms_available:
-    def ripemd160(message: bytes) -> bytes:
-        """Helper function to compute RIPEMD160 hash"""
-        return hashlib.new("ripemd160", message).digest()
+    RIPEMD160_IN_HASHLIB = True
 else:
     try:
         from Crypto.Hash import RIPEMD
-        def ripemd160(message: bytes) -> bytes:
-            """Helper function to compute RIPEMD160 hash"""
-            return RIPEMD.new(message).digest()
+        RIPEMD160_IN_HASHLIB = False
     except ImportError:
         raise ImportError("""Your OpenSSL implementation does not include """
                           """the RIPEMD160 algorithm, which is required """
@@ -43,4 +39,7 @@ def get_account_id(public_key: bytes) -> bytes:
         The account ID for the given public key.
     """
     sha_hash = hashlib.sha256(public_key).digest()
-    return ripemd160(sha_hash)
+    if RIPEMD160_IN_HASHLIB:
+        return RIPEMD.new(sha_hash).digest()
+    else:
+        return hashlib.new("ripemd160", sha_hash).digest()

--- a/xrpl/core/keypairs/helpers.py
+++ b/xrpl/core/keypairs/helpers.py
@@ -6,11 +6,14 @@ if "ripemd160" in hashlib.algorithms_available:
 else:
     try:
         from Crypto.Hash import RIPEMD
+
         RIPEMD160_IN_HASHLIB = False
     except ImportError:
-        raise ImportError("""Your OpenSSL implementation does not include """
-                          """the RIPEMD160 algorithm, which is required """
-                          """by XRPL, or pycrypto needs installing""")
+        raise ImportError(
+            """Your OpenSSL implementation does not include """
+            """the RIPEMD160 algorithm, which is required """
+            """by XRPL, or pycrypto needs installing"""
+        )
 
 
 def sha512_first_half(message: bytes) -> bytes:

--- a/xrpl/core/keypairs/helpers.py
+++ b/xrpl/core/keypairs/helpers.py
@@ -2,6 +2,18 @@
 import hashlib
 
 
+if "ripemd160" in hashlib.algorithms_available:
+    ripemd160 = lambda x: hashlib.new("ripemd160", x).digest()
+else:
+    try:
+        from Crypto.Hash import RIPEMD
+        ripemd160 = lambda x: RIPEMD.new(x).digest()
+    except ImportError:
+        raise ImportError("""Your OpenSSL implementation does not include the RIPEMD160 """
+                          """algorithm, which is required by XRPL, or pycrypto """
+                          """needs installing""")
+
+
 def sha512_first_half(message: bytes) -> bytes:
     """
     Returns the first 32 bytes of SHA-512 hash of message.
@@ -28,4 +40,4 @@ def get_account_id(public_key: bytes) -> bytes:
         The account ID for the given public key.
     """
     sha_hash = hashlib.sha256(public_key).digest()
-    return hashlib.new("ripemd160", sha_hash).digest()
+    return ripemd160(sha_hash)

--- a/xrpl/core/keypairs/helpers.py
+++ b/xrpl/core/keypairs/helpers.py
@@ -1,13 +1,16 @@
 """Miscellaneous functions that are private to xrpl.core.keypairs."""
 import hashlib
 
-
 if "ripemd160" in hashlib.algorithms_available:
-    def ripemd160(x): return hashlib.new("ripemd160", x).digest()
+    def ripemd160(message: bytes) -> bytes:
+        """Helper function to compute RIPEMD160 hash"""
+        return hashlib.new("ripemd160", message).digest()
 else:
     try:
         from Crypto.Hash import RIPEMD
-        def ripemd160(x): return RIPEMD.new(x).digest()
+        def ripemd160(message: bytes) -> bytes:
+            """Helper function to compute RIPEMD160 hash"""
+            return RIPEMD.new(message).digest()
     except ImportError:
         raise ImportError("""Your OpenSSL implementation does not include """
                           """the RIPEMD160 algorithm, which is required """

--- a/xrpl/core/keypairs/helpers.py
+++ b/xrpl/core/keypairs/helpers.py
@@ -43,6 +43,6 @@ def get_account_id(public_key: bytes) -> bytes:
     """
     sha_hash = hashlib.sha256(public_key).digest()
     if RIPEMD160_IN_HASHLIB:
-        return RIPEMD.new(sha_hash).digest()
+        return bytes(RIPEMD.new(sha_hash).digest())
     else:
         return hashlib.new("ripemd160", sha_hash).digest()


### PR DESCRIPTION
## High Level Overview of Change

Use PyCrypto for RIPEMD160 hash if not found in hashlib

### Context of Change

`hashlib` relies upon OpenSSL to provide RIPEMD160. It can occur that OpenSSL is not configured to have RIPEMD160, in particular it is not found in Google Colab. I had a good play around with installing/re-installing OpenSSL and various dependancies on Google Colab, but could not get it to find RIPEMD160. There is an implementation of it in `pycrypto`, and so if we can't find it in hashlib, then try looking in there instead.

### Type of Change


- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Moved the check from `__init__.py` into `helpers.py`, define a lambda to abstract the call.

## Test Plan

Manual test and it seems to work ok.

