### PR TITLE
feat: add sidechain-specific RPCs/sugar

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Type-check
         run: |
-          poetry run mypy --strict xrpl
+          poetry run mypy --strict --implicit-reexport xrpl
 
   unit-test:
     name: Unit test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       - id: mypy
         name: mypy
         entry: poetry run mypy
-        args: ["--strict"]
+        args: ["--strict", "--implicit-reexport"]
         language: system
         files: xrpl/
         types: [python]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [[Unreleased]]
 ### Added
 - Support setting flags with booleans. For each transaction type supporting flags there is a `FlagInterface` to set the flags with booleans.
+- `federator_info` RPC support
+- Helper method for creating a cross-chain payment to/from a sidechain
 
 ### Fixed
 - `xrpl.asyncio.clients` exports (now includes `request_to_websocket`, `websocket_to_response`)

--- a/tests/unit/utils/test_sidechain.py
+++ b/tests/unit/utils/test_sidechain.py
@@ -1,0 +1,70 @@
+from unittest import TestCase
+
+import xrpl.utils
+from xrpl.constants import XRPLException
+from xrpl.models import Memo, Payment
+
+_ACCOUNT = "r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ"
+_DESTINATION = "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"
+_AMOUNT = "10"
+
+_SIDECHAIN_DEST = "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW"
+_EXPECTED_MEMO = Memo(memo_data=xrpl.utils.str_to_hex(_SIDECHAIN_DEST))
+
+
+class TestSidechain(TestCase):
+    def test_create_cross_chain_payment_successful(self):
+        payment = Payment(account=_ACCOUNT, amount=_AMOUNT, destination=_DESTINATION)
+
+        result = xrpl.utils.create_cross_chain_payment(payment, _SIDECHAIN_DEST)
+        expected = Payment(
+            account=_ACCOUNT,
+            amount=_AMOUNT,
+            destination=_DESTINATION,
+            memos=[_EXPECTED_MEMO],
+        )
+
+        self.assertEqual(result, expected)
+
+    def test_create_cross_chain_payment_successful_memos(self):
+        memo = Memo(memo_data="deadbeef")
+        payment = Payment(
+            account=_ACCOUNT, amount=_AMOUNT, destination=_DESTINATION, memos=[memo]
+        )
+
+        result = xrpl.utils.create_cross_chain_payment(payment, _SIDECHAIN_DEST)
+        expected = Payment(
+            account=_ACCOUNT,
+            amount=_AMOUNT,
+            destination=_DESTINATION,
+            memos=[_EXPECTED_MEMO, memo],
+        )
+
+        self.assertEqual(result, expected)
+
+    def test_create_cross_chain_payment_remove_txnsignature(self):
+        payment = Payment(
+            account=_ACCOUNT,
+            amount=_AMOUNT,
+            destination=_DESTINATION,
+            txn_signature="oaisudofiasd",
+        )
+
+        result = xrpl.utils.create_cross_chain_payment(payment, _SIDECHAIN_DEST)
+        expected = Payment(
+            account=_ACCOUNT,
+            amount=_AMOUNT,
+            destination=_DESTINATION,
+            memos=[_EXPECTED_MEMO],
+        )
+
+        self.assertEqual(result, expected)
+
+    def test_create_cross_chain_payment_too_many_memos(self):
+        memo = Memo(memo_data="deadbeef")
+        payment = Payment(
+            account=_ACCOUNT, amount=_AMOUNT, destination=_DESTINATION, memos=[memo] * 3
+        )
+
+        with self.assertRaises(XRPLException):
+            xrpl.utils.create_cross_chain_payment(payment, _SIDECHAIN_DEST)

--- a/tests/unit/utils/test_time_conversions.py
+++ b/tests/unit/utils/test_time_conversions.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 import xrpl.utils
 
 
-class TestMain(TestCase):
+class TestTimeConversions(TestCase):
     def test_posix_round_trip(self):
         current_time = time.time()
         time_whole_seconds = int(current_time)

--- a/tests/unit/utils/test_xrp_conversions.py
+++ b/tests/unit/utils/test_xrp_conversions.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 import xrpl.utils
 
 
-class TestMain(TestCase):
+class TestXRPConversions(TestCase):
     def test_1_xrp(self):
         self.assertEqual(xrpl.utils.xrp_to_drops(1), "1000000")
 

--- a/xrpl/models/requests/federator_info.py
+++ b/xrpl/models/requests/federator_info.py
@@ -1,0 +1,21 @@
+"""
+The server_info command asks the server for a
+human-readable version of various information
+about the rippled server being queried.
+"""
+from dataclasses import dataclass, field
+
+from xrpl.models.requests.request import Request, RequestMethod
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class FederatorInfo(Request):
+    """
+    The federator_info command asks the federator for a
+    human-readable version of various information
+    about the federator being queried.
+    """
+
+    method: RequestMethod = field(default=RequestMethod.FEDERATOR_INFO, init=False)

