### PR TITLE
fix: replace Decimal `setcontext` with `localcontext` context manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exports `Transaction`, `Response`, pseudo-transactions at the `xrpl.models` level
 - Makes the account delete fee dynamic, based on the ledger's reserve, instead of hard-coded
 - Fee scaling based on load on the ledger
+- Fixes potential issue with conflicting Decimal contexts
 
 ## [1.2.0] - 2021-11-09
 ### Added

--- a/xrpl/constants.py
+++ b/xrpl/constants.py
@@ -1,4 +1,5 @@
 """Collection of public constants for XRPL."""
+from decimal import Context
 from enum import Enum
 from re import compile
 from typing import Pattern
@@ -26,5 +27,43 @@ ISO_CURRENCY_REGEX: Final[Pattern[str]] = compile("^[A-Z0-9]{3}$")
 
 HEX_CURRENCY_REGEX: Final[Pattern[str]] = compile("^[A-F0-9]{40}$")
 """
+:meta private:
+"""
+
+# Constants for validating amounts.
+MIN_IOU_EXPONENT: Final[int] = -96
+"""
+:meta private:
+"""
+MAX_IOU_EXPONENT: Final[int] = 80
+"""
+:meta private:
+"""
+MAX_IOU_PRECISION: Final[int] = 16
+"""
+:meta private:
+"""
+MIN_MANTISSA: Final[int] = 10 ** 15
+"""
+:meta private:
+"""
+MAX_MANTISSA: Final[int] = 10 ** 16 - 1
+"""
+:meta private:
+"""
+
+# Configure Decimal
+IOU_CONTEXT: Final[Context] = Context(
+    prec=MAX_IOU_PRECISION, Emax=MAX_IOU_EXPONENT, Emin=MIN_IOU_EXPONENT
+)
+"""
+Decimal context for working with IOUs.
+:meta private:
+"""
+
+
+DROPS_CONTEXT: Final[Context] = Context(prec=18, Emin=0, Emax=18)
+"""
+Decimal context for working with drops.
 :meta private:
 """

--- a/xrpl/constants.py
+++ b/xrpl/constants.py
@@ -43,17 +43,17 @@ MAX_IOU_PRECISION: Final[int] = 16
 """
 :meta private:
 """
-MIN_MANTISSA: Final[int] = 10 ** 15
+MIN_IOU_MANTISSA: Final[int] = 10 ** 15
 """
 :meta private:
 """
-MAX_MANTISSA: Final[int] = 10 ** 16 - 1
+MAX_IOU_MANTISSA: Final[int] = 10 ** 16 - 1
 """
 :meta private:
 """
 
 # Configure Decimal
