### PR TITLE
fix: use the ledger to determine the AccountDelete fee instead of hardcoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix issue where unsupported currency codes weren't being correctly processed in the binary codec
 - Fixes issue with UNLModify encoding (due to a bug in rippled)
 - Exports `Transaction`, `Response`, pseudo-transactions at the `xrpl.models` level
+- Makes the account delete fee dynamic, based on the ledger's reserve, instead of hard-coded
 
 ## [1.2.0] - 2021-11-09
 ### Added

--- a/tests/integration/sugar/test_transaction.py
+++ b/tests/integration/sugar/test_transaction.py
@@ -155,7 +155,7 @@ class TestTransaction(IntegrationTestCase):
         # GIVEN a new AccountDelete transaction
         account_delete = AccountDelete(
             account=ACCOUNT,
-            # WITH fee higher than 5 XRP
+            # WITH fee higher than 2 XRP
             fee=FEE,
             sequence=WALLET.sequence,
             destination=DESTINATION,
@@ -221,8 +221,8 @@ class TestTransaction(IntegrationTestCase):
             account_delete, WALLET, client
         )
 
-        # THEN we expect the calculated fee to be 5 XRP
-        expected_fee = xrp_to_drops(5)
+        # THEN we expect the calculated fee to be 2 XRP
+        expected_fee = xrp_to_drops(2)
         self.assertEqual(account_delete_signed.fee, expected_fee)
 
     @test_async_and_sync(

--- a/tests/integration/sugar/test_transaction.py
+++ b/tests/integration/sugar/test_transaction.py
@@ -36,7 +36,7 @@ MESSAGE_KEY = "03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931ED
 SET_FLAG = 8
 TRANSFER_RATE = 0
 TICK_SIZE = 10
-FEE = xrp_to_drops(6)
+FEE = xrp_to_drops(60)  # standalone has a delete fee of 50 XRP
 DESTINATION_TAG = 3
 OFFER_SEQUENCE = 7
 CONDITION = (
@@ -221,8 +221,8 @@ class TestTransaction(IntegrationTestCase):
             account_delete, WALLET, client
         )
 
-        # THEN we expect the calculated fee to be 2 XRP
-        expected_fee = xrp_to_drops(2)
+        # THEN we expect the calculated fee to be 50 XRP (default in standalone)
+        expected_fee = xrp_to_drops(50)
         self.assertEqual(account_delete_signed.fee, expected_fee)
 
     @test_async_and_sync(


### PR DESCRIPTION
## High Level Overview of Change

This PR pulls the fee for an AccountDelete transaction from the ledger, instead of using a hardcoded value.

### Context of Change

A few months ago, the network voted to move the fee structure from 20/5 to 10/2. The fee for an autofilled AccountDelete transaction in xrpl-py wouldn't change, in that case, because it was hardcoded to 5 XRP. 

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes.