--- a/xrpl/models/requests/request.py
+++ b/xrpl/models/requests/request.py
@@ -73,6 +73,9 @@ class RequestMethod(str, Enum):
     PING = "ping"
     RANDOM = "random"
 
+    # sidechain methods
+    FEDERATOR_INFO = "federator_info"
+
     # generic unknown/unsupported request
     # (there is no XRPL analog, this model is specific to xrpl-py)
     GENERIC_REQUEST = "zzgeneric_request"

--- a/xrpl/utils/__init__.py
+++ b/xrpl/utils/__init__.py
@@ -1,5 +1,6 @@
 """Convenience utilities for the XRP Ledger"""
 
+from xrpl.utils.sidechain import create_cross_chain_payment
 from xrpl.utils.str_conversions import hex_to_str, str_to_hex
 from xrpl.utils.time_conversions import (
     XRPLTimeRangeException,
@@ -21,4 +22,5 @@ __all__ = [
     "posix_to_ripple_time",
     "XRPRangeException",
     "XRPLTimeRangeException",
+    "create_cross_chain_payment",
 ]

--- a/xrpl/utils/sidechain.py
+++ b/xrpl/utils/sidechain.py
@@ -36,10 +36,10 @@ def create_cross_chain_payment(payment: Payment, dest_account: str) -> Payment:
         raise XRPLException(
             "Cannot have more than 2 memos in a cross-chain transaction."
         )
-    memos = [dest_account_memo] + memos
+    new_memos = [dest_account_memo] + memos
 
     payment_dict = payment.to_dict()
-    payment_dict["memos"] = memos
+    payment_dict["memos"] = new_memos
     if "txn_signature" in payment_dict:
         del payment_dict["txn_signature"]
     return cast(Payment, Payment.from_dict(payment_dict))

--- a/xrpl/utils/sidechain.py
+++ b/xrpl/utils/sidechain.py
@@ -13,9 +13,9 @@ def create_cross_chain_payment(payment: Payment, dest_account: str) -> Payment:
 
     Args:
         payment: The initial payment transaction. If the transaction is signed, then
-            it will need to be re-signed. There must be no more than 2 memos, since one
-            memo is used for the sidechain destination account. The destination must be
-            the sidechain's door account.
+            it will need to be re-signed. There must be no more than 2 memos, since the
+            first memo is used for the sidechain destination account. The destination
+            must be the sidechain's door account.
         dest_account: The destination account on the sidechain.
 
     Returns:

--- a/xrpl/utils/sidechain.py
+++ b/xrpl/utils/sidechain.py
@@ -1,0 +1,45 @@
+"""Sidechain-related helper util functions."""
+
+from typing import cast
+
+from xrpl.constants import XRPLException
+from xrpl.models import Memo, Payment
+from xrpl.utils.str_conversions import str_to_hex
+
+
+def create_cross_chain_payment(payment: Payment, dest_account: str) -> Payment:
+    """
+    Creates a cross-chain payment transaction.
+
+    Args:
+        payment: The initial payment transaction. If the transaction is signed, then
+            it will need to be re-signed. There must be no more than 2 memos, since one
+            memo is used for the sidechain destination account. The destination must be
+            the sidechain's door account.
+        dest_account: The destination account on the sidechain.
+
+    Returns:
+        A cross-chain payment transaction, where the mainchain door account is the
+            `Destination` and the destination account on the sidechain is encoded in
+            the memos.
+
+    Raises:
+        XRPLException: If there are more than 2 memos.
+    """
+    dest_account_memo = Memo(memo_data=str_to_hex(dest_account))
+
+    if payment.memos is None:
+        memos = []
+    else:
+        memos = payment.memos
+    if memos is not None and len(memos) > 2:
+        raise XRPLException(
+            "Cannot have more than 2 memos in a cross-chain transaction."
+        )
+    memos = [dest_account_memo] + memos
+
+    payment_dict = payment.to_dict()
+    payment_dict["memos"] = memos
+    if "txn_signature" in payment_dict:
+        del payment_dict["txn_signature"]
+    return cast(Payment, Payment.from_dict(payment_dict))


### PR DESCRIPTION
## High Level Overview of Change

This PR:
* Adds `federator_info` request and response objects
* Adds a sugar util method to create a cross-chain payment transaction from a normal payment transaction

### Context of Change

xrpl-py sidechain support

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

Added tests. CI passes.

<!--
## Future Tasks
For future tasks related to PR.
-->