-IOU_CONTEXT: Final[Context] = Context(
+IOU_DECIMAL_CONTEXT: Final[Context] = Context(
     prec=MAX_IOU_PRECISION, Emax=MAX_IOU_EXPONENT, Emin=MIN_IOU_EXPONENT
 )
 """
@@ -62,7 +62,7 @@ Decimal context for working with IOUs.
 """
 
 
-DROPS_CONTEXT: Final[Context] = Context(prec=18, Emin=0, Emax=18)
+DROPS_DECIMAL_CONTEXT: Final[Context] = Context(prec=18, Emin=0, Emax=18)
 """
 Decimal context for working with drops.
 :meta private:

--- a/xrpl/core/binarycodec/types/amount.py
+++ b/xrpl/core/binarycodec/types/amount.py
@@ -24,7 +24,7 @@ _MIN_MANTISSA: Final[int] = 10 ** 15
 _MAX_MANTISSA: Final[int] = 10 ** 16 - 1
 
 # Configure Decimal
-_AMOUNT_CONTEXT = Context(
+_AMOUNT_CONTEXT: Final[Context] = Context(
     prec=_MAX_IOU_PRECISION, Emax=_MAX_IOU_EXPONENT, Emin=_MIN_IOU_EXPONENT
 )
 

--- a/xrpl/core/binarycodec/types/amount.py
+++ b/xrpl/core/binarycodec/types/amount.py
@@ -24,6 +24,7 @@ _MIN_MANTISSA: Final[int] = 10 ** 15
 _MAX_MANTISSA: Final[int] = 10 ** 16 - 1
 
 # Configure Decimal
+# TODO: export this context so others can use it
 _AMOUNT_CONTEXT: Final[Context] = Context(
     prec=_MAX_IOU_PRECISION, Emax=_MAX_IOU_EXPONENT, Emin=_MIN_IOU_EXPONENT
 )

--- a/xrpl/utils/xrp_conversions.py
+++ b/xrpl/utils/xrp_conversions.py
@@ -21,6 +21,7 @@ MAX_DROPS: Final[Decimal] = Decimal(10 ** 17)
 # See also: https://xrpl.org/currency-formats.html#string-numbers
 _DROPS_REGEX: Final[str] = r"[1-9][0-9Ee-]{0,17}|0"
 
+# TODO: export this context so others can use it
 _DROPS_CONTEXT: Final[Context] = Context(prec=18, Emin=0, Emax=18)
 
 

--- a/xrpl/utils/xrp_conversions.py
+++ b/xrpl/utils/xrp_conversions.py
@@ -1,12 +1,12 @@
 """Conversions between XRP drops and native number types."""
 
-from decimal import Context, Decimal, InvalidOperation, localcontext
+from decimal import Decimal, InvalidOperation, localcontext
 from re import fullmatch
 from typing import Union
 
 from typing_extensions import Final
 
-from xrpl.constants import XRPLException
+from xrpl.constants import DROPS_CONTEXT, XRPLException
 
 ONE_DROP: Final[Decimal] = Decimal("0.000001")
 """Indivisible unit of XRP"""
@@ -20,9 +20,6 @@ MAX_DROPS: Final[Decimal] = Decimal(10 ** 17)
 # Drops should be an integer string. MAY have (positive) exponent.
 # See also: https://xrpl.org/currency-formats.html#string-numbers
 _DROPS_REGEX: Final[str] = r"[1-9][0-9Ee-]{0,17}|0"
-
-# TODO: export this context so others can use it
-_DROPS_CONTEXT: Final[Context] = Context(prec=18, Emin=0, Emax=18)
 
 
 def xrp_to_drops(xrp: Union[int, float, Decimal]) -> str:
@@ -45,7 +42,7 @@ def xrp_to_drops(xrp: Union[int, float, Decimal]) -> str:
         raise TypeError(
             "XRP provided as a string. Use a number format" "like Decimal or int."
         )
-    with localcontext(_DROPS_CONTEXT):
+    with localcontext(DROPS_CONTEXT):
         try:
             xrp_d = Decimal(xrp)
         except InvalidOperation:
@@ -90,7 +87,7 @@ def drops_to_xrp(drops: str) -> Decimal:
     if type(drops) != str:
         raise TypeError(f"Drops must be provided as string (got {type(drops)})")
     drops = drops.strip()
-    with localcontext(_DROPS_CONTEXT):
+    with localcontext(DROPS_CONTEXT):
         if not fullmatch(_DROPS_REGEX, drops):
             raise XRPRangeException(f"Not a valid amount of drops: '{drops}'")
         try:

--- a/xrpl/utils/xrp_conversions.py
+++ b/xrpl/utils/xrp_conversions.py
@@ -6,7 +6,7 @@ from typing import Union
 
 from typing_extensions import Final
 
-from xrpl.constants import DROPS_CONTEXT, XRPLException
+from xrpl.constants import DROPS_DECIMAL_CONTEXT, XRPLException
 
 ONE_DROP: Final[Decimal] = Decimal("0.000001")
 """Indivisible unit of XRP"""
@@ -42,7 +42,7 @@ def xrp_to_drops(xrp: Union[int, float, Decimal]) -> str:
         raise TypeError(
             "XRP provided as a string. Use a number format" "like Decimal or int."
         )
-    with localcontext(DROPS_CONTEXT):
+    with localcontext(DROPS_DECIMAL_CONTEXT):
         try:
             xrp_d = Decimal(xrp)
         except InvalidOperation:
@@ -87,7 +87,7 @@ def drops_to_xrp(drops: str) -> Decimal:
     if type(drops) != str:
         raise TypeError(f"Drops must be provided as string (got {type(drops)})")
     drops = drops.strip()
-    with localcontext(DROPS_CONTEXT):
+    with localcontext(DROPS_DECIMAL_CONTEXT):
         if not fullmatch(_DROPS_REGEX, drops):
             raise XRPRangeException(f"Not a valid amount of drops: '{drops}'")
         try:


### PR DESCRIPTION
## High Level Overview of Change

This PR replaces all instances of Decimal's `setcontext` with the `localcontext` context manager.

Tests were failing for some weird dependency reason, so this PR also updates some dev dependencies as well.

### Context of Change

It's better practice to use a context manager than to set global state. Plus, it's less likely to cause problems.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes (tests don't pass if the context is set incorrectly).
