### PR TITLE
fix: remove erroring in `send_reliable_submission` if not success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Makes the default ledger version for `get_next_valid_seq_number` `current` instead of `validated`
+- Stops erroring on non-`tesSUCCESS` responses in reliable transaction submission
 
 ## [1.2.0] - 2021-11-09
 ### Added

--- a/xrpl/asyncio/transaction/reliable_submission.py
+++ b/xrpl/asyncio/transaction/reliable_submission.py
@@ -77,13 +77,6 @@ async def send_reliable_submission(
             `last_ledger_sequence` param.
     """
     transaction_hash = transaction.get_hash()
-    submit_response = await submit_transaction(transaction, client)
-    result = submit_response.result
-    if result["engine_result"] != "tesSUCCESS":
-        result_code = result["engine_result"]
-        result_message = result["engine_result_message"]
-        raise XRPLReliableSubmissionException(
-            f"Transaction failed, {result_code}: {result_message}"
-        )
+    await submit_transaction(transaction, client)
 
     return await _wait_for_final_transaction_outcome(transaction_hash, client)

--- a/xrpl/asyncio/transaction/reliable_submission.py
+++ b/xrpl/asyncio/transaction/reliable_submission.py
@@ -76,6 +76,10 @@ async def send_reliable_submission(
         XRPLReliableSubmissionException: if the transaction fails or is missing a
             `last_ledger_sequence` param.
     """
+    if transaction.last_ledger_sequence is None:
+        raise XRPLReliableSubmissionException(
+            "Transaction must have a `last_ledger_sequence` param."
+        )
     transaction_hash = transaction.get_hash()
     await submit_transaction(transaction, client)
 


### PR DESCRIPTION
## High Level Overview of Change

This PR removes erroring in `send_reliable_submission` if the response code is something other than `tesSUCCESS`. It also adds an error if there is no `last_ledger_sequence` in the transaction.

### Context of Change

Fixes #291. Also https://github.com/XRPLF/xrpl.js/pull/1704#pullrequestreview-773442168

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

Added a test for if the `last_ledger_sequence` is missing in a transaction.
