### PR TITLE
fix: encoding issue with encoding non-traditional currency codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removes runtime asserts in websocket clients that were used for type checks
   only
 - Adds missing top-level `py.typed` file for exceptions and constants
+- Fix issue where unsupported currency codes weren't being correctly processed in the binary codec
 
 ## [1.2.0] - 2021-11-09
 ### Added

--- a/tests/unit/core/binarycodec/types/test_currency.py
+++ b/tests/unit/core/binarycodec/types/test_currency.py
@@ -7,6 +7,7 @@ XRP_HEX_CODE = "0000000000000000000000000000000000000000"
 ILLEGAL_XRP_HEX_CODE = "0000000000000000000000005852500000000000"
 USD_HEX_CODE = "0000000000000000000000005553440000000000"
 NONSTANDARD_HEX_CODE = "015841551A748AD2C1F76FF6ECB0CCCD00000000"
+NOT_RECOMMENDED_HEX_CODE = "0000000000414C6F676F30330000000000000000"
 XRP_ISO = "XRP"
 USD_ISO = "USD"
 
@@ -69,6 +70,10 @@ class TestCurrency(TestCase):
     def test_construction_from_hex_nonstandard(self):
         currency_object = currency.Currency.from_value(NONSTANDARD_HEX_CODE)
         self.assertEqual(currency_object.to_json(), NONSTANDARD_HEX_CODE)
+
+    def test_construction_from_hex_nonrecommended(self):
+        currency_object = currency.Currency.from_value(NOT_RECOMMENDED_HEX_CODE)
+        self.assertEqual(currency_object.to_json(), NOT_RECOMMENDED_HEX_CODE)
 
     def test_raises_invalid_value_type(self):
         invalid_value = [1, 2, 3]

--- a/xrpl/core/binarycodec/types/currency.py
+++ b/xrpl/core/binarycodec/types/currency.py
@@ -86,7 +86,7 @@ class Currency(Hash160):
         if self.buffer[0] != 0:
             # non-standard currency
             self._iso = None
-        elif code_bytes.hex() == "000000":
+        elif self.buffer.hex() == "0" * 40:  # all 0s
             # the special case for literal XRP
             self._iso = "XRP"
         else:


### PR DESCRIPTION
## High Level Overview of Change

This PR fixes an issue where some tokens with non-traditional currency codes weren't being encoded properly; they were being incorrectly encoded as `XRP`. 

### Context of Change

https://github.com/XRPLF/xrpl.js/pull/1857

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

Added a test that failed before the fix. CI passes.
