### PR TITLE
fix bug in GenericRequest.to_dict()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Resolve `txnNotFound` error with `send_reliable_submission` when waiting for a submitted malformed transaction
 - Small typing mistake in GenericRequest
+- Fix GenericRequest initialization bug
 
 ## [1.5.0] - 2022-04-25
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Resolve `txnNotFound` error with `send_reliable_submission` when waiting for a submitted malformed transaction
 - Small typing mistake in GenericRequest
-- Fix GenericRequest initialization bug
+- Fix bug in GenericRequest.to_dict()
 
 ## [1.5.0] - 2022-04-25
 ### Added

--- a/tests/unit/models/requests/test_requests.py
+++ b/tests/unit/models/requests/test_requests.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from xrpl.models.requests import Fee
+from xrpl.models.requests import Fee, GenericRequest
 
 
 class TestRequest(TestCase):
@@ -8,3 +8,8 @@ class TestRequest(TestCase):
         tx = Fee()
         value = tx.to_dict()["method"]
         self.assertEqual(type(value), str)
+
+    def test_generic_request_to_dict_sets_command_as_method(self):
+        command = "validator_list_sites"
+        tx = GenericRequest(command=command).to_dict()
+        self.assertDictEqual(tx, {"method": command})

--- a/xrpl/models/requests/generic_request.py
+++ b/xrpl/models/requests/generic_request.py
@@ -33,9 +33,13 @@ class GenericRequest(Request):
             kwargs: All the arguments for the request.
         """
         # initialize all the dataclass stuff
+        method = RequestMethod.GENERIC_REQUEST
+        if "command" in kwargs:
+            method = kwargs["command"]
+            del kwargs["command"]
         super().__init__(
             id=(cast(Union[str, int, None], kwargs["id"]) if "id" in kwargs else None),
-            method=RequestMethod.GENERIC_REQUEST,
+            method=method,
         )
         # pass in all the kwargs into the object (so self.key == value)
         for key, value in kwargs.items():

--- a/xrpl/models/requests/generic_request.py
+++ b/xrpl/models/requests/generic_request.py
@@ -33,13 +33,9 @@ class GenericRequest(Request):
             kwargs: All the arguments for the request.
         """
         # initialize all the dataclass stuff
-        method = RequestMethod.GENERIC_REQUEST
-        if "command" in kwargs:
-            method = kwargs["command"]
-            del kwargs["command"]
         super().__init__(
             id=(cast(Union[str, int, None], kwargs["id"]) if "id" in kwargs else None),
-            method=method,
+            method=RequestMethod.GENERIC_REQUEST,
         )
         # pass in all the kwargs into the object (so self.key == value)
         for key, value in kwargs.items():
@@ -83,8 +79,14 @@ class GenericRequest(Request):
         """
         # uses self.__dict__ instead of self.__dataclass_fields__.keys(), which is what
         # the other models do, because this model doesn't have any dataclass fields
-        return {
+        dict = {
             key: self._to_dict_elem(getattr(self, key))
             for key in self.__dict__
             if getattr(self, key) is not None
         }
+
+        if "command" in dict:
+            dict["method"] = dict["command"]
+            del dict["command"]
+
+        return dict


### PR DESCRIPTION
## High Level Overview of Change

Fix bug in `GenericRequest.to_dict()`

### Context of Change

There's an initialization bug in GenericRequest where `command` param doesn't get set to `method`:
```
>>> GenericRequest(command='validator_list_sites').to_dict()
{'method': 'zzgeneric_request', 'command': 'validator_list_sites'}
```

Correct state:
```
>>> GenericRequest(command='validator_list_sites').to_dict()
{'method': 'validator_list_sites'}
```

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan

Added unit test to check GenericRequest state after initialization.
