### PR TITLE
feat: add client method `request_json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [[Unreleased]]
 ### Added
 - `ledger_index` optional param for all the main account methods
+- `request_json` client method that allows sending dictionaries directly to rippled
 
 ### Fixed
 - Makes the default ledger version for `get_next_valid_seq_number` `current` instead of `validated`

--- a/tests/integration/it_utils.py
+++ b/tests/integration/it_utils.py
@@ -106,6 +106,7 @@ def test_async_and_sync(
         sync_code += first_line.replace("    async def ", "").replace(":", "")
 
         sync_modules_to_import = {}
+        # replace all calls to async methods with sync methods
         if modules is not None:
             for module_str in modules:
                 function = module_str.split(".")[-1]
@@ -113,6 +114,7 @@ def test_async_and_sync(
                 module = getattr(importlib.import_module(location), function)
                 sync_modules_to_import[function] = module
 
+        # import stack
         all_modules = {**original_globals, **globals(), **sync_modules_to_import}
         # NOTE: passing `globals()` into `exec` is really bad practice and not safe at
         # all, but in this case it's fine because it's only running test code

--- a/tests/integration/reqs/test_account_info.py
+++ b/tests/integration/reqs/test_account_info.py
@@ -1,15 +1,36 @@
 from tests.integration.integration_test_case import IntegrationTestCase
 from tests.integration.it_utils import test_async_and_sync
 from tests.integration.reusable_values import WALLET
+from xrpl.asyncio.clients.utils import (
+    json_to_response,
+    request_to_json_rpc,
+    request_to_websocket,
+    websocket_to_response,
+)
 from xrpl.models.requests import AccountInfo
+
+_REQUEST = AccountInfo(
+    account=WALLET.classic_address,
+)
 
 
 class TestAccountInfo(IntegrationTestCase):
     @test_async_and_sync(globals())
     async def test_basic_functionality(self, client):
-        response = await client.request(
-            AccountInfo(
-                account=WALLET.classic_address,
-            )
-        )
+        response = await client.request(_REQUEST)
         self.assertTrue(response.is_successful())
+
+    @test_async_and_sync(globals())
+    async def test_request_json(self, client):
+        # TODO: run request_json tests via metaprogramming, instead of copy-paste
+        is_websocket = "ws" in client.url
+        if is_websocket:
+            request = request_to_websocket(_REQUEST)
+        else:
+            request = request_to_json_rpc(_REQUEST)
+        response = await client.request_json(request)
+        if is_websocket:
+            resp = websocket_to_response(response)
+        else:
+            resp = json_to_response(response)
+        self.assertTrue(resp.is_successful())

--- a/tests/integration/reqs/test_account_objects.py
+++ b/tests/integration/reqs/test_account_objects.py
@@ -1,15 +1,36 @@
 from tests.integration.integration_test_case import IntegrationTestCase
 from tests.integration.it_utils import test_async_and_sync
 from tests.integration.reusable_values import WALLET
+from xrpl.asyncio.clients.utils import (
+    json_to_response,
+    request_to_json_rpc,
+    request_to_websocket,
+    websocket_to_response,
+)
 from xrpl.models.requests import AccountObjects
+
+_REQUEST = AccountObjects(
+    account=WALLET.classic_address,
+)
 
 
 class TestAccountObjects(IntegrationTestCase):
     @test_async_and_sync(globals())
     async def test_basic_functionality(self, client):
-        response = await client.request(
-            AccountObjects(
-                account=WALLET.classic_address,
-            )
-        )
+        response = await client.request(_REQUEST)
         self.assertTrue(response.is_successful())
+
+    @test_async_and_sync(globals())
+    async def test_request_json(self, client):
+        # TODO: run request_json tests via metaprogramming, instead of copy-paste
+        is_websocket = "ws" in client.url
+        if is_websocket:
+            request = request_to_websocket(_REQUEST)
+        else:
+            request = request_to_json_rpc(_REQUEST)
+        response = await client.request_json(request)
+        if is_websocket:
+            resp = websocket_to_response(response)
+        else:
+            resp = json_to_response(response)
+        self.assertTrue(resp.is_successful())

--- a/tests/integration/reqs/test_account_tx.py
+++ b/tests/integration/reqs/test_account_tx.py
@@ -1,15 +1,36 @@
 from tests.integration.integration_test_case import IntegrationTestCase
 from tests.integration.it_utils import test_async_and_sync
 from tests.integration.reusable_values import WALLET
+from xrpl.asyncio.clients.utils import (
+    json_to_response,
+    request_to_json_rpc,
+    request_to_websocket,
+    websocket_to_response,
+)
 from xrpl.models.requests import AccountTx
+
+_REQUEST = AccountTx(
+    account=WALLET.classic_address,
+)
 
 
 class TestAccountTx(IntegrationTestCase):
     @test_async_and_sync(globals())
     async def test_basic_functionality(self, client):
-        response = await client.request(
-            AccountTx(
-                account=WALLET.classic_address,
-            )
-        )
+        response = await client.request(_REQUEST)
         self.assertTrue(response.is_successful())
+
+    @test_async_and_sync(globals())
+    async def test_request_json(self, client):
+        # TODO: run request_json tests via metaprogramming, instead of copy-paste
+        is_websocket = "ws" in client.url
+        if is_websocket:
+            request = request_to_websocket(_REQUEST)
+        else:
+            request = request_to_json_rpc(_REQUEST)
+        response = await client.request_json(request)
+        if is_websocket:
+            resp = websocket_to_response(response)
+        else:
+            resp = json_to_response(response)
+        self.assertTrue(resp.is_successful())

--- a/tests/integration/reqs/test_book_offers.py
+++ b/tests/integration/reqs/test_book_offers.py
@@ -1,22 +1,43 @@
 from tests.integration.integration_test_case import IntegrationTestCase
 from tests.integration.it_utils import test_async_and_sync
 from tests.integration.reusable_values import WALLET
+from xrpl.asyncio.clients.utils import (
+    json_to_response,
+    request_to_json_rpc,
+    request_to_websocket,
+    websocket_to_response,
+)
 from xrpl.models.currencies import XRP, IssuedCurrency
 from xrpl.models.requests import BookOffers
+
+_REQUEST = BookOffers(
+    taker=WALLET.classic_address,
+    taker_gets=XRP(),
+    taker_pays=IssuedCurrency(
+        currency="USD",
+        issuer="rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+    ),
+    ledger_index="validated",
+)
 
 
 class TestBookOffers(IntegrationTestCase):
     @test_async_and_sync(globals())
     async def test_basic_functionality(self, client):
-        response = await client.request(
-            BookOffers(
-                taker=WALLET.classic_address,
-                taker_gets=XRP(),
-                taker_pays=IssuedCurrency(
-                    currency="USD",
-                    issuer="rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
-                ),
-                ledger_index="validated",
-            ),
-        )
+        response = await client.request(_REQUEST)
         self.assertTrue(response.is_successful())
+
+    @test_async_and_sync(globals())
+    async def test_request_json(self, client):
+        # TODO: run request_json tests via metaprogramming, instead of copy-paste
+        is_websocket = "ws" in client.url
+        if is_websocket:
+            request = request_to_websocket(_REQUEST)
+        else:
+            request = request_to_json_rpc(_REQUEST)
+        response = await client.request_json(request)
+        if is_websocket:
+            resp = websocket_to_response(response)
+        else:
+            resp = json_to_response(response)
+        self.assertTrue(resp.is_successful())

--- a/tests/integration/reqs/test_channel_verify.py
+++ b/tests/integration/reqs/test_channel_verify.py
@@ -1,18 +1,39 @@
 from tests.integration.integration_test_case import IntegrationTestCase
 from tests.integration.it_utils import test_async_and_sync
 from tests.integration.reusable_values import PAYMENT_CHANNEL, WALLET
+from xrpl.asyncio.clients.utils import (
+    json_to_response,
+    request_to_json_rpc,
+    request_to_websocket,
+    websocket_to_response,
+)
 from xrpl.models.requests import ChannelVerify
+
+_REQUEST = ChannelVerify(
+    channel_id=PAYMENT_CHANNEL.result["hash"],
+    amount="1",
+    public_key=WALLET.public_key,
+    signature="304402204EF0AFB78AC23ED1C472E74F4299C0C21",
+)
 
 
 class TestChannelVerify(IntegrationTestCase):
     @test_async_and_sync(globals())
     async def test_basic_functionality(self, client):
-        response = await client.request(
-            ChannelVerify(
-                channel_id=PAYMENT_CHANNEL.result["hash"],
-                amount="1",
-                public_key=WALLET.public_key,
-                signature="304402204EF0AFB78AC23ED1C472E74F4299C0C21",
-            ),
-        )
+        response = await client.request(_REQUEST)
         self.assertTrue(response.is_successful())
+
+    @test_async_and_sync(globals())
+    async def test_request_json(self, client):
+        # TODO: run request_json tests via metaprogramming, instead of copy-paste
+        is_websocket = "ws" in client.url
+        if is_websocket:
+            request = request_to_websocket(_REQUEST)
+        else:
+            request = request_to_json_rpc(_REQUEST)
+        response = await client.request_json(request)
+        if is_websocket:
+            resp = websocket_to_response(response)
+        else:
+            resp = json_to_response(response)
+        self.assertTrue(resp.is_successful())

--- a/tests/integration/reqs/test_ledger.py
+++ b/tests/integration/reqs/test_ledger.py
@@ -1,10 +1,33 @@
 from tests.integration.integration_test_case import IntegrationTestCase
 from tests.integration.it_utils import test_async_and_sync
+from xrpl.asyncio.clients.utils import (
+    json_to_response,
+    request_to_json_rpc,
+    request_to_websocket,
+    websocket_to_response,
+)
 from xrpl.models.requests import Ledger
+
+_REQUEST = Ledger()
 
 
 class TestLedger(IntegrationTestCase):
     @test_async_and_sync(globals())
     async def test_basic_functionality(self, client):
-        response = await client.request(Ledger())
+        response = await client.request(_REQUEST)
         self.assertTrue(response.is_successful())
+
+    @test_async_and_sync(globals())
+    async def test_request_json(self, client):
+        # TODO: run request_json tests via metaprogramming, instead of copy-paste
+        is_websocket = "ws" in client.url
+        if is_websocket:
+            request = request_to_websocket(_REQUEST)
+        else:
+            request = request_to_json_rpc(_REQUEST)
+        response = await client.request_json(request)
+        if is_websocket:
+            resp = websocket_to_response(response)
+        else:
+            resp = json_to_response(response)
+        self.assertTrue(resp.is_successful())

--- a/tests/integration/reqs/test_no_ripple_check.py
+++ b/tests/integration/reqs/test_no_ripple_check.py
@@ -1,16 +1,37 @@
 from tests.integration.integration_test_case import IntegrationTestCase
 from tests.integration.it_utils import test_async_and_sync
 from tests.integration.reusable_values import WALLET
+from xrpl.asyncio.clients.utils import (
+    json_to_response,
+    request_to_json_rpc,
+    request_to_websocket,
+    websocket_to_response,
+)
 from xrpl.models.requests import NoRippleCheck, NoRippleCheckRole
+
+_REQUEST = NoRippleCheck(
+    account=WALLET.classic_address,
+    role=NoRippleCheckRole.USER,
+)
 
 
 class TestNoRippleCheck(IntegrationTestCase):
     @test_async_and_sync(globals())
     async def test_basic_functionality(self, client):
-        response = await client.request(
-            NoRippleCheck(
-                account=WALLET.classic_address,
-                role=NoRippleCheckRole.USER,
-            )
-        )
+        response = await client.request(_REQUEST)
         self.assertTrue(response.is_successful())
+
+    @test_async_and_sync(globals())
+    async def test_request_json(self, client):
+        # TODO: run request_json tests via metaprogramming, instead of copy-paste
+        is_websocket = "ws" in client.url
+        if is_websocket:
+            request = request_to_websocket(_REQUEST)
+        else:
+            request = request_to_json_rpc(_REQUEST)
+        response = await client.request_json(request)
+        if is_websocket:
+            resp = websocket_to_response(response)
+        else:
+            resp = json_to_response(response)
+        self.assertTrue(resp.is_successful())

--- a/tests/integration/reqs/test_ripple_path_find.py
+++ b/tests/integration/reqs/test_ripple_path_find.py
@@ -1,17 +1,40 @@
 from tests.integration.integration_test_case import IntegrationTestCase
 from tests.integration.it_utils import test_async_and_sync
 from tests.integration.reusable_values import DESTINATION, WALLET
+from xrpl.asyncio.clients.utils import (
+    json_to_response,
+    request_to_json_rpc,
+    request_to_websocket,
+    websocket_to_response,
+)
 from xrpl.models.requests import RipplePathFind
+
+_REQUEST = RipplePathFind(
+    source_account=WALLET.classic_address,
+    destination_account=DESTINATION.classic_address,
+    destination_amount="100",
+)
 
 
 class TestRipplePathFind(IntegrationTestCase):
     @test_async_and_sync(globals())
     async def test_basic_functionality(self, client):
         response = await client.request(
-            RipplePathFind(
-                source_account=WALLET.classic_address,
-                destination_account=DESTINATION.classic_address,
-                destination_amount="100",
-            ),
+            _REQUEST,
         )
         self.assertTrue(response.is_successful())
+
+    @test_async_and_sync(globals())
+    async def test_request_json(self, client):
+        # TODO: run request_json tests via metaprogramming, instead of copy-paste
+        is_websocket = "ws" in client.url
+        if is_websocket:
+            request = request_to_websocket(_REQUEST)
+        else:
+            request = request_to_json_rpc(_REQUEST)
+        response = await client.request_json(request)
+        if is_websocket:
+            resp = websocket_to_response(response)
+        else:
+            resp = json_to_response(response)
+        self.assertTrue(resp.is_successful())

--- a/tests/integration/reqs/test_server_info.py
+++ b/tests/integration/reqs/test_server_info.py
@@ -1,10 +1,33 @@
 from tests.integration.integration_test_case import IntegrationTestCase
 from tests.integration.it_utils import test_async_and_sync
+from xrpl.asyncio.clients.utils import (
+    json_to_response,
+    request_to_json_rpc,
+    request_to_websocket,
+    websocket_to_response,
+)
 from xrpl.models.requests import ServerInfo
+
+_REQUEST = ServerInfo()
 
 
 class TestServerInfo(IntegrationTestCase):
     @test_async_and_sync(globals())
     async def test_basic_functionality(self, client):
-        response = await client.request(ServerInfo())
+        response = await client.request(_REQUEST)
         self.assertTrue(response.is_successful())
+
+    @test_async_and_sync(globals())
+    async def test_request_json(self, client):
+        # TODO: run request_json tests via metaprogramming, instead of copy-paste
+        is_websocket = "ws" in client.url
+        if is_websocket:
+            request = request_to_websocket(_REQUEST)
+        else:
+            request = request_to_json_rpc(_REQUEST)
+        response = await client.request_json(request)
+        if is_websocket:
+            resp = websocket_to_response(response)
+        else:
+            resp = json_to_response(response)
+        self.assertTrue(resp.is_successful())

--- a/tests/integration/reqs/test_submit_multisigned.py
+++ b/tests/integration/reqs/test_submit_multisigned.py
@@ -5,6 +5,12 @@ from tests.integration.it_utils import (
     test_async_and_sync,
 )
 from tests.integration.reusable_values import WALLET
+from xrpl.asyncio.clients.utils import (
+    json_to_response,
+    request_to_json_rpc,
+    request_to_websocket,
+    websocket_to_response,
+)
 from xrpl.core.binarycodec import encode_for_multisigning
 from xrpl.core.keypairs import sign
 from xrpl.ledger import get_fee
@@ -118,3 +124,76 @@ class TestSubmitMultisigned(IntegrationTestCase):
             )
         )
         self.assertTrue(response.is_successful())
+
+    @test_async_and_sync(globals())
+    async def test_request_json(self, client):
+        # TODO: run request_json tests via metaprogramming, instead of copy-paste
+        issuer = Wallet.create()
+        tx = TrustSet(
+            account=WALLET.classic_address,
+            sequence=WALLET.sequence,
+            fee=FEE,
+            flags=TrustSetFlag.TF_SET_NO_RIPPLE,
+            limit_amount=IssuedCurrencyAmount(
+                issuer=issuer.classic_address,
+                currency="USD",
+                value="10",
+            ),
+        )
+        tx_json = tx.to_xrpl()
+        first_sig = sign(
+            bytes.fromhex(
+                encode_for_multisigning(
+                    tx_json,
+                    FIRST_SIGNER.classic_address,
+                )
+            ),
+            FIRST_SIGNER.private_key,
+        )
+        second_sig = sign(
+            bytes.fromhex(
+                encode_for_multisigning(
+                    tx_json,
+                    SECOND_SIGNER.classic_address,
+                )
+            ),
+            SECOND_SIGNER.private_key,
+        )
+        multisigned_tx = TrustSet(
+            account=WALLET.classic_address,
+            sequence=WALLET.sequence,
+            fee=FEE,
+            flags=TrustSetFlag.TF_SET_NO_RIPPLE,
+            limit_amount=IssuedCurrencyAmount(
+                issuer=issuer.classic_address,
+                currency="USD",
+                value="10",
+            ),
+            signers=[
+                Signer(
+                    account=FIRST_SIGNER.classic_address,
+                    txn_signature=first_sig,
+                    signing_pub_key=FIRST_SIGNER.public_key,
+                ),
+                Signer(
+                    account=SECOND_SIGNER.classic_address,
+                    txn_signature=second_sig,
+                    signing_pub_key=SECOND_SIGNER.public_key,
+                ),
+            ],
+        )
+
+        is_websocket = "ws" in client.url
+        req = SubmitMultisigned(
+            tx_json=multisigned_tx,
+        )
+        if is_websocket:
+            request = request_to_websocket(req)
+        else:
+            request = request_to_json_rpc(req)
+        response = await client.request_json(request)
+        if is_websocket:
+            resp = websocket_to_response(response)
+        else:
+            resp = json_to_response(response)
+        self.assertTrue(resp.is_successful())

--- a/tests/integration/reqs/test_submit_only.py
+++ b/tests/integration/reqs/test_submit_only.py
@@ -1,6 +1,12 @@
 from tests.integration.integration_test_case import IntegrationTestCase
 from tests.integration.it_utils import test_async_and_sync
 from tests.integration.reusable_values import WALLET
+from xrpl.asyncio.clients.utils import (
+    json_to_response,
+    request_to_json_rpc,
+    request_to_websocket,
+    websocket_to_response,
+)
 from xrpl.asyncio.transaction import (
     safe_sign_and_autofill_transaction as safe_sign_and_autofill_transaction_async,
 )
@@ -34,3 +40,24 @@ class TestSubmitOnly(IntegrationTestCase):
             )
         )
         self.assertTrue(response.is_successful())
+
+    @test_async_and_sync(globals())
+    async def test_request_json(self, client):
+        # TODO: run request_json tests via metaprogramming, instead of copy-paste
+        transaction = await safe_sign_and_autofill_transaction_async(TX, WALLET, client)
+        tx_json = transaction.to_xrpl()
+        tx_blob = encode(tx_json)
+        is_websocket = "ws" in client.url
+        req = SubmitOnly(
+            tx_blob=tx_blob,
+        )
+        if is_websocket:
+            request = request_to_websocket(req)
+        else:
+            request = request_to_json_rpc(req)
+        response = await client.request_json(request)
+        if is_websocket:
+            resp = websocket_to_response(response)
+        else:
+            resp = json_to_response(response)
+        self.assertTrue(resp.is_successful())

--- a/tests/integration/reqs/test_tx.py
+++ b/tests/integration/reqs/test_tx.py
@@ -1,15 +1,36 @@
 from tests.integration.integration_test_case import IntegrationTestCase
 from tests.integration.it_utils import test_async_and_sync
 from tests.integration.reusable_values import OFFER
+from xrpl.asyncio.clients.utils import (
+    json_to_response,
+    request_to_json_rpc,
+    request_to_websocket,
+    websocket_to_response,
+)
 from xrpl.models.requests import Tx
+
+_REQUEST = Tx(
+    transaction=OFFER.result["hash"],
+)
 
 
 class TestTx(IntegrationTestCase):
     @test_async_and_sync(globals())
     async def test_basic_functionality(self, client):
-        response = await client.request(
-            Tx(
-                transaction=OFFER.result["hash"],
-            ),
-        )
+        response = await client.request(_REQUEST)
         self.assertTrue(response.is_successful())
+
+    @test_async_and_sync(globals())
+    async def test_request_json(self, client):
+        # TODO: run request_json tests via metaprogramming, instead of copy-paste
+        is_websocket = "ws" in client.url
+        if is_websocket:
+            request = request_to_websocket(_REQUEST)
+        else:
+            request = request_to_json_rpc(_REQUEST)
+        response = await client.request_json(request)
+        if is_websocket:
+            resp = websocket_to_response(response)
+        else:
+            resp = json_to_response(response)
+        self.assertTrue(resp.is_successful())

--- a/xrpl/asyncio/clients/async_client.py
+++ b/xrpl/asyncio/clients/async_client.py
@@ -1,6 +1,8 @@
 """Interface for all async network clients to follow."""
 from __future__ import annotations
 
+from typing import Any, Dict
+
 from xrpl.asyncio.clients.client import Client
 from xrpl.models.requests.request import Request
 from xrpl.models.response import Response
@@ -24,3 +26,17 @@ class AsyncClient(Client):
             The Response for the given Request.
         """
         return await self.request_impl(request)
+
+    async def request_json(
+        self: AsyncClient, request: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Makes a request with this client and returns the response.
+
+        Arguments:
+            request: The request JSON to send.
+
+        Returns:
+            The response JSON for the given request.
+        """
+        return await self.request_json_impl(request)

--- a/xrpl/asyncio/clients/async_client.py
+++ b/xrpl/asyncio/clients/async_client.py
@@ -31,7 +31,8 @@ class AsyncClient(Client):
         self: AsyncClient, request: Dict[str, Any]
     ) -> Dict[str, Any]:
         """
-        Makes a request with this client and returns the response.
+        Makes a request with this client with a raw dictionary and returns the
+        dictionary response.
 
         Arguments:
             request: The request JSON to send.

--- a/xrpl/asyncio/clients/client.py
+++ b/xrpl/asyncio/clients/client.py
@@ -25,23 +25,6 @@ class Client(ABC):
         self.url = url
 
     @abstractmethod
-    async def request_impl(self: Client, request: Request) -> Response:
-        """
-        This is the main driver for a given Client's request. It must be
-        async because all of the helper functions in this library are
-        async-first.
-
-        Arguments:
-            request: An object representing information about a rippled request.
-
-        Returns:
-            The response from the server, as a Response object.
-
-        :meta private:
-        """
-        pass
-
-    @abstractmethod
     async def request_json_impl(
         self: Client, request: Dict[str, Any]
     ) -> Dict[str, Any]:
@@ -53,6 +36,23 @@ class Client(ABC):
         Arguments:
             request: An JSON-esque dictionary representing information about a rippled
                 request.
+
+        Returns:
+            The response from the server, as a Response object.
+
+        :meta private:
+        """
+        pass
+
+    @abstractmethod
+    async def request_impl(self: Client, request: Request) -> Response:
+        """
+        This is the primary driver for a given Client's request. It must be
+        async because all of the helper functions in this library are
+        async-first. Implement this using `request_json_impl` in a given Client.
+
+        Arguments:
+            request: An object representing information about a rippled request.
 
         Returns:
             The response from the server, as a Response object.

--- a/xrpl/asyncio/clients/client.py
+++ b/xrpl/asyncio/clients/client.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Any, Dict
 
 from xrpl.models.requests.request import Request
 from xrpl.models.response import Response
@@ -26,12 +27,32 @@ class Client(ABC):
     @abstractmethod
     async def request_impl(self: Client, request: Request) -> Response:
         """
+        This is the main driver for a given Client's request. It must be
+        async because all of the helper functions in this library are
+        async-first.
+
+        Arguments:
+            request: An object representing information about a rippled request.
+
+        Returns:
+            The response from the server, as a Response object.
+
+        :meta private:
+        """
+        pass
+
+    @abstractmethod
+    async def request_json_impl(
+        self: Client, request: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
         This is the actual driver for a given Client's request. It must be
         async because all of the helper functions in this library are
         async-first. Implement this in a given Client.
 
         Arguments:
-            request: An object representing information about a rippled request.
+            request: An JSON-esque dictionary representing information about a rippled
+                request.
 
         Returns:
             The response from the server, as a Response object.

--- a/xrpl/asyncio/clients/json_rpc_base.py
+++ b/xrpl/asyncio/clients/json_rpc_base.py
@@ -26,7 +26,7 @@ class JsonRpcBase(Client):
         Base ``request_impl`` implementation for JSON RPC.
 
         Arguments:
-            request: An object representing information about a rippled request.
+            request: A Request object representing information about a rippled request.
 
         Returns:
             The response from the server, as a Response object.
@@ -43,10 +43,10 @@ class JsonRpcBase(Client):
         Base ``request_json_impl`` implementation for JSON RPC.
 
         Arguments:
-            request: An object representing information about a rippled request.
+            request: A dictionary representing information about a rippled request.
 
         Returns:
-            The response from the server, as a Response object.
+            The response from the server, as a dictionary.
 
         :meta private:
         """

--- a/xrpl/asyncio/clients/json_rpc_base.py
+++ b/xrpl/asyncio/clients/json_rpc_base.py
@@ -1,6 +1,8 @@
 """A common interface for JsonRpc requests."""
 from __future__ import annotations
 
+from typing import Any, Dict, cast
+
 from httpx import AsyncClient
 from typing_extensions import Final
 
@@ -31,9 +33,26 @@ class JsonRpcBase(Client):
 
         :meta private:
         """
+        response_json = await self.request_json_impl(request_to_json_rpc(request))
+        return json_to_response(response_json)
+
+    async def request_json_impl(
+        self: Client, request: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Base ``request_json_impl`` implementation for JSON RPC.
+
+        Arguments:
+            request: An object representing information about a rippled request.
+
+        Returns:
+            The response from the server, as a Response object.
+
+        :meta private:
+        """
         async with AsyncClient(timeout=_TIMEOUT) as http_client:
             response = await http_client.post(
                 self.url,
-                json=request_to_json_rpc(request),
+                json=request,
             )
-            return json_to_response(response.json())
+            return cast(Dict[str, Any], response.json())

--- a/xrpl/asyncio/clients/websocket_base.py
+++ b/xrpl/asyncio/clients/websocket_base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 from asyncio import Future, Queue, Task, create_task, get_running_loop
 from random import randrange
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 
 from typing_extensions import Final
 from websockets.legacy.client import WebSocketClientProtocol, connect
@@ -26,7 +26,7 @@ def _inject_request_id(request: Dict[str, Any]) -> Dict[str, Any]:
     """
     if "id" in request and request["id"] is not None:
         return request
-    request_dict = request.copy()  # TODO: make this a deepcopy
+    request_dict = cast(Dict[str, Any], json.loads(json.dumps(request)))  # deepcopy
     command = request["command"]
     request_dict["id"] = f"{command}_{randrange(_REQ_ID_MAX)}"
     return request_dict

--- a/xrpl/asyncio/clients/websocket_base.py
+++ b/xrpl/asyncio/clients/websocket_base.py
@@ -134,7 +134,7 @@ class WebsocketBase(Client):
         Given a request with an ID, ensure that that ID is backed by an open
         Future in self._open_requests.
         """
-        if request["id"] is None:
+        if "id" not in request or request["id"] is None:
             return
         request_str = str(request["id"])
         if (

--- a/xrpl/asyncio/clients/websocket_base.py
+++ b/xrpl/asyncio/clients/websocket_base.py
@@ -24,7 +24,7 @@ def _inject_request_id(request: Dict[str, Any]) -> Dict[str, Any]:
 
     Given a request dictionary without an ID, make a copy with a randomly generated ID.
     """
-    if request["id"] is not None:
+    if "id" in request and request["id"] is not None:
         return request
     request_dict = request.copy()  # TODO: make this a deepcopy
     command = request["command"]

--- a/xrpl/asyncio/clients/websocket_base.py
+++ b/xrpl/asyncio/clients/websocket_base.py
@@ -165,25 +165,6 @@ class WebsocketBase(Client):
         self._messages.task_done()
         return msg
 
-    async def request_impl(self: WebsocketBase, request: Request) -> Response:
-        """
-        Base ``request_impl`` implementation for Websockets.
-
-        Arguments:
-            request: An object representing information about a rippled request.
-
-        Returns:
-            The response from the server, as a Response object.
-
-        Raises:
-            XRPLWebsocketException: If there is already an open request by the
-                request's ID, or if this WebsocketBase is not open.
-
-        :meta private:
-        """
-        response_json = await self.request_json_impl(request_to_websocket(request))
-        return websocket_to_response(response_json)
-
     async def request_json_impl(
         self: WebsocketBase, request: Dict[str, Any]
     ) -> Dict[str, Any]:
@@ -191,10 +172,10 @@ class WebsocketBase(Client):
         Base ``request_json_impl`` implementation for Websockets.
 
         Arguments:
-            request: An object representing information about a rippled request.
+            request: A dictionary representing information about a rippled request.
 
         Returns:
-            The response from the server, as a Response object.
+            The response from the server, as a dictionary.
 
         Raises:
             XRPLWebsocketException: If there is already an open request by the
@@ -218,3 +199,22 @@ class WebsocketBase(Client):
         # remove the resolved Future, hopefully getting it garbage colleted
         del self._open_requests[request_str]
         return raw_response
+
+    async def request_impl(self: WebsocketBase, request: Request) -> Response:
+        """
+        Base ``request_impl`` implementation for Websockets.
+
+        Arguments:
+            request: A Request object representing information about a rippled request.
+
+        Returns:
+            The response from the server, as a Response object.
+
+        Raises:
+            XRPLWebsocketException: If there is already an open request by the
+                request's ID, or if this WebsocketBase is not open.
+
+        :meta private:
+        """
+        response_json = await self.request_json_impl(request_to_websocket(request))
+        return websocket_to_response(response_json)

--- a/xrpl/clients/sync_client.py
+++ b/xrpl/clients/sync_client.py
@@ -28,7 +28,7 @@ class SyncClient(Client):
         """
         return asyncio.run(self.request_impl(request))
 
-    async def request_json(self: SyncClient, request: Dict[str, Any]) -> Dict[str, Any]:
+    def request_json(self: SyncClient, request: Dict[str, Any]) -> Dict[str, Any]:
         """
         Makes a request with this client and returns the response.
 

--- a/xrpl/clients/sync_client.py
+++ b/xrpl/clients/sync_client.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any, Dict
 
 from xrpl.asyncio.clients.client import Client
 from xrpl.models.requests.request import Request
@@ -26,3 +27,15 @@ class SyncClient(Client):
             The Response for the given Request.
         """
         return asyncio.run(self.request_impl(request))
+
+    async def request_json(self: SyncClient, request: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Makes a request with this client and returns the response.
+
+        Arguments:
+            request: The request JSON to send.
+
+        Returns:
+            The response JSON for the given request.
+        """
+        return asyncio.run(self.request_json_impl(request))

--- a/xrpl/clients/sync_client.py
+++ b/xrpl/clients/sync_client.py
@@ -33,9 +33,9 @@ class SyncClient(Client):
         Makes a request with this client and returns the response.
 
         Arguments:
-            request: The request JSON to send.
+            request: The request dictionary to send.
 
         Returns:
-            The response JSON for the given request.
+            The response dictionary for the given request.
         """
         return asyncio.run(self.request_json_impl(request))

--- a/xrpl/clients/websocket_client.py
+++ b/xrpl/clients/websocket_client.py
@@ -11,7 +11,6 @@ from xrpl.asyncio.clients.exceptions import XRPLWebsocketException
 from xrpl.asyncio.clients.websocket_base import WebsocketBase
 from xrpl.clients.sync_client import SyncClient
 from xrpl.models.requests.request import Request
-from xrpl.models.response import Response
 
 
 class WebsocketClient(SyncClient, WebsocketBase):
@@ -193,7 +192,9 @@ class WebsocketClient(SyncClient, WebsocketBase):
         assert self._loop is not None  # mypy
         run_coroutine_threadsafe(self._do_send(request), self._loop).result()
 
-    async def request_impl(self: WebsocketClient, request: Request) -> Response:
+    async def request_json_impl(
+        self: WebsocketClient, request: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """
         ``request_impl`` implementation for sync websockets that ensures the
         ``WebsocketBase.request_impl`` implementation is run on the other thread.
@@ -202,7 +203,7 @@ class WebsocketClient(SyncClient, WebsocketBase):
             request: An object representing information about a rippled request.
 
         Returns:
-            The response from the server, as a Response object.
+            The response from the server.
 
         Raises:
             XRPLWebsocketException: If there is already an open request by the
@@ -222,10 +223,10 @@ class WebsocketClient(SyncClient, WebsocketBase):
         # complete. also, `asyncio.run_coroutine_threadsafe` returns a
         # concurrent.futures.Future which is not awaitable.
         #
-        # when this is run via `await client.request_impl`, it will
+        # when this is run via `await client.request_json_impl`, it will
         # completely block the main thread until completed,
         # just as if it were not async.
         return run_coroutine_threadsafe(
-            super().request_impl(request),
+            super().request_json_impl(request),
             self._loop,
         ).result()

--- a/xrpl/clients/websocket_client.py
+++ b/xrpl/clients/websocket_client.py
@@ -196,8 +196,8 @@ class WebsocketClient(SyncClient, WebsocketBase):
         self: WebsocketClient, request: Dict[str, Any]
     ) -> Dict[str, Any]:
         """
-        ``request_impl`` implementation for sync websockets that ensures the
-        ``WebsocketBase.request_impl`` implementation is run on the other thread.
+        ``request_json_impl`` implementation for sync websockets that ensures the
+        ``WebsocketBase.request_json_impl`` implementation is run on the other thread.
 
         Arguments:
             request: An object representing information about a rippled request.


### PR DESCRIPTION
## High Level Overview of Change

This PR adds a new method to the clients, `request_json`. This allows devs to send a dictionary (that is properly formatted) directly to rippled, instead of needing to use a request model. 

This is useful for features where the models do not exist yet (such as NFT features or sidechain features) or for admin features (which don't have models right now).

### Context of Change

The clients need the ability to send raw JSON (in the form of dictionaries) to nodes. This was necessary for sidechain work and for docs work.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes. Added tests to test `request_json`. Integration tests pass.
