### PR TITLE
feat: make `autofill` a public method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Methods to convert between `IssuedCurrency` and `IssuedCurrencyAmount`
 - Support for ints and floats in the `IssuedCurrency` and `IssuedCurrencyAmount` models (and ints for `XRP`)
 - `max_fee` and `fee_type` optional params for `get_fee`
-- Makes `autofill_transaction` a publicly exposed method
+- Makes `autofill` a publicly exposed method
 
 ### Fixed
 - Makes the default ledger version for `get_next_valid_seq_number` `current` instead of `validated`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Methods to convert between `IssuedCurrency` and `IssuedCurrencyAmount`
 - Support for ints and floats in the `IssuedCurrency` and `IssuedCurrencyAmount` models (and ints for `XRP`)
 - `max_fee` and `fee_type` optional params for `get_fee`
-- Makes `autofill` a publicly exposed method
+- `autofill`, a new public method that populates the `fee`, `sequence`, and `last_ledger_sequence` fields of a transaction, based on the current state retrieved from the server the Client is connected to. It also converts all X-Addresses to classic addresses.
 
 ### Fixed
 - Makes the default ledger version for `get_next_valid_seq_number` `current` instead of `validated`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Methods to convert between `IssuedCurrency` and `IssuedCurrencyAmount`
 - Support for ints and floats in the `IssuedCurrency` and `IssuedCurrencyAmount` models (and ints for `XRP`)
 - `max_fee` and `fee_type` optional params for `get_fee`
+- Makes `autofill_transaction` a publicly exposed method
 
 ### Fixed
 - Makes the default ledger version for `get_next_valid_seq_number` `current` instead of `validated`

--- a/tests/integration/sugar/test_transaction.py
+++ b/tests/integration/sugar/test_transaction.py
@@ -13,6 +13,7 @@ from xrpl.asyncio.account import get_next_valid_seq_number
 from xrpl.asyncio.ledger import get_fee, get_latest_validated_ledger_sequence
 from xrpl.asyncio.transaction import (
     XRPLReliableSubmissionException,
+    autofill_transaction,
     get_transaction_from_hash,
     safe_sign_and_autofill_transaction,
     safe_sign_transaction,
@@ -204,9 +205,7 @@ class TestTransaction(IntegrationTestCase):
         self.assertTrue(response.is_successful())
         WALLET.sequence += 1
 
-    @test_async_and_sync(
-        globals(), ["xrpl.transaction.safe_sign_and_autofill_transaction"]
-    )
+    @test_async_and_sync(globals(), ["xrpl.transaction.autofill_transaction"])
     async def test_calculate_account_delete_fee(self, client):
         # GIVEN a new AccountDelete transaction
         account_delete = AccountDelete(
@@ -217,7 +216,7 @@ class TestTransaction(IntegrationTestCase):
         )
 
         # AFTER autofilling the transaction fee
-        account_delete_signed = await safe_sign_and_autofill_transaction(
+        account_delete_signed = await autofill_transaction(
             account_delete, WALLET, client
         )
 
@@ -227,7 +226,7 @@ class TestTransaction(IntegrationTestCase):
 
     @test_async_and_sync(
         globals(),
-        ["xrpl.transaction.safe_sign_and_autofill_transaction", "xrpl.ledger.get_fee"],
+        ["xrpl.transaction.autofill_transaction", "xrpl.ledger.get_fee"],
     )
     async def test_calculate_escrow_finish_fee(self, client):
         # GIVEN a new EscrowFinish transaction
@@ -241,9 +240,7 @@ class TestTransaction(IntegrationTestCase):
         )
 
         # AFTER autofilling the transaction fee
-        escrow_finish_signed = await safe_sign_and_autofill_transaction(
-            escrow_finish, WALLET, client
-        )
+        escrow_finish_signed = await autofill_transaction(escrow_finish, WALLET, client)
 
         # AND calculating the expected fee with the formula
         # 10 drops × (33 + (Fulfillment size in bytes ÷ 16))
@@ -256,7 +253,7 @@ class TestTransaction(IntegrationTestCase):
 
     @test_async_and_sync(
         globals(),
-        ["xrpl.transaction.safe_sign_and_autofill_transaction", "xrpl.ledger.get_fee"],
+        ["xrpl.transaction.autofill_transaction", "xrpl.ledger.get_fee"],
     )
     async def test_calculate_payment_fee(self, client):
         # GIVEN a new Payment transaction
@@ -268,9 +265,7 @@ class TestTransaction(IntegrationTestCase):
         )
 
         # AFTER autofilling the transaction fee
-        payment_signed = await safe_sign_and_autofill_transaction(
-            payment, WALLET, client
-        )
+        payment_signed = await autofill_transaction(payment, WALLET, client)
 
         # THEN We expect the fee to be the default network fee (usually 10 drops)
         expected_fee = await get_fee(client)

