### PR TITLE
fix: allow lower-case currency codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `xrpl.asyncio.clients` exports (now includes `request_to_websocket`, `websocket_to_response`)
-- Added optional `owner` field to NFTokenBurn
+- Adds optional `owner` field to NFTokenBurn
+- Allows lower-case currency codes
 
 ## [1.4.0] - 2022-02-24
 ### Added

--- a/tests/unit/models/currencies/test_issued_currency.py
+++ b/tests/unit/models/currencies/test_issued_currency.py
@@ -14,13 +14,12 @@ class TestIssuedCurrency(TestCase):
         )
         self.assertTrue(obj.is_valid())
 
-    def test_correct_lower_currency_code_format(self):
-        # lower case is not allowed
-        with self.assertRaises(XRPLModelException):
-            IssuedCurrency(
-                currency="usd",
-                issuer=_ACCOUNT,
-            )
+    def test_lower_currency_code_format(self):
+        obj = IssuedCurrency(
+            currency="usd",
+            issuer=_ACCOUNT,
+        )
+        self.assertTrue(obj.is_valid())
 
     def test_incorrect_currency_code_format(self):
         # the "+" is not allowed in a currency format"

--- a/xrpl/constants.py
+++ b/xrpl/constants.py
@@ -20,7 +20,7 @@ class XRPLException(Exception):
     pass
 
 
-ISO_CURRENCY_REGEX: Final[Pattern[str]] = re.compile("[A-Z0-9]{3}")
+ISO_CURRENCY_REGEX: Final[Pattern[str]] = re.compile("[A-Za-z0-9]{3}")
 """
 Matches ISO currencies like "USD" or "EUR" in the format allowed by XRPL.
 


### PR DESCRIPTION
## High Level Overview of Change

According to [the xrpl.org page on currency codes](https://xrpl.org/currency-formats.html#standard-currency-codes), we should support lower-case currency codes.

### Context of Change

Issue in the launch kit where lower-case currency codes were throwing an error.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

Relevant test was fixed.
