### PR TITLE
Add util to parse an NFTokenID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support setting flags with booleans. For each transaction type supporting flags there is a `FlagInterface` to set the flags with booleans.
 - `federator_info` RPC support
 - Helper method for creating a cross-chain payment to/from a sidechain
+- Helper method for parsing an NFTokenID
 
 ### Fixed
 - `xrpl.asyncio.clients` exports (now includes `request_to_websocket`, `websocket_to_response`)

--- a/tests/unit/utils/test_parse_nftoken_id.py
+++ b/tests/unit/utils/test_parse_nftoken_id.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from unittest import TestCase
 
+from xrpl import XRPLException
 from xrpl.utils.parse_nftoken_id import parse_nftoken_id
 
 
@@ -10,7 +11,7 @@ class TestParseNFTokenID(TestCase):
     """Test parse_nftoken_id."""
 
     def test_parse_nftoken_id_successful(self: TestParseNFTokenID) -> None:
-        nft_id = "000B0539C35B55AA096BA6D87A6E6C965A6534150DC56E5E12C5D09E0000000C"  # noqa:E501
+        nft_id = "000B0539C35B55AA096BA6D87A6E6C965A6534150DC56E5E12C5D09E0000000C"
         result = parse_nftoken_id(nft_id)
         expected = {
             "token_id": nft_id,
@@ -23,5 +24,5 @@ class TestParseNFTokenID(TestCase):
         self.assertEqual(result, expected)
 
     def test_parse_nftoken_id_raises(self: TestParseNFTokenID) -> None:
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(XRPLException):
             parse_nftoken_id("ABCD")

--- a/tests/unit/utils/test_parse_nftoken_id.py
+++ b/tests/unit/utils/test_parse_nftoken_id.py
@@ -1,0 +1,27 @@
+"""Test the parse_nftoken_id util."""
+from __future__ import annotations
+
+from unittest import TestCase
+
+from xrpl.utils.parse_nftoken_id import parse_nftoken_id
+
+
+class TestParseNFTokenID(TestCase):
+    """Test parse_nftoken_id."""
+
+    def _test_parse_nftoken_id_successful(self: TestParseNFTokenID) -> None:
+        nft_id = "000B0539C35B55AA096BA6D87A6E6C965A6534150DC56E5E12C5D09E0000000C"  # noqa:E501
+        result = parse_nftoken_id(nft_id)
+        expected = {
+            "token_id": nft_id,
+            "flags": 11,
+            "transfer_fee": 1337,
+            "issuer": "rJoxBSzpXhPtAuqFmqxQtGKjA13jUJWthE",
+            "taxon": 1337,
+            "sequence": 12,
+        }
+        self.assertEqual(result, expected)
+
+    def _test_parse_nftoken_id_raises(self: TestParseNFTokenID) -> None:
+        with self.assertRaises(RuntimeError):
+            parse_nftoken_id("ABCD")

--- a/tests/unit/utils/test_parse_nftoken_id.py
+++ b/tests/unit/utils/test_parse_nftoken_id.py
@@ -9,7 +9,7 @@ from xrpl.utils.parse_nftoken_id import parse_nftoken_id
 class TestParseNFTokenID(TestCase):
     """Test parse_nftoken_id."""
 
-    def _test_parse_nftoken_id_successful(self: TestParseNFTokenID) -> None:
+    def test_parse_nftoken_id_successful(self: TestParseNFTokenID) -> None:
         nft_id = "000B0539C35B55AA096BA6D87A6E6C965A6534150DC56E5E12C5D09E0000000C"  # noqa:E501
         result = parse_nftoken_id(nft_id)
         expected = {
@@ -22,6 +22,6 @@ class TestParseNFTokenID(TestCase):
         }
         self.assertEqual(result, expected)
 
-    def _test_parse_nftoken_id_raises(self: TestParseNFTokenID) -> None:
+    def test_parse_nftoken_id_raises(self: TestParseNFTokenID) -> None:
         with self.assertRaises(RuntimeError):
             parse_nftoken_id("ABCD")

--- a/xrpl/utils/parse_nftoken_id.py
+++ b/xrpl/utils/parse_nftoken_id.py
@@ -1,6 +1,7 @@
 """Utils to parse NFTokenIDs."""
 from typing_extensions import TypedDict
 
+from xrpl.constants import XRPLException
 from xrpl.core.addresscodec.codec import encode_classic_address
 
 
@@ -69,7 +70,7 @@ def parse_nftoken_id(nft_id: str) -> NFTokenID:
         nft_id: A hex string which identifies an NFToken on the ledger.
 
     Raises:
-        RuntimeError: when given an invalid Token ID as nft_id.
+        XRPLException: when given an invalid Token ID as nft_id.
 
     Returns:
         A decoded nft TokenID with all information encoded within
@@ -79,7 +80,7 @@ def parse_nftoken_id(nft_id: str) -> NFTokenID:
     expected_length = 64
     print(len(nft_id))
     if len(nft_id) != expected_length:
-        raise RuntimeError(
+        raise XRPLException(
             f"Attempting to parse a tokenID with length"
             f" {len(nft_id)}, but expected a length of {expected_length}`"
         )

--- a/xrpl/utils/parse_nftoken_id.py
+++ b/xrpl/utils/parse_nftoken_id.py
@@ -1,5 +1,5 @@
 """Utils to parse NFTokenIDs."""
-from typing import TypedDict
+from typing_extensions import TypedDict
 
 from .str_conversions import hex_to_str  # noqa: ABS101
 

--- a/xrpl/utils/parse_nftoken_id.py
+++ b/xrpl/utils/parse_nftoken_id.py
@@ -1,7 +1,7 @@
 """Utils to parse NFTokenIDs."""
 from typing_extensions import TypedDict
 
-from .str_conversions import hex_to_str  # noqa: ABS101
+from xrpl.core.addresscodec.codec import encode_classic_address
 
 
 class NFTokenID(TypedDict):
@@ -77,20 +77,21 @@ def parse_nftoken_id(nft_id: str) -> NFTokenID:
     # noqa:E501
     """
     expected_length = 64
+    print(len(nft_id))
     if len(nft_id) != expected_length:
         raise RuntimeError(
             f"Attempting to parse a tokenID with length"
             f" {len(nft_id)}, but expected a length of {expected_length}`"
         )
 
-    scrambled_taxon = int(hex_to_str(nft_id[48:56]))
-    sequence = int(hex_to_str(nft_id[56:64]))
+    scrambled_taxon = int(nft_id[48:56], base=16)
+    sequence = int(nft_id[56:64], base=16)
 
     nftoken_data: NFTokenID = {
         "token_id": nft_id,
-        "flags": int(hex_to_str(nft_id[0:4])),
-        "transfer_fee": int(hex_to_str(nft_id[4:8])),
-        "issuer": hex_to_str(nft_id[8:48]),
+        "flags": int(nft_id[0:4], base=16),
+        "transfer_fee": int(nft_id[4:8], base=16),
+        "issuer": encode_classic_address(bytes.fromhex(nft_id[8:48])),
         "taxon": unscramble_taxon(scrambled_taxon, sequence),
         "sequence": sequence,
     }

--- a/xrpl/utils/parse_nftoken_id.py
+++ b/xrpl/utils/parse_nftoken_id.py
@@ -1,0 +1,98 @@
+"""Utils to parse NFTokenIDs."""
+from typing import TypedDict
+
+from .str_conversions import hex_to_str  # noqa: ABS101
+
+
+class NFTokenID(TypedDict):
+    """A decoded representation of info from the NFTokenID."""
+
+    token_id: str
+    flags: int
+    transfer_fee: int
+    issuer: str
+    taxon: int
+    sequence: int
+
+
+def unscramble_taxon(taxon: int, token_seq: int) -> int:
+    """
+    Unscrambles or rescrambles a taxon in an NFTokenID.
+
+    An issuer may issue several NFTs with the same taxon; to ensure that NFTs
+    are spread across multiple pages we lightly mix the taxon up by using the
+    sequence (which is not under the issuer's direct control) as the seed for
+    a simple linear congruential generator.
+
+    From the Hull-Dobell theorem we know that f(x)=(m*x+c) mod n will yield a
+    permutation of [0, n) when n is a power of 2 if m is congruent to 1 mod 4
+    and c is odd. By doing a bitwise XOR with this permutation we can
+    scramble/unscramble the taxon.
+
+    The XLS-20d proposal fixes m = 384160001 and c = 2459.
+    We then take the modulus of 2^32 which is 4294967296.
+
+    Args:
+        taxon: The scrambled or unscrambled taxon (The XOR is both the
+                encoding and decoding)
+        token_seq: The account sequence when the token was minted. Used as a
+                psuedorandom seed.
+
+    Returns:
+        The opposite taxon. If the taxon was scrambled it becomes unscrambled,
+        and vice versa.
+    """
+    return (taxon ^ (384160001 * token_seq + 2459)) % 4294967296
+
+
+def parse_nftoken_id(nft_id: str) -> NFTokenID:
+    """
+    Parse an NFTokenID into the information it is encoding.
+
+    Example decoding:
+
+    000B 0539 C35B55AA096BA6D87A6E6C965A6534150DC56E5E 12C5D09E 0000000C
+    +--- +--- +--------------------------------------- +------- +-------
+    |    |    |                                        |        |
+    |    |    |                                        |        `---> Sequence: 12
+    |    |    |                                        |
+    |    |    |                                        `---> Scrambled Taxon: 314,953,886
+    |    |    |                                              Unscrambled Taxon: 1337
+    |    |    |
+    |    |    `---> Issuer: rJoxBSzpXhPtAuqFmqxQtGKjA13jUJWthE
+    |    |
+    |    `---> TransferFee: 1337.0 bps or 13.37%
+    |
+    `---> Flags: 11 -> lsfBurnable, lsfOnlyXRP and lsfTransferable
+
+    Args:
+        nft_id: A hex string which identifies an NFToken on the ledger.
+
+    Raises:
+        RuntimeError: when given an invalid Token ID as nft_id.
+
+    Returns:
+        A decoded nft TokenID with all information encoded within
+
+    # noqa:E501
+    """
+    expected_length = 64
+    if len(nft_id) != expected_length:
+        raise RuntimeError(
+            f"Attempting to parse a tokenID with length"
+            f" {len(nft_id)}, but expected a length of {expected_length}`"
+        )
+
+    scrambled_taxon = int(hex_to_str(nft_id[48:56]))
+    sequence = int(hex_to_str(nft_id[56:64]))
+
+    nftoken_data: NFTokenID = {
+        "token_id": nft_id,
+        "flags": int(hex_to_str(nft_id[0:4])),
+        "transfer_fee": int(hex_to_str(nft_id[4:8])),
+        "issuer": hex_to_str(nft_id[8:48]),
+        "taxon": unscramble_taxon(scrambled_taxon, sequence),
+        "sequence": sequence,
+    }
+
+    return nftoken_data

--- a/xrpl/utils/parse_nftoken_id.py
+++ b/xrpl/utils/parse_nftoken_id.py
@@ -78,7 +78,6 @@ def parse_nftoken_id(nft_id: str) -> NFTokenID:
     # noqa:E501
     """
     expected_length = 64
-    print(len(nft_id))
     if len(nft_id) != expected_length:
         raise XRPLException(
             f"Attempting to parse a tokenID with length"


### PR DESCRIPTION
## High Level Overview of Change

Add a utility method to parse NFTokenIDs into a readable format.

### Context of Change

In response to #1897 

### Type of Change

- [X] New feature (non-breaking change which adds functionality)

## Test Plan

Added unit tests for this new feature.

<!--
## Future Tasks
For future tasks related to PR.
-->