--- a/tests/integration/sugar/test_transaction.py
+++ b/tests/integration/sugar/test_transaction.py
@@ -216,9 +216,7 @@ class TestTransaction(IntegrationTestCase):
         )
 
         # AFTER autofilling the transaction fee
-        account_delete_signed = await autofill_transaction(
-            account_delete, WALLET, client
-        )
+        account_delete_signed = await autofill_transaction(account_delete, client)
 
         # THEN we expect the calculated fee to be 50 XRP (default in standalone)
         expected_fee = xrp_to_drops(50)
@@ -240,7 +238,7 @@ class TestTransaction(IntegrationTestCase):
         )
 
         # AFTER autofilling the transaction fee
-        escrow_finish_signed = await autofill_transaction(escrow_finish, WALLET, client)
+        escrow_finish_signed = await autofill_transaction(escrow_finish, client)
 
         # AND calculating the expected fee with the formula
         # 10 drops × (33 + (Fulfillment size in bytes ÷ 16))
@@ -265,7 +263,7 @@ class TestTransaction(IntegrationTestCase):
         )
 
         # AFTER autofilling the transaction fee
-        payment_signed = await autofill_transaction(payment, WALLET, client)
+        payment_signed = await autofill_transaction(payment, client)
 
         # THEN We expect the fee to be the default network fee (usually 10 drops)
         expected_fee = await get_fee(client)

--- a/tests/integration/sugar/test_transaction.py
+++ b/tests/integration/sugar/test_transaction.py
@@ -216,11 +216,11 @@ class TestTransaction(IntegrationTestCase):
         )
 
         # AFTER autofilling the transaction fee
-        account_delete_signed = await autofill(account_delete, client)
+        account_delete_autofilled = await autofill(account_delete, client)
 
         # THEN we expect the calculated fee to be 50 XRP (default in standalone)
         expected_fee = xrp_to_drops(50)
-        self.assertEqual(account_delete_signed.fee, expected_fee)
+        self.assertEqual(account_delete_autofilled.fee, expected_fee)
 
     @test_async_and_sync(
         globals(),
@@ -238,7 +238,7 @@ class TestTransaction(IntegrationTestCase):
         )
 
         # AFTER autofilling the transaction fee
-        escrow_finish_signed = await autofill(escrow_finish, client)
+        escrow_finish_autofilled = await autofill(escrow_finish, client)
 
         # AND calculating the expected fee with the formula
         # 10 drops × (33 + (Fulfillment size in bytes ÷ 16))
@@ -247,7 +247,7 @@ class TestTransaction(IntegrationTestCase):
         expected_fee = net_fee * (33 + len(fulfillment_in_bytes) / 16)
 
         # THEN we expect the fee to be the calculation result above
-        self.assertEqual(float(escrow_finish_signed.fee), float(expected_fee))
+        self.assertEqual(float(escrow_finish_autofilled.fee), float(expected_fee))
 
     @test_async_and_sync(
         globals(),
@@ -263,11 +263,11 @@ class TestTransaction(IntegrationTestCase):
         )
 
         # AFTER autofilling the transaction fee
-        payment_signed = await autofill(payment, client)
+        payment_autofilled = await autofill(payment, client)
 
         # THEN We expect the fee to be the default network fee (usually 10 drops)
         expected_fee = await get_fee(client)
-        self.assertEqual(payment_signed.fee, expected_fee)
+        self.assertEqual(payment_autofilled.fee, expected_fee)
 
 
 class TestReliableSubmission(IntegrationTestCase):

--- a/tests/integration/sugar/test_transaction.py
+++ b/tests/integration/sugar/test_transaction.py
@@ -13,7 +13,7 @@ from xrpl.asyncio.account import get_next_valid_seq_number
 from xrpl.asyncio.ledger import get_fee, get_latest_validated_ledger_sequence
 from xrpl.asyncio.transaction import (
     XRPLReliableSubmissionException,
-    autofill_transaction,
+    autofill,
     get_transaction_from_hash,
     safe_sign_and_autofill_transaction,
     safe_sign_transaction,
@@ -205,7 +205,7 @@ class TestTransaction(IntegrationTestCase):
         self.assertTrue(response.is_successful())
         WALLET.sequence += 1
 
-    @test_async_and_sync(globals(), ["xrpl.transaction.autofill_transaction"])
+    @test_async_and_sync(globals(), ["xrpl.transaction.autofill"])
     async def test_calculate_account_delete_fee(self, client):
         # GIVEN a new AccountDelete transaction
         account_delete = AccountDelete(
@@ -216,7 +216,7 @@ class TestTransaction(IntegrationTestCase):
         )
 
         # AFTER autofilling the transaction fee
-        account_delete_signed = await autofill_transaction(account_delete, client)
+        account_delete_signed = await autofill(account_delete, client)
 
         # THEN we expect the calculated fee to be 50 XRP (default in standalone)
         expected_fee = xrp_to_drops(50)
@@ -224,7 +224,7 @@ class TestTransaction(IntegrationTestCase):
 
     @test_async_and_sync(
         globals(),
-        ["xrpl.transaction.autofill_transaction", "xrpl.ledger.get_fee"],
+        ["xrpl.transaction.autofill", "xrpl.ledger.get_fee"],
     )
     async def test_calculate_escrow_finish_fee(self, client):
         # GIVEN a new EscrowFinish transaction
@@ -238,7 +238,7 @@ class TestTransaction(IntegrationTestCase):
         )
 
         # AFTER autofilling the transaction fee
