### PR TITLE
feat: add optional `ledger_index` param to account methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [[Unreleased]]
+### Added
+- `ledger_index` optional param for all the main account methods
+
+### Fixed
+- Makes the default ledger version for `get_next_valid_seq_number` `current` instead of `validated`
 
 ## [1.2.0] - 2021-11-09
 ### Added

--- a/xrpl/account/main.py
+++ b/xrpl/account/main.py
@@ -8,13 +8,19 @@ from xrpl.clients.sync_client import SyncClient
 from xrpl.models.response import Response
 
 
-def does_account_exist(address: str, client: SyncClient) -> bool:
+def does_account_exist(
+    address: str, client: SyncClient, ledger_index: Union[str, int] = "validated"
+) -> bool:
     """
     Query the ledger for whether the account exists.
 
     Args:
         address: the account to query.
         client: the network client used to make network calls.
+        ledger_index: The ledger index to use for the request. Must be an integer
+            ledger value or "current" (the current working version), "closed" (for the
+            closed-and-proposed version), or "validated" (the most recent version
+            validated by consensus). Defaults to "validated".
 
     Returns:
         Whether the account exists on the ledger.
@@ -22,58 +28,82 @@ def does_account_exist(address: str, client: SyncClient) -> bool:
     Raises:
         XRPLRequestFailureException: if the transaction fails.
     """
-    return asyncio.run(main.does_account_exist(address, client))
+    return asyncio.run(main.does_account_exist(address, client, ledger_index))
 
 
-def get_next_valid_seq_number(address: str, client: SyncClient) -> int:
+def get_next_valid_seq_number(
+    address: str, client: SyncClient, ledger_index: Union[str, int] = "current"
+) -> int:
     """
     Query the ledger for the next available sequence number for an account.
 
     Args:
         address: the account to query.
         client: the network client used to make network calls.
+        ledger_index: The ledger index to use for the request. Must be an integer
+            ledger value or "current" (the current working version), "closed" (for the
+            closed-and-proposed version), or "validated" (the most recent version
+            validated by consensus). Defaults to "current".
 
     Returns:
         The next valid sequence number for the address.
     """
-    return asyncio.run(main.get_next_valid_seq_number(address, client))
+    return asyncio.run(main.get_next_valid_seq_number(address, client, ledger_index))
 
 
-def get_balance(address: str, client: SyncClient) -> int:
+def get_balance(
+    address: str, client: SyncClient, ledger_index: Union[str, int] = "validated"
+) -> int:
     """
     Query the ledger for the balance of the given account.
 
     Args:
         address: the account to query.
         client: the network client used to make network calls.
+        ledger_index: The ledger index to use for the request. Must be an integer
+            ledger value or "current" (the current working version), "closed" (for the
+            closed-and-proposed version), or "validated" (the most recent version
+            validated by consensus). Defaults to "validated".
 
     Returns:
         The balance of the address.
     """
-    return asyncio.run(main.get_balance(address, client))
+    return asyncio.run(main.get_balance(address, client, ledger_index))
 
 
-def get_account_root(address: str, client: SyncClient) -> Dict[str, Union[int, str]]:
+def get_account_root(
+    address: str, client: SyncClient, ledger_index: Union[str, int] = "validated"
+) -> Dict[str, Union[int, str]]:
     """
     Query the ledger for the AccountRoot object associated with a given address.
 
     Args:
         address: the account to query.
         client: the network client used to make network calls.
+        ledger_index: The ledger index to use for the request. Must be an integer
+            ledger value or "current" (the current working version), "closed" (for the
+            closed-and-proposed version), or "validated" (the most recent version
+            validated by consensus). Defaults to "validated".
 
     Returns:
         The AccountRoot dictionary for the address.
     """
