### PR TITLE
fix: add workaround for rippled UNLModify encoding bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   only
 - Adds missing top-level `py.typed` file for exceptions and constants
 - Fix issue where unsupported currency codes weren't being correctly processed in the binary codec
+- Fixes issue with UNLModify encoding (due to a bug in rippled)
 
 ## [1.2.0] - 2021-11-09
 ### Added

--- a/tests/unit/core/binarycodec/test_main.py
+++ b/tests/unit/core/binarycodec/test_main.py
@@ -279,6 +279,26 @@ class TestMainSimple(TestCase):
         self.assertEqual(encode(json_blank_acct), binary)
         self.assertEqual(decode(encode(json_blank_acct)), json_dict)
 
+    def test_unl_modify(self):
+        v_hash = "EDB6FC8E803EE8EDC2793F1EC917B2EE41D35255618DEB91D3F9B1FC89B75D4539"
+        json_dict = {
+            "UNLModifyDisabling": 1,
+            "LedgerSequence": 67850752,
+            "UNLModifyValidator": v_hash,
+            "TransactionType": "UNLModify",
+            "Account": "rrrrrrrrrrrrrrrrrrrrrhoLvTp",
+            "Sequence": 0,
+            "Fee": "0",
+            "SigningPubKey": "",
+        }
+        binary = (
+            "120066240000000026040B52006840000000000000007300701321EDB6FC8E803E"
+            "E8EDC2793F1EC917B2EE41D35255618DEB91D3F9B1FC89B75D4539810000101101"
+        )
+
+        self.assertEqual(encode(json_dict), binary)
+        self.assertEqual(decode(encode(json_dict)), json_dict)
+
 
 class TestXAddress(TestCase):
     def test_xaddress_encode(self):

--- a/xrpl/core/binarycodec/types/account_id.py
+++ b/xrpl/core/binarycodec/types/account_id.py
@@ -33,7 +33,7 @@ class AccountID(Hash160):
         Construct an AccountID from given bytes.
         If buffer is not provided, default to 20 zero bytes.
         """
-        if buffer is not None:
+        if buffer is not None and len(buffer) > 0:
             super().__init__(buffer)
         else:
             super().__init__(bytes(self.LENGTH))

--- a/xrpl/core/binarycodec/types/hash.py
+++ b/xrpl/core/binarycodec/types/hash.py
@@ -28,7 +28,9 @@ class Hash(SerializedType, ABC):
         buffer = buffer if buffer is not None else bytes(self._get_length())
 
         if len(buffer) != self._get_length():
-            raise XRPLBinaryCodecException("Invalid hash length {len(buffer)}")
+            raise XRPLBinaryCodecException(
+                f"Invalid hash length {len(buffer)}. Expected {self._get_length()}"
+            )
         super().__init__(buffer)
 
     def __str__(self: Hash) -> str:

--- a/xrpl/core/binarycodec/types/serialized_dict.py
+++ b/xrpl/core/binarycodec/types/serialized_dict.py
@@ -29,6 +29,8 @@ _ACCOUNT: Final[str] = "Account"
 _SOURCE_TAG: Final[str] = "SourceTag"
 _DEST_TAG: Final[str] = "DestinationTag"
 
+_UNL_MODIFY_TX: Final[str] = "0066"
+
 
 def _handle_xaddress(field: str, xaddress: str) -> Dict[str, Union[str, int]]:
     """Break down an X-Address into a classic address and a tag.
@@ -195,7 +197,10 @@ class SerializedDict(SerializedType):
                 # keeps the original stack trace
                 e.args = (f"Error processing {field.name}: {e.args[0]}",) + e.args[1:]
                 raise
-            if field.name == "TransactionType" and str(associated_value) == "0066":
+            if (
+                field.name == "TransactionType"
+                and str(associated_value) == _UNL_MODIFY_TX
+            ):
                 # triggered when the TransactionType field has a value of 'UNLModify'
                 is_unl_modify = True
             is_unl_modify_workaround = field.name == "Account" and is_unl_modify

--- a/xrpl/core/binarycodec/types/serialized_dict.py
+++ b/xrpl/core/binarycodec/types/serialized_dict.py
@@ -199,6 +199,11 @@ class SerializedDict(SerializedType):
                 # triggered when the TransactionType field has a value of 'UNLModify'
                 is_unl_modify = True
             is_unl_modify_workaround = field.name == "Account" and is_unl_modify
+            # true when in the UNLModify pseudotransaction (after the transaction type
+            # has been processed) and working with the Account field
+            # The Account field must not be a part of the UNLModify pseudotransaction
+            # encoding, due to a bug in rippled
+
             serializer.write_field_and_value(
                 field, associated_value, is_unl_modify_workaround
             )


### PR DESCRIPTION
## High Level Overview of Change

There's a bug in rippled that means that UNLModify pseudotransactions aren't being encoded properly (the account isn't being included in the encoded pseudo-tx). This PR adds a workaround for that issue.

### Context of Change

https://github.com/XRPLF/xrpl.js/pull/1830

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

Added a test that failed before the fix. CI passes.
