### PR TITLE
add better error handling for invalid client URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [[Unreleased]]
 ### Added:
 - Support for dynamic fee calculation
+- Better error handling for invalid client URL
 
 ### Fixed
 - Resolve `txnNotFound` error with `send_reliable_submission` when waiting for a submitted malformed transaction

--- a/tests/unit/clients/test_json_rpc_client.py
+++ b/tests/unit/clients/test_json_rpc_client.py
@@ -2,8 +2,8 @@
 from __future__ import annotations
 
 from unittest import TestCase
-from xrpl.asyncio.clients.exceptions import XRPLRequestFailureException
 
+from xrpl.asyncio.clients.exceptions import XRPLRequestFailureException
 from xrpl.clients import JsonRpcClient
 from xrpl.models.requests import ServerInfo
 
@@ -23,4 +23,3 @@ class TestJsonRpcClient(TestCase):
         with self.assertRaises(XRPLRequestFailureException):
             client = JsonRpcClient(JSON_RPC_URL)
             client.request(ServerInfo())
-        

--- a/tests/unit/clients/test_json_rpc_client.py
+++ b/tests/unit/clients/test_json_rpc_client.py
@@ -1,0 +1,26 @@
+"""Test the json_rpc_client."""
+from __future__ import annotations
+
+from unittest import TestCase
+from xrpl.asyncio.clients.exceptions import XRPLRequestFailureException
+
+from xrpl.clients import JsonRpcClient
+from xrpl.models.requests import ServerInfo
+
+
+class TestJsonRpcClient(TestCase):
+    """Test json_rpc_client."""
+
+    def test_json_rpc_client_valid_url(self: TestJsonRpcClient) -> None:
+        # Valid URL
+        JSON_RPC_URL = "https://s.altnet.rippletest.net:51234/"
+        client = JsonRpcClient(JSON_RPC_URL)
+        client.request(ServerInfo())
+
+    def test_json_rpc_client_invalid_url(self: TestJsonRpcClient) -> None:
+        # Invalid URL
+        JSON_RPC_URL = "https://s2.ripple.com:51233/"
+        with self.assertRaises(XRPLRequestFailureException):
+            client = JsonRpcClient(JSON_RPC_URL)
+            client.request(ServerInfo())
+        

--- a/tests/unit/clients/test_json_rpc_client.py
+++ b/tests/unit/clients/test_json_rpc_client.py
@@ -11,12 +11,6 @@ from xrpl.models.requests import ServerInfo
 class TestJsonRpcClient(TestCase):
     """Test json_rpc_client."""
 
-    def test_json_rpc_client_valid_url(self: TestJsonRpcClient) -> None:
-        # Valid URL
-        JSON_RPC_URL = "https://s.altnet.rippletest.net:51234/"
-        client = JsonRpcClient(JSON_RPC_URL)
-        client.request(ServerInfo())
-
     def test_json_rpc_client_invalid_url(self: TestJsonRpcClient) -> None:
         # Invalid URL
         JSON_RPC_URL = "https://s2.ripple.com:51233/"

--- a/xrpl/asyncio/clients/json_rpc_base.py
+++ b/xrpl/asyncio/clients/json_rpc_base.py
@@ -5,6 +5,7 @@ from httpx import AsyncClient
 from typing_extensions import Final
 
 from xrpl.asyncio.clients.client import Client
+from xrpl.asyncio.clients.exceptions import XRPLRequestFailureException
 from xrpl.asyncio.clients.utils import json_to_response, request_to_json_rpc
 from xrpl.models.requests.request import Request
 from xrpl.models.response import Response
@@ -36,4 +37,9 @@ class JsonRpcBase(Client):
                 self.url,
                 json=request_to_json_rpc(request),
             )
+            if response.status_code != 200:
+                raise XRPLRequestFailureException({
+                    'error': response.status_code,
+                    'error_message': response.text,
+                })
             return json_to_response(response.json())

--- a/xrpl/asyncio/clients/json_rpc_base.py
+++ b/xrpl/asyncio/clients/json_rpc_base.py
@@ -1,6 +1,8 @@
 """A common interface for JsonRpc requests."""
 from __future__ import annotations
 
+from json import JSONDecodeError
+
 from httpx import AsyncClient
 from typing_extensions import Final
 
@@ -30,6 +32,9 @@ class JsonRpcBase(Client):
         Returns:
             The response from the server, as a Response object.
 
+        Raises:
+            XRPLRequestFailureException: if response can't be JSON decoded.
+
         :meta private:
         """
         async with AsyncClient(timeout=_TIMEOUT) as http_client:
@@ -37,9 +42,12 @@ class JsonRpcBase(Client):
                 self.url,
                 json=request_to_json_rpc(request),
             )
-            if response.status_code != 200:
-                raise XRPLRequestFailureException({
-                    'error': response.status_code,
-                    'error_message': response.text,
-                })
-            return json_to_response(response.json())
+            try:
+                return json_to_response(response.json())
+            except JSONDecodeError:
+                raise XRPLRequestFailureException(
+                    {
+                        "error": response.status_code,
+                        "error_message": response.text,
+                    }
+                )


### PR DESCRIPTION
## High Level Overview of Change

Add better error handling for invalid client URLs.

### Context of Change

If you put in the wrong URL of a node for a client, the error that it returns is super opaque (it's a `JSONDecodeError`). We should return a better error/error message, so that it's clear that the user entered the wrong URL for the node.

This change now raises an `XRPLRequestFailureException` if the response can't be JSON decoded (`JSONDecodeError`).

https://github.com/XRPLF/xrpl-py/issues/353

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan

Added unit tests.