### PR TITLE
fix: make `response.result` type more specific

### DIFF
--- a/xrpl/asyncio/account/main.py
+++ b/xrpl/asyncio/account/main.py
@@ -1,6 +1,6 @@
 """High-level methods to obtain information about accounts."""
 
-from typing import Any, Dict, Union, cast
+from typing import Dict, Union, cast
 
 from xrpl.asyncio.clients import Client, XRPLRequestFailureException
 from xrpl.core.addresscodec import is_valid_xaddress, xaddress_to_classic_address
@@ -72,8 +72,7 @@ async def get_account_root(address: str, client: Client) -> Dict[str, Union[int,
         The AccountRoot dictionary for the address.
     """
     account_info = await get_account_info(address, client)
-    result = cast(Dict[str, Any], account_info.result)
-    return cast(Dict[str, Union[int, str]], result["account_data"])
+    return cast(Dict[str, Union[int, str]], account_info.result["account_data"])
 
 
 async def get_account_info(address: str, client: Client) -> Response:
@@ -101,5 +100,4 @@ async def get_account_info(address: str, client: Client) -> Response:
     if response.is_successful():
         return response
 
-    result = cast(Dict[str, Any], response.result)
-    raise XRPLRequestFailureException(result)
+    raise XRPLRequestFailureException(response.result)

--- a/xrpl/asyncio/account/transaction_history.py
+++ b/xrpl/asyncio/account/transaction_history.py
@@ -28,8 +28,7 @@ async def get_latest_transaction(account: str, client: Client) -> Response:
         AccountTx(account=account, ledger_index_max=-1, limit=1)
     )
     if not response.is_successful():
-        result = cast(Dict[str, Any], response.result)
-        raise XRPLRequestFailureException(result)
+        raise XRPLRequestFailureException(response.result)
     return response
 
 
@@ -53,10 +52,9 @@ async def get_account_transactions(
         address, _, _ = xaddress_to_classic_address(address)
     request = AccountTx(account=address)
     response = await client.request_impl(request)
-    result = cast(Dict[str, Any], response.result)
     if not response.is_successful():
-        raise XRPLRequestFailureException(result)
-    return cast(List[Dict[str, Any]], result["transactions"])
+        raise XRPLRequestFailureException(response.result)
+    return cast(List[Dict[str, Any]], response.result["transactions"])
 
 
 async def get_account_payment_transactions(

--- a/xrpl/asyncio/ledger/main.py
+++ b/xrpl/asyncio/ledger/main.py
@@ -1,6 +1,6 @@
 """High-level ledger methods with the XRPL ledger."""
 
-from typing import Any, Dict, cast
+from typing import cast
 
 from xrpl.asyncio.clients import Client, XRPLRequestFailureException
 from xrpl.models.requests import Fee, Ledger
@@ -20,11 +20,10 @@ async def get_latest_validated_ledger_sequence(client: Client) -> int:
         XRPLRequestFailureException: if the rippled API call fails.
     """
     response = await client.request_impl(Ledger(ledger_index="validated"))
-    result = cast(Dict[str, Any], response.result)
     if response.is_successful():
-        return cast(int, result["ledger_index"])
+        return cast(int, response.result["ledger_index"])
 
-    raise XRPLRequestFailureException(result)
+    raise XRPLRequestFailureException(response.result)
 
 
 async def get_latest_open_ledger_sequence(client: Client) -> int:
@@ -41,11 +40,10 @@ async def get_latest_open_ledger_sequence(client: Client) -> int:
         XRPLRequestFailureException: if the rippled API call fails.
     """
     response = await client.request_impl(Ledger(ledger_index="open"))
-    result = cast(Dict[str, Any], response.result)
     if response.is_successful():
-        return cast(int, result["ledger_index"])
+        return cast(int, response.result["ledger_index"])
 
-    raise XRPLRequestFailureException(result)
+    raise XRPLRequestFailureException(response.result)
 
 
 async def get_fee(client: Client) -> str:
@@ -62,8 +60,7 @@ async def get_fee(client: Client) -> str:
         XRPLRequestFailureException: if the rippled API call fails.
     """
     response = await client.request_impl(Fee())
-    result = cast(Dict[str, Any], response.result)
     if response.is_successful():
-        return cast(str, result["drops"]["minimum_fee"])
+        return cast(str, response.result["drops"]["minimum_fee"])
 
-    raise XRPLRequestFailureException(result)
+    raise XRPLRequestFailureException(response.result)

--- a/xrpl/asyncio/transaction/ledger.py
+++ b/xrpl/asyncio/transaction/ledger.py
@@ -1,6 +1,6 @@
 """High-level methods that fetch transaction information from the XRP Ledger."""
 
-from typing import Any, Dict, Optional, cast
+from typing import Optional
 
 from xrpl.asyncio.clients import Client, XRPLRequestFailureException
 from xrpl.models.requests import Tx
@@ -47,6 +47,5 @@ async def get_transaction_from_hash(
         )
     )
     if not response.is_successful():
-        result = cast(Dict[str, Any], response.result)
-        raise XRPLRequestFailureException(result)
+        raise XRPLRequestFailureException(response.result)
     return response

--- a/xrpl/asyncio/transaction/main.py
+++ b/xrpl/asyncio/transaction/main.py
@@ -137,8 +137,7 @@ async def submit_transaction(
     if response.is_successful():
         return response
 
-    result = cast(Dict[str, Any], response.result)
-    raise XRPLRequestFailureException(result)
+    raise XRPLRequestFailureException(response.result)
 
 
 def _prepare_transaction(

--- a/xrpl/asyncio/transaction/reliable_submission.py
+++ b/xrpl/asyncio/transaction/reliable_submission.py
@@ -1,7 +1,6 @@
 """High-level reliable submission methods with XRPL transactions."""
 
 import asyncio
-from typing import Any, Dict, cast
 
 from typing_extensions import Final
 
@@ -37,7 +36,7 @@ async def _wait_for_final_transaction_outcome(
     # query transaction by hash
     transaction_response = await get_transaction_from_hash(transaction_hash, client)
 
-    result = cast(Dict[str, Any], transaction_response.result)
+    result = transaction_response.result
     if "validated" in result and result["validated"]:
         # result is in a validated ledger, outcome is final
         return transaction_response
@@ -79,7 +78,7 @@ async def send_reliable_submission(
     """
     transaction_hash = transaction.get_hash()
     submit_response = await submit_transaction(transaction, client)
-    result = cast(Dict[str, Any], submit_response.result)
+    result = submit_response.result
     if result["engine_result"] != "tesSUCCESS":
         result_code = result["engine_result"]
         result_message = result["engine_result_message"]

--- a/xrpl/models/response.py
+++ b/xrpl/models/response.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import warnings
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from xrpl.models.base_model import BaseModel
 from xrpl.models.required import REQUIRED
@@ -48,7 +48,7 @@ class Response(BaseModel):
     :meta hide-value:
     """
 
-    result: Union[List[Any], Dict[Any]] = REQUIRED  # type: ignore
+    result: Dict[str, Any] = REQUIRED  # type: ignore
     """
     This field is required.
 


### PR DESCRIPTION
## High Level Overview of Change

In `Response`, the result type was initially either a `List` or a `Dict`. But it turns out that there aren't actually any `rippled` responses where the result type is a `List`. So this PR removes that as an option in the type, which eliminates a lot of casting.

### Context of Change

This was discovered while working on the Sidechain Launch Kit.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes.
