### PR TITLE
chore: parallelize linting and unit tests in CI

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -45,7 +45,6 @@ jobs:
       matrix:
         # we have to use 3.7.1 to get around openssl issues
         python-version: ['3.7.1', '3.8', '3.9', '3.10']
-    needs: lint-and-type-check
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## High Level Overview of Change

This PR parallelizes linting and unit tests in the Github Actions CI. Previously, the CI required the linting and type-check tests to run before the unit tests would run. This meant that the tests would take longer to run, because they were running partially in series. This PR makes them run in parallel to save time, especially because the linting and type-checking takes the longest of all the tests.

### Context of Change

make CI faster

### Type of Change

- [x] CI Updates

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes.