-    return asyncio.run(main.get_account_root(address, client))
+    return asyncio.run(main.get_account_root(address, client, ledger_index))
 
 
-def get_account_info(address: str, client: SyncClient) -> Response:
+def get_account_info(
+    address: str, client: SyncClient, ledger_index: Union[str, int] = "validated"
+) -> Response:
     """
     Query the ledger for account info of given address.
 
     Args:
         address: the account to query.
         client: the network client used to make network calls.
+        ledger_index: The ledger index to use for the request. Must be an integer
+            ledger value or "current" (the current working version), "closed" (for the
+            closed-and-proposed version), or "validated" (the most recent version
+            validated by consensus). Defaults to "validated".
 
     Returns:
         The account info for the address.
@@ -81,4 +111,4 @@ def get_account_info(address: str, client: SyncClient) -> Response:
     Raises:
         XRPLRequestFailureException: if the rippled API call fails.
     """
-    return asyncio.run(main.get_account_info(address, client))
+    return asyncio.run(main.get_account_info(address, client, ledger_index))

--- a/xrpl/account/main.py
+++ b/xrpl/account/main.py
@@ -20,7 +20,7 @@ def does_account_exist(
         ledger_index: The ledger index to use for the request. Must be an integer
             ledger value or "current" (the current working version), "closed" (for the
             closed-and-proposed version), or "validated" (the most recent version
-            validated by consensus). Defaults to "validated".
+            validated by consensus). The default is "validated".
 
     Returns:
         Whether the account exists on the ledger.
@@ -43,7 +43,7 @@ def get_next_valid_seq_number(
         ledger_index: The ledger index to use for the request. Must be an integer
             ledger value or "current" (the current working version), "closed" (for the
             closed-and-proposed version), or "validated" (the most recent version
-            validated by consensus). Defaults to "current".
+            validated by consensus). The default is "current".
 
     Returns:
         The next valid sequence number for the address.
@@ -63,7 +63,7 @@ def get_balance(
         ledger_index: The ledger index to use for the request. Must be an integer
             ledger value or "current" (the current working version), "closed" (for the
             closed-and-proposed version), or "validated" (the most recent version
-            validated by consensus). Defaults to "validated".
+            validated by consensus). The default is "validated".
 
     Returns:
         The balance of the address.
@@ -83,7 +83,7 @@ def get_account_root(
         ledger_index: The ledger index to use for the request. Must be an integer
             ledger value or "current" (the current working version), "closed" (for the
             closed-and-proposed version), or "validated" (the most recent version
-            validated by consensus). Defaults to "validated".
+            validated by consensus). The default is "validated".
 
     Returns:
         The AccountRoot dictionary for the address.
@@ -103,7 +103,7 @@ def get_account_info(
         ledger_index: The ledger index to use for the request. Must be an integer
             ledger value or "current" (the current working version), "closed" (for the
             closed-and-proposed version), or "validated" (the most recent version
-            validated by consensus). Defaults to "validated".
+            validated by consensus). The default is "validated".
 
     Returns:
         The account info for the address.

--- a/xrpl/asyncio/account/main.py
+++ b/xrpl/asyncio/account/main.py
@@ -21,7 +21,7 @@ async def does_account_exist(
         ledger_index: The ledger index to use for the request. Must be an integer
             ledger value or "current" (the current working version), "closed" (for the
             closed-and-proposed version), or "validated" (the most recent version
-            validated by consensus). Defaults to "validated".
+            validated by consensus). The default is "validated".
 
     Returns:
         Whether the account exists on the ledger.
@@ -51,7 +51,7 @@ async def get_next_valid_seq_number(
         ledger_index: The ledger index to use for the request. Must be an integer
             ledger value or "current" (the current working version), "closed" (for the
             closed-and-proposed version), or "validated" (the most recent version
-            validated by consensus). Defaults to "current".
+            validated by consensus). The default is "current".
 
     Returns:
         The next valid sequence number for the address.
@@ -73,7 +73,7 @@ async def get_balance(
         ledger_index: The ledger index to use for the request. Must be an integer
             ledger value or "current" (the current working version), "closed" (for the
             closed-and-proposed version), or "validated" (the most recent version
-            validated by consensus). Defaults to "validated".
+            validated by consensus). The default is "validated".
 
     Returns:
         The balance of the address.
