### PR TITLE
Add missing owner field to NFTokenBurn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `xrpl.asyncio.clients` exports (now includes `request_to_websocket`, `websocket_to_response`)
+- Added optional `owner` field to NFTokenBurn
 
 ## [1.4.0] - 2022-02-24
 ### Added

--- a/xrpl/models/transactions/nftoken_burn.py
+++ b/xrpl/models/transactions/nftoken_burn.py
@@ -45,8 +45,6 @@ class NFTokenBurn(Transaction):
     Indicates which account currently owns the token if it is different than
     Account. Only used to burn tokens which have the lsfBurnable flag enabled
     and are not owned by the signing account.
-
-    :meta hide-value:
     """
 
     transaction_type: TransactionType = field(

--- a/xrpl/models/transactions/nftoken_burn.py
+++ b/xrpl/models/transactions/nftoken_burn.py
@@ -1,6 +1,7 @@
 """Model for NFTokenBurn transaction type."""
 
 from dataclasses import dataclass, field
+from typing import Optional
 
 from xrpl.models.required import REQUIRED
 from xrpl.models.transactions.transaction import Transaction
@@ -35,6 +36,15 @@ class NFTokenBurn(Transaction):
     token_id: str = REQUIRED  # type: ignore
     """
     Identifies the NFToken to be burned. This field is required.
+
+    :meta hide-value:
+    """
+
+    owner: Optional[str] = None
+    """
+    Indicates which account currently owns the token if it is different than
+    Account. Only used to burn tokens which have the lsfBurnable flag enabled
+    and are not owned by the signing account.
 
     :meta hide-value:
     """


### PR DESCRIPTION
## High Level Overview of Change

Add missing Owner field to the NFTokenBurn transaction.

### Context of Change

Found thanks to this issue: https://github.com/XRPLF/xrpl.js/issues/1947

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Bug fix (non-breaking change which fixes an issue)

## Test Plan

None

<!--
## Future Tasks
For future tasks related to PR.
-->