### PR TITLE
Fix safe_sign_transaction doc

### DIFF
--- a/xrpl/transaction/main.py
+++ b/xrpl/transaction/main.py
@@ -81,7 +81,7 @@ def safe_sign_transaction(
             type fee. Defaults to True.
 
     Returns:
-        The signed transaction blob.
+        The signed transaction.
     """
     return asyncio.run(
         main.safe_sign_transaction(


### PR DESCRIPTION
## High Level Overview of Change

The `safe_sign_transaction` function's return type description misleadingly says it returns a blob, when actually it returns an object. (The type information is correct, but the text description is wrong.)

### Type of Change

- [x] Documentation Updates