@@ -93,7 +93,7 @@ async def get_account_root(
         ledger_index: The ledger index to use for the request. Must be an integer
             ledger value or "current" (the current working version), "closed" (for the
             closed-and-proposed version), or "validated" (the most recent version
-            validated by consensus). Defaults to "validated".
+            validated by consensus). The default is "validated".
 
     Returns:
         The AccountRoot dictionary for the address.
@@ -114,7 +114,7 @@ async def get_account_info(
         ledger_index: The ledger index to use for the request. Must be an integer
             ledger value or "current" (the current working version), "closed" (for the
             closed-and-proposed version), or "validated" (the most recent version
-            validated by consensus). Defaults to "validated".
+            validated by consensus). The default is "validated".
 
     Returns:
         The account info for the address.

--- a/xrpl/asyncio/account/main.py
+++ b/xrpl/asyncio/account/main.py
@@ -32,18 +32,23 @@ async def does_account_exist(address: str, client: Client) -> bool:
         raise
 
 
-async def get_next_valid_seq_number(address: str, client: Client) -> int:
+async def get_next_valid_seq_number(
+    address: str, client: Client, ledger_index: Union[str, int] = "current"
+) -> int:
     """
     Query the ledger for the next available sequence number for an account.
 
     Args:
         address: the account to query.
         client: the network client used to make network calls.
+        ledger_index: the version of the ledger to query. Defaults to "current".
 
     Returns:
         The next valid sequence number for the address.
     """
-    return cast(int, (await get_account_root(address, client))["Sequence"])
+    return cast(
+        int, (await get_account_root(address, client, ledger_index))["Sequence"]
+    )
 
 
 async def get_balance(address: str, client: Client) -> int:
@@ -60,28 +65,34 @@ async def get_balance(address: str, client: Client) -> int:
     return int((await get_account_root(address, client))["Balance"])
 
 
-async def get_account_root(address: str, client: Client) -> Dict[str, Union[int, str]]:
+async def get_account_root(
+    address: str, client: Client, ledger_index: Union[str, int] = "validated"
+) -> Dict[str, Union[int, str]]:
     """
     Query the ledger for the AccountRoot object associated with a given address.
 
     Args:
         address: the account to query.
         client: the network client used to make network calls.
+        ledger_index: the version of the ledger to query. Defaults to "validated".
 
     Returns:
         The AccountRoot dictionary for the address.
     """
-    account_info = await get_account_info(address, client)
+    account_info = await get_account_info(address, client, ledger_index)
     return cast(Dict[str, Union[int, str]], account_info.result["account_data"])
 
 
-async def get_account_info(address: str, client: Client) -> Response:
+async def get_account_info(
+    address: str, client: Client, ledger_index: Union[str, int] = "validated"
+) -> Response:
     """
     Query the ledger for account info of given address.
 
     Args:
         address: the account to query.
         client: the network client used to make network calls.
+        ledger_index: the version of the ledger to query. Defaults to "validated".
 
     Returns:
         The account info for the address.
@@ -94,7 +105,7 @@ async def get_account_info(address: str, client: Client) -> Response:
     response = await client.request_impl(
         AccountInfo(
             account=address,
-            ledger_index="validated",
+            ledger_index=ledger_index,
         )
     )
     if response.is_successful():

--- a/xrpl/asyncio/account/main.py
+++ b/xrpl/asyncio/account/main.py
@@ -8,13 +8,19 @@ from xrpl.models.requests import AccountInfo
 from xrpl.models.response import Response
 
 
-async def does_account_exist(address: str, client: Client) -> bool:
+async def does_account_exist(
+    address: str, client: Client, ledger_index: Union[str, int] = "validated"
+) -> bool:
     """
     Query the ledger for whether the account exists.
 
     Args:
         address: the account to query.
         client: the network client used to make network calls.
