### PR TITLE
Fix GenericRequest mypy typing error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Resolve `txnNotFound` error with `send_reliable_submission` when waiting for a submitted malformed transaction
+- Small typing mistake in GenericRequest
 
 ## [1.5.0] - 2022-04-25
 ### Added

--- a/xrpl/models/requests/generic_request.py
+++ b/xrpl/models/requests/generic_request.py
@@ -25,7 +25,7 @@ class GenericRequest(Request):
     :meta hide-value:
     """
 
-    def __init__(self: GenericRequest, **kwargs: Dict[str, Any]) -> None:
+    def __init__(self: GenericRequest, **kwargs: Any) -> None:
         """
         Initializes a GenericRequest.
 


### PR DESCRIPTION
## High Level Overview of Change

Fix GenericRequest typing issue. 

### Context of Change

Came up as part of sidechain dev.

According to [this StackOverflow post](https://stackoverflow.com/questions/36901/what-does-double-star-asterisk-and-star-asterisk-do-for-parameters), `**kwargs` should be typed according to an individual element that gets passed in to kwargs, instead of the overall collection of parameters. In this case, that means `Dict[str, Any]` becomes `Any`. 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Bug fix (non-breaking change which fixes an issue)

## Test Plan

CI passes

<!--
## Future Tasks
For future tasks related to PR.
-->