### PR TITLE
fix: export `Transaction`, `Response`, pseudotransactions at the `models` level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds missing top-level `py.typed` file for exceptions and constants
 - Fix issue where unsupported currency codes weren't being correctly processed in the binary codec
 - Fixes issue with UNLModify encoding (due to a bug in rippled)
+- Exports `Transaction`, `Response`, pseudo-transactions at the `xrpl.models` level
 
 ## [1.2.0] - 2021-11-09
 ### Added

--- a/xrpl/models/__init__.py
+++ b/xrpl/models/__init__.py
@@ -5,6 +5,7 @@ from xrpl.models.currencies import *  # noqa: F401, F403
 from xrpl.models.exceptions import XRPLModelException
 from xrpl.models.path import Path, PathStep
 from xrpl.models.requests import *  # noqa: F401, F403
+from xrpl.models.response import Response
 from xrpl.models.transactions import *  # noqa: F401, F403
 
 __all__ = [
@@ -19,4 +20,5 @@ __all__ = [
     *transactions.__all__,
     "Path",
     "PathStep",
+    "Response",
 ]

--- a/xrpl/models/__init__.py
+++ b/xrpl/models/__init__.py
@@ -7,6 +7,7 @@ from xrpl.models.path import Path, PathStep
 from xrpl.models.requests import *  # noqa: F401, F403
 from xrpl.models.response import Response
 from xrpl.models.transactions import *  # noqa: F401, F403
+from xrpl.models.transactions.pseudo_transactions import *  # noqa: F401, F403
 
 __all__ = [
     "XRPLModelException",
@@ -18,6 +19,7 @@ __all__ = [
     *requests.__all__,
     "transactions",
     *transactions.__all__,
+    *transactions.pseudo_transactions.__all__,
     "Path",
     "PathStep",
     "Response",

--- a/xrpl/models/transactions/__init__.py
+++ b/xrpl/models/transactions/__init__.py
@@ -24,7 +24,7 @@ from xrpl.models.transactions.payment_channel_fund import PaymentChannelFund
 from xrpl.models.transactions.set_regular_key import SetRegularKey
 from xrpl.models.transactions.signer_list_set import SignerEntry, SignerListSet
 from xrpl.models.transactions.ticket_create import TicketCreate
-from xrpl.models.transactions.transaction import Memo, Signer
+from xrpl.models.transactions.transaction import Memo, Signer, Transaction
 from xrpl.models.transactions.trust_set import TrustSet, TrustSetFlag
 
 __all__ = [
@@ -53,6 +53,7 @@ __all__ = [
     "SignerEntry",
     "SignerListSet",
     "TicketCreate",
+    "Transaction",
     "TrustSet",
     "TrustSetFlag",
 ]


### PR DESCRIPTION
## High Level Overview of Change

Title pretty much says it all.

I decided not to import the pseudotransactions at the `xrpl.models.transactions` level because that felt confusing, since they're not actually transactions.

### Context of Change

Dogfooding showed that it was really annoying to have to specifically import `Transaction` from `xrpl.models.transactions.transaction`.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes.