### PR TITLE
fixes typing issue with websockets in 3.7 and 3.8

### DIFF
--- a/xrpl/asyncio/clients/websocket_base.py
+++ b/xrpl/asyncio/clients/websocket_base.py
@@ -38,8 +38,7 @@ def _inject_request_id(request: Request) -> Request:
         return request
     request_dict = request.to_dict()
     request_dict["id"] = f"{request.method}_{randrange(_REQ_ID_MAX)}"
-    resp = Request.from_dict(request_dict)
-    return resp
+    return Request.from_dict(request_dict)
 
 
 class WebsocketBase(Client):
@@ -82,9 +81,6 @@ class WebsocketBase(Client):
 
     async def _do_open(self: WebsocketBase) -> None:
         """Connects the client to the Web Socket API at its URL."""
-        if self.is_open():
-            return
-
         # open the connection
         self._websocket = await connect(self.url)
 
@@ -96,9 +92,6 @@ class WebsocketBase(Client):
 
     async def _do_close(self: WebsocketBase) -> None:
         """Closes the connection."""
-        if not self.is_open():
-            return
-
         # cancel the handler
         cast(_HANDLER_TYPE, self._handler_task).cancel()
         self._handler_task = None
@@ -173,9 +166,9 @@ class WebsocketBase(Client):
         cast(_MESSAGES_TYPE, self._messages).task_done()
         return msg
 
-    async def request_impl(self: WebsocketBase, request: Request) -> Response:
+    async def _do_request_impl(self: WebsocketBase, request: Request) -> Response:
         """
-        Base ``request_impl`` implementation for Websockets.
+        Base ``request_impl`` implementation for websockets.
 
         Arguments:
             request: An object representing information about a rippled request.
@@ -186,12 +179,7 @@ class WebsocketBase(Client):
         Raises:
             XRPLWebsocketException: If there is already an open request by the
                 request's ID, or if this WebsocketBase is not open.
-
-        :meta private:
         """
-        if not self.is_open():
-            raise XRPLWebsocketException("Websocket is not open")
-
         # if no ID on this request, generate and inject one, and ensure it
         # is backed by a future
         request_with_id = _inject_request_id(request)

--- a/xrpl/clients/websocket_client.py
+++ b/xrpl/clients/websocket_client.py
@@ -200,7 +200,7 @@ class WebsocketClient(SyncClient, WebsocketBase):
     async def request_impl(self: WebsocketClient, request: Request) -> Response:
         """
         ``request_impl`` implementation for sync websockets that ensures the
-        ``WebsocketBase.request_impl`` implementation is run on the other thread.
+        ``WebsocketBase._do_request_impl`` implementation is run on the other thread.
 
         Arguments:
             request: An object representing information about a rippled request.
@@ -229,6 +229,6 @@ class WebsocketClient(SyncClient, WebsocketBase):
         # completely block the main thread until completed,
         # just as if it were not async.
         return run_coroutine_threadsafe(
-            super().request_impl(request),
+            self._do_request_impl(request),
             cast(AbstractEventLoop, self._loop),
         ).result()


### PR DESCRIPTION
## High Level Overview of Change

fixes an issue encountered in integration tests for 3.7 and 3.8. also some minor refactoring of the websocket clients such that the sync client will now only check `self.is_open()` once when trying a network operator. previously it would have called it twice due to the implementation.

### Type of Change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release
