### PR TITLE
feat: add int/float support to `IssuedCurrency`, `XRP, `IssuedCurrencyAmount`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `TicketCreate` transaction model
 - `GenericRequest` model for unsupported request types
 - Methods to convert between `IssuedCurrency` and `IssuedCurrencyAmount`
+- Support for ints and floats in the `IssuedCurrency` and `IssuedCurrencyAmount` models
 
 ### Fixed
 - Makes the default ledger version for `get_next_valid_seq_number` `current` instead of `validated`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `TicketCreate` transaction model
 - `GenericRequest` model for unsupported request types
 - Methods to convert between `IssuedCurrency` and `IssuedCurrencyAmount`
-- Support for ints and floats in the `IssuedCurrency` and `IssuedCurrencyAmount` models
+- Support for ints and floats in the `IssuedCurrency` and `IssuedCurrencyAmount` models (and ints for `XRP`)
 
 ### Fixed
 - Makes the default ledger version for `get_next_valid_seq_number` `current` instead of `validated`

--- a/xrpl/models/amounts/issued_currency_amount.py
+++ b/xrpl/models/amounts/issued_currency_amount.py
@@ -6,6 +6,7 @@ See https://xrpl.org/currency-formats.html#issued-currency-amounts.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Dict, Union
 
 from xrpl.models.currencies import IssuedCurrency
 from xrpl.models.required import REQUIRED
@@ -21,7 +22,7 @@ class IssuedCurrencyAmount(IssuedCurrency):
     See https://xrpl.org/currency-formats.html#issued-currency-amounts.
     """
 
-    value: str = REQUIRED  # type: ignore
+    value: Union[str, int, float] = REQUIRED  # type: ignore
     """
     This field is required.
 
@@ -36,3 +37,12 @@ class IssuedCurrencyAmount(IssuedCurrency):
             The IssuedCurrency for this IssuedCurrencyAmount.
         """
         return IssuedCurrency(issuer=self.issuer, currency=self.currency)
+
+    def to_dict(self: IssuedCurrencyAmount) -> Dict[str, str]:
+        """
+        Returns the dictionary representation of an IssuedCurrencyAmount.
+
+        Returns:
+            The dictionary representation of an IssuedCurrencyAmount.
+        """
+        return {**super().to_dict(), "value": str(self.value)}

--- a/xrpl/models/currencies/issued_currency.py
+++ b/xrpl/models/currencies/issued_currency.py
@@ -7,7 +7,7 @@ See https://xrpl.org/currency-formats.html#specifying-currency-amounts
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict
+from typing import Dict, Union
 
 import xrpl.models.amounts  # not a direct import, to get around circular imports
 from xrpl.constants import HEX_CURRENCY_REGEX, ISO_CURRENCY_REGEX
@@ -56,7 +56,7 @@ class IssuedCurrency(BaseModel):
         return errors
 
     def to_amount(
-        self: IssuedCurrency, value: str
+        self: IssuedCurrency, value: Union[str, int, float]
     ) -> xrpl.models.amounts.IssuedCurrencyAmount:
         """
         Converts an IssuedCurrency to an IssuedCurrencyAmount.
@@ -69,5 +69,5 @@ class IssuedCurrency(BaseModel):
                 provided value.
         """
         return xrpl.models.amounts.IssuedCurrencyAmount(
-            currency=self.currency, issuer=self.issuer, value=value
+            currency=self.currency, issuer=self.issuer, value=str(value)
         )

--- a/xrpl/models/currencies/xrp.py
+++ b/xrpl/models/currencies/xrp.py
@@ -11,7 +11,7 @@ See https://xrpl.org/currency-formats.html#specifying-currency-amounts
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, Type
+from typing import Any, Dict, Type, Union
 
 from xrpl.models.base_model import BaseModel
 from xrpl.models.exceptions import XRPLModelException
@@ -61,7 +61,7 @@ class XRP(BaseModel):
         """
         return {**super().to_dict(), "currency": "XRP"}
 
-    def to_amount(self: XRP, value: str) -> str:
+    def to_amount(self: XRP, value: Union[str, int]) -> str:
         """
         Converts value to XRP.
 


### PR DESCRIPTION
## High Level Overview of Change

This PR allows users to use `int`s and `float`s for issued currencies and XRP amounts.

### Context of Change

Follow-up to #319 

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes.