-        escrow_finish_signed = await autofill_transaction(escrow_finish, client)
+        escrow_finish_signed = await autofill(escrow_finish, client)
 
         # AND calculating the expected fee with the formula
         # 10 drops × (33 + (Fulfillment size in bytes ÷ 16))
@@ -251,7 +251,7 @@ class TestTransaction(IntegrationTestCase):
 
     @test_async_and_sync(
         globals(),
-        ["xrpl.transaction.autofill_transaction", "xrpl.ledger.get_fee"],
+        ["xrpl.transaction.autofill", "xrpl.ledger.get_fee"],
     )
     async def test_calculate_payment_fee(self, client):
         # GIVEN a new Payment transaction
@@ -263,7 +263,7 @@ class TestTransaction(IntegrationTestCase):
         )
 
         # AFTER autofilling the transaction fee
-        payment_signed = await autofill_transaction(payment, client)
+        payment_signed = await autofill(payment, client)
 
         # THEN We expect the fee to be the default network fee (usually 10 drops)
         expected_fee = await get_fee(client)

--- a/xrpl/asyncio/transaction/__init__.py
+++ b/xrpl/asyncio/transaction/__init__.py
@@ -1,6 +1,7 @@
 """Async methods for working with transactions on the XRP Ledger."""
 from xrpl.asyncio.transaction.ledger import get_transaction_from_hash
 from xrpl.asyncio.transaction.main import (
+    autofill_transaction,
     safe_sign_and_autofill_transaction,
     safe_sign_and_submit_transaction,
     safe_sign_transaction,
@@ -13,6 +14,7 @@ from xrpl.asyncio.transaction.reliable_submission import (
 )
 
 __all__ = [
+    "autofill_transaction",
     "get_transaction_from_hash",
     "safe_sign_transaction",
     "safe_sign_and_autofill_transaction",

--- a/xrpl/asyncio/transaction/__init__.py
+++ b/xrpl/asyncio/transaction/__init__.py
@@ -1,7 +1,7 @@
 """Async methods for working with transactions on the XRP Ledger."""
 from xrpl.asyncio.transaction.ledger import get_transaction_from_hash
 from xrpl.asyncio.transaction.main import (
-    autofill_transaction,
+    autofill,
     safe_sign_and_autofill_transaction,
     safe_sign_and_submit_transaction,
     safe_sign_transaction,
@@ -14,7 +14,7 @@ from xrpl.asyncio.transaction.reliable_submission import (
 )
 
 __all__ = [
-    "autofill_transaction",
+    "autofill",
     "get_transaction_from_hash",
     "safe_sign_transaction",
     "safe_sign_and_autofill_transaction",

--- a/xrpl/asyncio/transaction/main.py
+++ b/xrpl/asyncio/transaction/main.py
@@ -108,12 +108,12 @@ async def safe_sign_and_autofill_transaction(
     """
     # We do the transaction fee check here as we have the Client available.
     # The fee check will be done if transaction.fee exists. Otherwise the fee
-    # will be auto-filled in _autofill_transaction()
+    # will be auto-filled in autofill_transaction()
     if check_fee:
         await _check_fee(transaction, client)
 
     return await safe_sign_transaction(
-        await _autofill_transaction(transaction, client), wallet, False
+        await autofill_transaction(transaction, client), wallet, False
     )
 
 
@@ -180,9 +180,19 @@ def _prepare_transaction(
     return transaction_json
 
 
-async def _autofill_transaction(
-    transaction: Transaction, client: Client
-) -> Transaction:
+async def autofill_transaction(transaction: Transaction, client: Client) -> Transaction:
+    """
+    Autofills fields in a transaction. This will set `sequence`, `fee`, and
+    `last_ledger_sequence` according to the current state of the server this Client is
+    connected to. It also converts all X-Addresses to classic addresses.
+
+    Args:
+        transaction: the transaction to be signed.
+        client: a network client.
+
+    Returns:
+        The autofilled transaction.
+    """
     transaction_json = transaction.to_dict()
     if "sequence" not in transaction_json:
         sequence = await get_next_valid_seq_number(transaction_json["account"], client)

--- a/xrpl/asyncio/transaction/main.py
+++ b/xrpl/asyncio/transaction/main.py
@@ -108,12 +108,12 @@ async def safe_sign_and_autofill_transaction(
     """
     # We do the transaction fee check here as we have the Client available.
     # The fee check will be done if transaction.fee exists. Otherwise the fee
-    # will be auto-filled in autofill_transaction()
+    # will be auto-filled in autofill()
     if check_fee:
         await _check_fee(transaction, client)
 
     return await safe_sign_transaction(
-        await autofill_transaction(transaction, client), wallet, False
+        await autofill(transaction, client), wallet, False
     )
 
 
@@ -180,7 +180,7 @@ def _prepare_transaction(
     return transaction_json
 
 
-async def autofill_transaction(transaction: Transaction, client: Client) -> Transaction:
+async def autofill(transaction: Transaction, client: Client) -> Transaction:
     """
     Autofills fields in a transaction. This will set `sequence`, `fee`, and
     `last_ledger_sequence` according to the current state of the server this Client is

--- a/xrpl/transaction/__init__.py
+++ b/xrpl/transaction/__init__.py
@@ -5,6 +5,7 @@ from xrpl.asyncio.transaction import (
 )
 from xrpl.transaction.ledger import get_transaction_from_hash
 from xrpl.transaction.main import (
+    autofill_transaction,
     safe_sign_and_autofill_transaction,
     safe_sign_and_submit_transaction,
     safe_sign_transaction,
@@ -13,6 +14,7 @@ from xrpl.transaction.main import (
 from xrpl.transaction.reliable_submission import send_reliable_submission
 
 __all__ = [
+    "autofill_transaction",
     "get_transaction_from_hash",
     "safe_sign_transaction",
     "safe_sign_and_autofill_transaction",

--- a/xrpl/transaction/__init__.py
+++ b/xrpl/transaction/__init__.py
@@ -5,7 +5,7 @@ from xrpl.asyncio.transaction import (
 )
 from xrpl.transaction.ledger import get_transaction_from_hash
 from xrpl.transaction.main import (
-    autofill_transaction,
+    autofill,
     safe_sign_and_autofill_transaction,
     safe_sign_and_submit_transaction,
     safe_sign_transaction,
@@ -14,7 +14,7 @@ from xrpl.transaction.main import (
 from xrpl.transaction.reliable_submission import send_reliable_submission
 
 __all__ = [
-    "autofill_transaction",
+    "autofill",
     "get_transaction_from_hash",
     "safe_sign_transaction",
     "safe_sign_and_autofill_transaction",

--- a/xrpl/transaction/main.py
+++ b/xrpl/transaction/main.py
@@ -120,3 +120,24 @@ def safe_sign_and_autofill_transaction(
             check_fee,
         )
     )
+
+
+def autofill_transaction(transaction: Transaction, client: SyncClient) -> Transaction:
+    """
+    Autofills fields in a transaction. This will set `sequence`, `fee`, and
+    `last_ledger_sequence` according to the current state of the server this Client is
+    connected to. It also converts all X-Addresses to classic addresses.
+
+    Args:
+        transaction: the transaction to be signed.
+        client: a network client.
+
+    Returns:
+        The autofilled transaction.
+    """
+    return asyncio.run(
+        main.autofill_transaction(
+            transaction,
+            client,
+        )
+    )

--- a/xrpl/transaction/main.py
+++ b/xrpl/transaction/main.py
@@ -122,7 +122,7 @@ def safe_sign_and_autofill_transaction(
     )
 
 
-def autofill_transaction(transaction: Transaction, client: SyncClient) -> Transaction:
+def autofill(transaction: Transaction, client: SyncClient) -> Transaction:
     """
     Autofills fields in a transaction. This will set `sequence`, `fee`, and
     `last_ledger_sequence` according to the current state of the server this Client is
@@ -136,7 +136,7 @@ def autofill_transaction(transaction: Transaction, client: SyncClient) -> Transa
         The autofilled transaction.
     """
     return asyncio.run(
-        main.autofill_transaction(
+        main.autofill(
             transaction,
             client,
         )


### PR DESCRIPTION
## High Level Overview of Change

This PR makes `_autofill_transaction` into a public method `autofill`. This exposes it to library users.

Tests were failing for some weird dependency reason, so this PR also updates some dev dependencies as well.

### Context of Change

Requested by @mDuo13 because there is only a sign-and-autofill public method, not just an autofill method.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes. Adjusted a few tests to call `autofill_transaction` directly instead of sign-and-autofill.
