### PR TITLE
fix: include missing `py.typed` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stops erroring on non-`tesSUCCESS` responses in reliable transaction submission
 - Removes runtime asserts in websocket clients that were used for type checks
   only
+- Adds missing top-level `py.typed` file for exceptions and constants
 
 ## [1.2.0] - 2021-11-09
 ### Added


### PR DESCRIPTION
## High Level Overview of Change

This PR extends #294 and adds one more `py.typed` file that was missed in that previous PR.

### Context of Change

I couldn't get the typing of `xrpl.constants` without it

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes. Tested the fix and it works.
