### PR TITLE
feat: scales fee based on ledger load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GenericRequest` model for unsupported request types
 - Methods to convert between `IssuedCurrency` and `IssuedCurrencyAmount`
 - Support for ints and floats in the `IssuedCurrency` and `IssuedCurrencyAmount` models (and ints for `XRP`)
-- fee scaling based on load on the ledger
+- Fee scaling based on load on the ledger
 
 ### Fixed
 - Makes the default ledger version for `get_next_valid_seq_number` `current` instead of `validated`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GenericRequest` model for unsupported request types
 - Methods to convert between `IssuedCurrency` and `IssuedCurrencyAmount`
 - Support for ints and floats in the `IssuedCurrency` and `IssuedCurrencyAmount` models (and ints for `XRP`)
+- fee scaling based on load on the ledger
 
 ### Fixed
 - Makes the default ledger version for `get_next_valid_seq_number` `current` instead of `validated`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Methods to convert between `IssuedCurrency` and `IssuedCurrencyAmount`
 - Support for ints and floats in the `IssuedCurrency` and `IssuedCurrencyAmount` models (and ints for `XRP`)
 - Fee scaling based on load on the ledger
+- `max_fee` optional param for `get_fee`
 
 ### Fixed
 - Makes the default ledger version for `get_next_valid_seq_number` `current` instead of `validated`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GenericRequest` model for unsupported request types
 - Methods to convert between `IssuedCurrency` and `IssuedCurrencyAmount`
 - Support for ints and floats in the `IssuedCurrency` and `IssuedCurrencyAmount` models (and ints for `XRP`)
-- Fee scaling based on load on the ledger
 - `max_fee` optional param for `get_fee`
 
 ### Fixed
@@ -28,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes issue with UNLModify encoding (due to a bug in rippled)
 - Exports `Transaction`, `Response`, pseudo-transactions at the `xrpl.models` level
 - Makes the account delete fee dynamic, based on the ledger's reserve, instead of hard-coded
+- Fee scaling based on load on the ledger
 
 ## [1.2.0] - 2021-11-09
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GenericRequest` model for unsupported request types
 - Methods to convert between `IssuedCurrency` and `IssuedCurrencyAmount`
 - Support for ints and floats in the `IssuedCurrency` and `IssuedCurrencyAmount` models (and ints for `XRP`)
-- `max_fee` optional param for `get_fee`
+- `max_fee` and `fee_type` optional params for `get_fee`
 
 ### Fixed
 - Makes the default ledger version for `get_next_valid_seq_number` `current` instead of `validated`

--- a/tests/integration/sugar/test_ledger.py
+++ b/tests/integration/sugar/test_ledger.py
@@ -1,0 +1,13 @@
+from tests.integration.integration_test_case import IntegrationTestCase
+from tests.integration.it_utils import test_async_and_sync
+from xrpl.asyncio.ledger import get_fee
+from xrpl.utils import drops_to_xrp
+
+
+class TestLedger(IntegrationTestCase):
+    @test_async_and_sync(globals(), ["xrpl.ledger.get_fee"])
+    async def test_get_fee_max(self, client):
+        expected = "1"
+        max_fee = drops_to_xrp(expected)
+        result = await get_fee(client, max_fee=max_fee)
+        self.assertEqual(result, expected)

--- a/xrpl/asyncio/ledger/main.py
+++ b/xrpl/asyncio/ledger/main.py
@@ -4,6 +4,7 @@ from typing import cast
 
 from xrpl.asyncio.clients import Client, XRPLRequestFailureException
 from xrpl.models.requests import Ledger, ServerInfo
+from xrpl.utils import xrp_to_drops
 
 
 async def get_latest_validated_ledger_sequence(client: Client) -> int:
@@ -54,7 +55,7 @@ async def get_fee(client: Client) -> str:
         client: the network client used to make network calls.
 
     Returns:
-        The minimum fee for transactions, in XRP.
+        The minimum fee for transactions, in drops.
 
     Raises:
         XRPLRequestFailureException: if the rippled API call fails.
@@ -67,7 +68,7 @@ async def get_fee(client: Client) -> str:
     if "validated_ledger" not in server_info:
         raise XRPLRequestFailureException(response.result)
 
-    base_fee = server_info["validated_ledger"]["base_fee_xrp"]
+    base_fee = int(xrp_to_drops(server_info["validated_ledger"]["base_fee_xrp"]))
 
     if "load_factor" not in server_info:
         load_factor = 1
@@ -76,4 +77,4 @@ async def get_fee(client: Client) -> str:
 
     fee = base_fee * load_factor
     # TODO: add cushion and max fee params to this method
-    return "%.6f" % fee
+    return str(int(fee))

--- a/xrpl/asyncio/ledger/main.py
+++ b/xrpl/asyncio/ledger/main.py
@@ -54,7 +54,7 @@ async def get_fee(client: Client) -> str:
         client: the network client used to make network calls.
 
     Returns:
-        The minimum fee for transactions.
+        The minimum fee for transactions, in XRP.
 
     Raises:
         XRPLRequestFailureException: if the rippled API call fails.

--- a/xrpl/asyncio/ledger/main.py
+++ b/xrpl/asyncio/ledger/main.py
@@ -3,8 +3,8 @@
 from typing import Optional, cast
 
 from xrpl.asyncio.clients import Client, XRPLRequestFailureException
-from xrpl.models.requests import Ledger, ServerInfo
-from xrpl.utils import xrp_to_drops
+from xrpl.constants import XRPLException
+from xrpl.models.requests import Fee, Ledger
 
 
 async def get_latest_validated_ledger_sequence(client: Client) -> int:
@@ -47,7 +47,9 @@ async def get_latest_open_ledger_sequence(client: Client) -> int:
     raise XRPLRequestFailureException(response.result)
 
 