+        ledger_index: The ledger index to use for the request. Must be an integer
+            ledger value or "current" (the current working version), "closed" (for the
+            closed-and-proposed version), or "validated" (the most recent version
+            validated by consensus). Defaults to "validated".
 
     Returns:
         Whether the account exists on the ledger.
@@ -41,7 +47,10 @@ async def get_next_valid_seq_number(
     Args:
         address: the account to query.
         client: the network client used to make network calls.
-        ledger_index: the version of the ledger to query. Defaults to "current".
+        ledger_index: The ledger index to use for the request. Must be an integer
+            ledger value or "current" (the current working version), "closed" (for the
+            closed-and-proposed version), or "validated" (the most recent version
+            validated by consensus). Defaults to "current".
 
     Returns:
         The next valid sequence number for the address.
@@ -51,13 +60,19 @@ async def get_next_valid_seq_number(
     )
 
 
-async def get_balance(address: str, client: Client) -> int:
+async def get_balance(
+    address: str, client: Client, ledger_index: Union[str, int] = "validated"
+) -> int:
     """
     Query the ledger for the balance of the given account.
 
     Args:
         address: the account to query.
         client: the network client used to make network calls.
+        ledger_index: The ledger index to use for the request. Must be an integer
+            ledger value or "current" (the current working version), "closed" (for the
+            closed-and-proposed version), or "validated" (the most recent version
+            validated by consensus). Defaults to "validated".
 
     Returns:
         The balance of the address.
@@ -74,7 +89,10 @@ async def get_account_root(
     Args:
         address: the account to query.
         client: the network client used to make network calls.
-        ledger_index: the version of the ledger to query. Defaults to "validated".
+        ledger_index: The ledger index to use for the request. Must be an integer
+            ledger value or "current" (the current working version), "closed" (for the
+            closed-and-proposed version), or "validated" (the most recent version
+            validated by consensus). Defaults to "validated".
 
     Returns:
         The AccountRoot dictionary for the address.
@@ -92,7 +110,10 @@ async def get_account_info(
     Args:
         address: the account to query.
         client: the network client used to make network calls.
-        ledger_index: the version of the ledger to query. Defaults to "validated".
+        ledger_index: The ledger index to use for the request. Must be an integer
+            ledger value or "current" (the current working version), "closed" (for the
+            closed-and-proposed version), or "validated" (the most recent version
+            validated by consensus). Defaults to "validated".
 
     Returns:
         The account info for the address.

--- a/xrpl/asyncio/account/main.py
+++ b/xrpl/asyncio/account/main.py
@@ -3,6 +3,7 @@
 from typing import Dict, Union, cast
 
 from xrpl.asyncio.clients import Client, XRPLRequestFailureException
+from xrpl.constants import XRPLException
 from xrpl.core.addresscodec import is_valid_xaddress, xaddress_to_classic_address
 from xrpl.models.requests import AccountInfo
 from xrpl.models.response import Response
@@ -119,10 +120,20 @@ async def get_account_info(
         The account info for the address.
 
     Raises:
+        XRPLException: If the ledger_index value is invalid.
         XRPLRequestFailureException: if the rippled API call fails.
     """
     if is_valid_xaddress(address):
         address, _, _ = xaddress_to_classic_address(address)
+    if isinstance(ledger_index, str) and ledger_index not in {
+        "validated",
+        "current",
+        "closed",
+    }:
+        raise XRPLException(
+            "`ledger_index` is not valid - must be an `int` or one of {'validated', "
+            "'current', 'closed'}."
+        )
     response = await client.request_impl(
         AccountInfo(
             account=address,


### PR DESCRIPTION
## High Level Overview of Change

This PR adds an optional parameter to the main account methods for the ledger index to query. It also sets the default ledger index for querying the sequence number to `"current"` instead of `"validated"`.

### Context of Change

https://github.com/XRPLF/xrpl.js/pull/1719

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes. Tests pass.
