### PR TITLE
chore: remove before/after from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,13 +31,6 @@ Please check relevant options, delete irrelevant ones.
 - [ ] Documentation Updates
 - [ ] Release
 
-## Before / After
-
-<!--
-If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
-If a UI change, screenshots should be included.
--->
-
 ## Test Plan
 
 <!--


### PR DESCRIPTION
## High Level Overview of Change

Title says it all.

### Context of Change

We always ignore the Before/After section anyways, since there is no UI component to this repo.

### Type of Change

- [x] Documentation Updates

## Before / After

This section will soon not exist

## Test Plan

N/A
