### PR TITLE
feat: add `on` callback method to websocket clients

### DIFF
--- a/tests/integration/it_utils.py
+++ b/tests/integration/it_utils.py
@@ -93,13 +93,13 @@ def test_async_and_sync(
         lines = _get_non_decorator_code(test_function)
         sync_code = (
             "".join(lines)
+            .replace("    async def", "async def")  # remove initial indenting
             .replace("async def", "def")  # convert method from async to sync
             .replace("async for", "for")  # convert for from async to sync
             .replace("async with", "with")  # convert with from async to sync
             .replace("await ", "")  # replace function calls
             .replace("_async(", "(")  # change methods
             .replace("\n    ", "\n")  # remove indenting (syntax error otherwise)
-            .replace("    def", "def")  # remove more indenting
         )
         # add an actual call to the function
         first_line = lines[0]
@@ -154,14 +154,14 @@ def test_async_and_sync(
 
         def modified_test(self):
             if not websockets_only:
-                with self.subTest(version="sync", client="json"):
-                    _run_sync_test(self, JSON_RPC_CLIENT)
                 with self.subTest(version="async", client="json"):
                     asyncio.run(_run_async_test(self, ASYNC_JSON_RPC_CLIENT))
-            with self.subTest(version="sync", client="websocket"):
-                _run_sync_test(self, WEBSOCKET_CLIENT)
+                with self.subTest(version="sync", client="json"):
+                    _run_sync_test(self, JSON_RPC_CLIENT)
             with self.subTest(version="async", client="websocket"):
                 asyncio.run(_run_async_test(self, ASYNC_WEBSOCKET_CLIENT))
+            with self.subTest(version="sync", client="websocket"):
+                _run_sync_test(self, WEBSOCKET_CLIENT)
 
         return modified_test
 


### PR DESCRIPTION
## High Level Overview of Change

This PR adds a method, `on`, to the async and sync websocket clients. This allows devs to write callbacks for streams.

### Context of Change

Needed for sidechains and for docs.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes. Wrote a test that passes.