-async def get_fee(client: Client, max_fee: Optional[float] = 2) -> str:
+async def get_fee(
+    client: Client, *, max_fee: Optional[float] = 2, fee_type: str = "open"
+) -> str:
     """
     Query the ledger for the current minimum transaction fee.
 
@@ -56,33 +58,28 @@ async def get_fee(client: Client, max_fee: Optional[float] = 2) -> str:
         max_fee: The maximum fee in XRP that the user wants to pay. If load gets too
             high, then the fees will not scale past the maximum fee. If None, there is
             no ceiling for the fee. The default is 2 XRP.
+        fee_type: The type of fee to return. The options are "open" (the load-scaled
+            fee to get into the open ledger) or "minimum" (the minimum transaction
+            cost). The default is "open".
 
     Returns:
-        The load-scaled transaction cost, in drops.
+        The transaction cost, in drops.
 
     Raises:
+        XRPLException: if an incorrect option for `fee_type` is passed in.
         XRPLRequestFailureException: if the rippled API call fails.
     """
-    response = await client.request_impl(ServerInfo())
-    if not response.is_successful():
-        raise XRPLRequestFailureException(response.result)
+    response = await client.request_impl(Fee())
+    if response.is_successful():
+        result = response.result["drops"]
+        if fee_type == "open":
+            return cast(str, result["open_ledger_fee"])
+        elif fee_type == "minimum":
+            return cast(str, result["minimum_fee"])
+        else:
+            raise XRPLException(
+                f'`fee_type` param must be "open" or "minimum". {fee_type} is not a '
+                "valid option."
+            )
 
-    server_info = response.result["info"]
-    if "validated_ledger" not in server_info:
-        raise XRPLRequestFailureException(response.result)
-
-    base_fee = int(xrp_to_drops(server_info["validated_ledger"]["base_fee_xrp"]))
-
-    if "load_factor" not in server_info:
-        load_factor = 1
-    else:
-        load_factor = server_info["load_factor"]
-
-    fee = base_fee * load_factor
-    if max_fee is not None:
-        max_fee_drops = int(xrp_to_drops(max_fee))
-        if max_fee_drops < fee:
-            fee = max_fee_drops
-    # TODO: add cushion param to this method
-    # rounds to the nearest integer, then converts to string
-    return str(int(fee))
+    raise XRPLRequestFailureException(response.result)

--- a/xrpl/ledger/main.py
+++ b/xrpl/ledger/main.py
@@ -1,6 +1,7 @@
 """High-level ledger methods with the XRPL ledger."""
 
 import asyncio
+from typing import Optional
 
 from xrpl.asyncio.ledger import main
 from xrpl.clients.sync_client import SyncClient
@@ -38,12 +39,15 @@ def get_latest_open_ledger_sequence(client: SyncClient) -> int:
     return asyncio.run(main.get_latest_open_ledger_sequence(client))
 
 
-def get_fee(client: SyncClient) -> str:
+def get_fee(client: SyncClient, max_fee: Optional[float] = 2) -> str:
     """
     Query the ledger for the current minimum transaction fee.
 
     Args:
         client: the network client used to make network calls.
+        max_fee: The maximum fee in XRP that the user wants to pay. If load gets too
+            high, then the fees will not scale past the maximum fee. If None, there is
+            no ceiling for the fee. The default is 2 XRP.
 
     Returns:
         The minimum fee for transactions.
@@ -51,4 +55,4 @@ def get_fee(client: SyncClient) -> str:
     Raises:
         XRPLRequestFailureException: if the rippled API call fails.
     """
-    return asyncio.run(main.get_fee(client))
+    return asyncio.run(main.get_fee(client, max_fee))

--- a/xrpl/ledger/main.py
+++ b/xrpl/ledger/main.py
@@ -39,7 +39,9 @@ def get_latest_open_ledger_sequence(client: SyncClient) -> int:
     return asyncio.run(main.get_latest_open_ledger_sequence(client))
 
 
-def get_fee(client: SyncClient, max_fee: Optional[float] = 2) -> str:
+def get_fee(
+    client: SyncClient, *, max_fee: Optional[float] = 2, fee_type: str = "open"
+) -> str:
     """
     Query the ledger for the current minimum transaction fee.
 
@@ -48,6 +50,9 @@ def get_fee(client: SyncClient, max_fee: Optional[float] = 2) -> str:
         max_fee: The maximum fee in XRP that the user wants to pay. If load gets too
             high, then the fees will not scale past the maximum fee. If None, there is
             no ceiling for the fee. The default is 2 XRP.
+        fee_type: The type of fee to return. The options are "open" (the load-scaled
+            fee to get into the open ledger) or "minimum" (the minimum transaction
+            cost). The default is "open".
 
     Returns:
         The minimum fee for transactions.
@@ -55,4 +60,4 @@ def get_fee(client: SyncClient, max_fee: Optional[float] = 2) -> str:
     Raises:
         XRPLRequestFailureException: if the rippled API call fails.
     """
-    return asyncio.run(main.get_fee(client, max_fee))
+    return asyncio.run(main.get_fee(client, max_fee=max_fee, fee_type=fee_type))


### PR DESCRIPTION
## High Level Overview of Change

This PR refactors `get_fee` to incorporate the ledger load, so that the fee it returns scales appropriately when the ledger is under load, instead of always returning the minimum fee.

### Context of Change

A minimum 10-drop fee currently does not work on mainnet. This PR uses the [formula used in xrpl.js](https://github.com/XRPLF/xrpl.js/blob/main/packages/xrpl/src/sugar/getFeeXrp.ts) to scale the fee based on ledger load.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes. I tested by hand and confirmed that the fees are in the 5k drop range on mainnet right now.