### PR TITLE
refactor: redo binary codec types to simplify

### DIFF
--- a/tests/unit/core/binarycodec/fixtures/data/data-driven-tests.json
+++ b/tests/unit/core/binarycodec/fixtures/data/data-driven-tests.json
@@ -33,11 +33,11 @@
       "ordinal": 8
     },
     {
-      "name": "SerializedDict",
+      "name": "STObject",
       "ordinal": 14
     },
     {
-      "name": "SerializedList",
+      "name": "STArray",
       "ordinal": 15
     },
     {
@@ -736,126 +736,126 @@
       "expected_hex": "88"
     },
     {
-      "type_name": "SerializedDict",
+      "type_name": "STObject",
       "name": "ObjectEndMarker",
       "nth_of_type": 1,
       "type": 14,
       "expected_hex": "E1"
     },
     {
-      "type_name": "SerializedDict",
+      "type_name": "STObject",
       "name": "TransactionMetaData",
       "nth_of_type": 2,
       "type": 14,
       "expected_hex": "E2"
     },
     {
-      "type_name": "SerializedDict",
+      "type_name": "STObject",
       "name": "CreatedNode",
       "nth_of_type": 3,
       "type": 14,
       "expected_hex": "E3"
     },
     {
-      "type_name": "SerializedDict",
+      "type_name": "STObject",
       "name": "DeletedNode",
       "nth_of_type": 4,
       "type": 14,
       "expected_hex": "E4"
     },
     {
-      "type_name": "SerializedDict",
+      "type_name": "STObject",
       "name": "ModifiedNode",
       "nth_of_type": 5,
       "type": 14,
       "expected_hex": "E5"
     },
     {
-      "type_name": "SerializedDict",
+      "type_name": "STObject",
       "name": "PreviousFields",
       "nth_of_type": 6,
       "type": 14,
       "expected_hex": "E6"
     },
     {
-      "type_name": "SerializedDict",
+      "type_name": "STObject",
       "name": "FinalFields",
       "nth_of_type": 7,
       "type": 14,
       "expected_hex": "E7"
     },
     {
-      "type_name": "SerializedDict",
+      "type_name": "STObject",
       "name": "NewFields",
       "nth_of_type": 8,
       "type": 14,
       "expected_hex": "E8"
     },
     {
-      "type_name": "SerializedDict",
+      "type_name": "STObject",
       "name": "TemplateEntry",
       "nth_of_type": 9,
       "type": 14,
       "expected_hex": "E9"
     },
     {
-      "type_name": "SerializedDict",
+      "type_name": "STObject",
       "name": "Memo",
       "nth_of_type": 10,
       "type": 14,
       "expected_hex": "EA"
     },
     {
-      "type_name": "SerializedList",
+      "type_name": "STArray",
       "name": "ArrayEndMarker",
       "nth_of_type": 1,
       "type": 15,
       "expected_hex": "F1"
     },
     {
-      "type_name": "SerializedList",
+      "type_name": "STArray",
       "name": "Signers",
       "nth_of_type": 3,
       "type": 15,
       "expected_hex": "F3"
     },
     {
-      "type_name": "SerializedList",
+      "type_name": "STArray",
       "name": "SignerEntries",
       "nth_of_type": 4,
       "type": 15,
       "expected_hex": "F4"
     },
     {
-      "type_name": "SerializedList",
+      "type_name": "STArray",
       "name": "Template",
       "nth_of_type": 5,
       "type": 15,
       "expected_hex": "F5"
     },
     {
-      "type_name": "SerializedList",
+      "type_name": "STArray",
       "name": "Necessary",
       "nth_of_type": 6,
       "type": 15,
       "expected_hex": "F6"
     },
     {
-      "type_name": "SerializedList",
+      "type_name": "STArray",
       "name": "Sufficient",
       "nth_of_type": 7,
       "type": 15,
       "expected_hex": "F7"
     },
     {
-      "type_name": "SerializedList",
+      "type_name": "STArray",
       "name": "AffectedNodes",
       "nth_of_type": 8,
       "type": 15,
       "expected_hex": "F8"
     },
     {
-      "type_name": "SerializedList",
+      "type_name": "STArray",
       "name": "Memos",
       "nth_of_type": 9,
       "type": 15,

--- a/tests/unit/core/binarycodec/types/test_serialized_dict.py
+++ b/tests/unit/core/binarycodec/types/test_serialized_dict.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from xrpl.core.binarycodec.binary_wrappers.binary_parser import BinaryParser
-from xrpl.core.binarycodec.types.serialized_dict import SerializedDict
+from xrpl.core.binarycodec.types.st_object import STObject
 
 expected_json = {
     "Account": "raD5qJMAShLeHZXf9wjUmo6vRK4arj9cF3",
@@ -37,18 +37,18 @@ buffer = (
 )
 
 
-class TestSerializedDict(TestCase):
+class TestSTObject(TestCase):
     maxDiff = 1000
 
     def test_from_value(self):
-        transaction = SerializedDict.from_value(expected_json)
+        transaction = STObject.from_value(expected_json)
         self.assertEqual(buffer, str(transaction).upper())
 
     def test_from_value_to_json(self):
-        transaction = SerializedDict.from_value(expected_json)
+        transaction = STObject.from_value(expected_json)
         self.assertEqual(transaction.to_json(), expected_json)
 
     def test_from_parser_to_json(self):
         parser = BinaryParser(buffer)
-        transaction = SerializedDict.from_parser(parser)
+        transaction = STObject.from_parser(parser)
         self.assertEqual(transaction.to_json(), expected_json)

--- a/tests/unit/core/binarycodec/types/test_serialized_list.py
+++ b/tests/unit/core/binarycodec/types/test_serialized_list.py
@@ -2,10 +2,7 @@ from unittest import TestCase
 
 from xrpl.core.binarycodec.binary_wrappers.binary_parser import BinaryParser
 from xrpl.core.binarycodec.exceptions import XRPLBinaryCodecException
-from xrpl.core.binarycodec.types.serialized_list import (
-    _ARRAY_END_MARKER,
-    SerializedList,
-)
+from xrpl.core.binarycodec.types.st_array import _ARRAY_END_MARKER, STArray
 
 MEMO = {
     "Memo": {
@@ -22,43 +19,43 @@ EXPECTED_JSON = [MEMO, MEMO]
 BUFFER = MEMO_HEX + MEMO_HEX + _ARRAY_END_MARKER.hex().upper()
 
 
-class TestSerializedList(TestCase):
+class TestSTArray(TestCase):
     maxDiff = 1000
 
     def test_from_value(self):
-        serialized_list = SerializedList.from_value(EXPECTED_JSON)
+        serialized_list = STArray.from_value(EXPECTED_JSON)
         self.assertEqual(BUFFER, str(serialized_list))
 
     def test_from_parser(self):
         parser = BinaryParser(BUFFER)
-        serialized_list = SerializedList.from_parser(parser)
+        serialized_list = STArray.from_parser(parser)
         self.assertEqual(BUFFER, str(serialized_list))
 
     def test_from_value_to_json(self):
-        serialized_list = SerializedList.from_value(EXPECTED_JSON)
+        serialized_list = STArray.from_value(EXPECTED_JSON)
         actual_json = serialized_list.to_json()
         self.assertEqual(actual_json[0], actual_json[1])
         self.assertEqual(actual_json, EXPECTED_JSON)
 
     def test_from_parser_to_json(self):
         parser = BinaryParser(BUFFER)
-        serialized_list = SerializedList.from_parser(parser)
+        serialized_list = STArray.from_parser(parser)
         self.assertEqual(serialized_list.to_json(), EXPECTED_JSON)
 
     def test_from_value_non_list(self):
         obj = 123
         with self.assertRaises(XRPLBinaryCodecException):
-            SerializedList.from_value(obj)
+            STArray.from_value(obj)
 
     def test_from_value_bad_list(self):
         obj = [123]
         with self.assertRaises(XRPLBinaryCodecException):
-            SerializedList.from_value(obj)
+            STArray.from_value(obj)
 
     def test_raises_invalid_value_type(self):
         invalid_value = 1
         self.assertRaises(
             XRPLBinaryCodecException,
-            SerializedList.from_value,
+            STArray.from_value,
             invalid_value,
         )

--- a/xrpl/core/binarycodec/definitions/field_instance.py
+++ b/xrpl/core/binarycodec/definitions/field_instance.py
@@ -21,39 +21,15 @@ def _get_type_by_name(name: str) -> Type[SerializedType]:
     Returns:
         The corresponding class object.
     """
-    from xrpl.core.binarycodec.types.account_id import AccountID
-    from xrpl.core.binarycodec.types.amount import Amount
-    from xrpl.core.binarycodec.types.blob import Blob
-    from xrpl.core.binarycodec.types.currency import Currency
-    from xrpl.core.binarycodec.types.hash128 import Hash128
-    from xrpl.core.binarycodec.types.hash160 import Hash160
-    from xrpl.core.binarycodec.types.hash256 import Hash256
-    from xrpl.core.binarycodec.types.path_set import PathSet
-    from xrpl.core.binarycodec.types.serialized_dict import SerializedDict
-    from xrpl.core.binarycodec.types.serialized_list import SerializedList
-    from xrpl.core.binarycodec.types.uint8 import UInt8
-    from xrpl.core.binarycodec.types.uint16 import UInt16
-    from xrpl.core.binarycodec.types.uint32 import UInt32
-    from xrpl.core.binarycodec.types.uint64 import UInt64
-    from xrpl.core.binarycodec.types.vector256 import Vector256
+    import xrpl.core.binarycodec.types as types
 
     type_map: Dict[str, Type[SerializedType]] = {
-        "AccountID": AccountID,
-        "Amount": Amount,
-        "Blob": Blob,
-        "Currency": Currency,
-        "Hash128": Hash128,
-        "Hash160": Hash160,
-        "Hash256": Hash256,
-        "PathSet": PathSet,
-        "STArray": SerializedList,
-        "STObject": SerializedDict,
-        "UInt8": UInt8,
-        "UInt16": UInt16,
-        "UInt32": UInt32,
-        "UInt64": UInt64,
-        "Vector256": Vector256,
+        name: object_type
+        for (name, object_type) in types.__dict__.items()
+        if name in types.__all__
     }
+    type_map["STObject"] = types.SerializedDict
+    type_map["STArray"] = types.SerializedList
 
     return type_map[name]
 

--- a/xrpl/core/binarycodec/definitions/field_instance.py
+++ b/xrpl/core/binarycodec/definitions/field_instance.py
@@ -28,7 +28,6 @@ def _get_type_by_name(name: str) -> Type[SerializedType]:
         for (name, object_type) in types.__dict__.items()
         if name in types.__all__
     }
-    type_map["STArray"] = types.SerializedList
 
     return type_map[name]
 

--- a/xrpl/core/binarycodec/definitions/field_instance.py
+++ b/xrpl/core/binarycodec/definitions/field_instance.py
@@ -28,7 +28,6 @@ def _get_type_by_name(name: str) -> Type[SerializedType]:
         for (name, object_type) in types.__dict__.items()
         if name in types.__all__
     }
-    type_map["STObject"] = types.SerializedDict
     type_map["STArray"] = types.SerializedList
 
     return type_map[name]

--- a/xrpl/core/binarycodec/main.py
+++ b/xrpl/core/binarycodec/main.py
@@ -10,7 +10,7 @@ from typing_extensions import Final
 from xrpl.core.binarycodec.binary_wrappers.binary_parser import BinaryParser
 from xrpl.core.binarycodec.types.account_id import AccountID
 from xrpl.core.binarycodec.types.hash256 import Hash256
-from xrpl.core.binarycodec.types.serialized_dict import SerializedDict
+from xrpl.core.binarycodec.types.st_object import STObject
 from xrpl.core.binarycodec.types.uint64 import UInt64
 
 
@@ -108,7 +108,7 @@ def decode(buffer: str) -> Dict[str, Any]:
         A JSON-like dictionary representation of the transaction.
     """
     parser = BinaryParser(buffer)
-    parsed_type = cast(SerializedDict, parser.read_type(SerializedDict))
+    parsed_type = cast(STObject, parser.read_type(STObject))
     return parsed_type.to_json()
 
 
@@ -122,7 +122,7 @@ def _serialize_json(
     if prefix is not None:
         buffer += prefix
 
-    buffer += bytes(SerializedDict.from_value(json, signing_only))
+    buffer += bytes(STObject.from_value(json, signing_only))
 
     if suffix is not None:
         buffer += suffix

--- a/xrpl/core/binarycodec/types/__init__.py
+++ b/xrpl/core/binarycodec/types/__init__.py
@@ -8,8 +8,8 @@ from xrpl.core.binarycodec.types.hash128 import Hash128
 from xrpl.core.binarycodec.types.hash160 import Hash160
 from xrpl.core.binarycodec.types.hash256 import Hash256
 from xrpl.core.binarycodec.types.path_set import PathSet
-from xrpl.core.binarycodec.types.serialized_dict import SerializedDict
 from xrpl.core.binarycodec.types.serialized_list import SerializedList
+from xrpl.core.binarycodec.types.st_object import STObject
 from xrpl.core.binarycodec.types.uint import UInt
 from xrpl.core.binarycodec.types.uint8 import UInt8
 from xrpl.core.binarycodec.types.uint16 import UInt16
@@ -27,7 +27,7 @@ __all__ = [
     "Hash160",
     "Hash256",
     "PathSet",
-    "SerializedDict",
+    "STObject",
     "SerializedList",
     "UInt",
     "UInt8",

--- a/xrpl/core/binarycodec/types/__init__.py
+++ b/xrpl/core/binarycodec/types/__init__.py
@@ -8,7 +8,7 @@ from xrpl.core.binarycodec.types.hash128 import Hash128
 from xrpl.core.binarycodec.types.hash160 import Hash160
 from xrpl.core.binarycodec.types.hash256 import Hash256
 from xrpl.core.binarycodec.types.path_set import PathSet
-from xrpl.core.binarycodec.types.serialized_list import SerializedList
+from xrpl.core.binarycodec.types.st_array import STArray
 from xrpl.core.binarycodec.types.st_object import STObject
 from xrpl.core.binarycodec.types.uint import UInt
 from xrpl.core.binarycodec.types.uint8 import UInt8
@@ -28,7 +28,7 @@ __all__ = [
     "Hash256",
     "PathSet",
     "STObject",
-    "SerializedList",
+    "STArray",
     "UInt",
     "UInt8",
     "UInt16",

--- a/xrpl/core/binarycodec/types/__init__.py
+++ b/xrpl/core/binarycodec/types/__init__.py
@@ -8,7 +8,8 @@ from xrpl.core.binarycodec.types.hash128 import Hash128
 from xrpl.core.binarycodec.types.hash160 import Hash160
 from xrpl.core.binarycodec.types.hash256 import Hash256
 from xrpl.core.binarycodec.types.path_set import PathSet
-from xrpl.core.binarycodec.types.serialized_type import SerializedType
+from xrpl.core.binarycodec.types.serialized_dict import SerializedDict
+from xrpl.core.binarycodec.types.serialized_list import SerializedList
 from xrpl.core.binarycodec.types.uint import UInt
 from xrpl.core.binarycodec.types.uint8 import UInt8
 from xrpl.core.binarycodec.types.uint16 import UInt16
@@ -26,7 +27,8 @@ __all__ = [
     "Hash160",
     "Hash256",
     "PathSet",
-    "SerializedType",
+    "SerializedDict",
+    "SerializedList",
     "UInt",
     "UInt8",
     "UInt16",

--- a/xrpl/core/binarycodec/types/serialized_list.py
+++ b/xrpl/core/binarycodec/types/serialized_list.py
@@ -10,8 +10,8 @@ from typing_extensions import Final
 
 from xrpl.core.binarycodec.binary_wrappers.binary_parser import BinaryParser
 from xrpl.core.binarycodec.exceptions import XRPLBinaryCodecException
-from xrpl.core.binarycodec.types.serialized_dict import SerializedDict
 from xrpl.core.binarycodec.types.serialized_type import SerializedType
+from xrpl.core.binarycodec.types.st_object import STObject
 
 _ARRAY_END_MARKER: Final[bytes] = bytes([0xF1])
 _ARRAY_END_MARKER_NAME: Final[str] = "ArrayEndMarker"
@@ -80,7 +80,7 @@ class SerializedList(SerializedType):
 
         bytestring = b""
         for obj in value:
-            transaction = SerializedDict.from_value(obj)
+            transaction = STObject.from_value(obj)
             bytestring += bytes(transaction)
         bytestring += _ARRAY_END_MARKER
         return SerializedList(bytestring)
@@ -101,6 +101,6 @@ class SerializedList(SerializedType):
                 break
 
             outer = {}
-            outer[field.name] = SerializedDict.from_parser(parser).to_json()
+            outer[field.name] = STObject.from_parser(parser).to_json()
             result.append(outer)
         return result

--- a/xrpl/core/binarycodec/types/serialized_type.py
+++ b/xrpl/core/binarycodec/types/serialized_type.py
@@ -2,7 +2,11 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Type
+from typing import TYPE_CHECKING, Any, Type
+
+if TYPE_CHECKING:
+    # To prevent a circular dependency.
+    from xrpl.core.binarycodec.binary_wrappers.binary_parser import BinaryParser
 
 
 class SerializedType(ABC):
@@ -16,8 +20,7 @@ class SerializedType(ABC):
     @abstractmethod
     def from_parser(  # noqa: D102
         cls: Type[SerializedType],
-        # TODO: Resolve Any (can't be ``BinaryParser`` because of circular imports)
-        parser: Any,
+        parser: BinaryParser,
         # length_hint is Any so that subclasses can choose whether or not to require it.
         length_hint: Any,
     ) -> SerializedType:

--- a/xrpl/core/binarycodec/types/st_array.py
+++ b/xrpl/core/binarycodec/types/st_array.py
@@ -19,25 +19,25 @@ _ARRAY_END_MARKER_NAME: Final[str] = "ArrayEndMarker"
 _OBJECT_END_MARKER: Final[bytes] = bytes([0xE1])
 
 
-class SerializedList(SerializedType):
+class STArray(SerializedType):
     """Class for serializing and deserializing Lists of objects.
     See `Array Fields <https://xrpl.org/serialization.html#array-fields>`_
     """
 
     @classmethod
     def from_parser(
-        cls: Type[SerializedList],
+        cls: Type[STArray],
         parser: BinaryParser,
         _length_hint: Optional[None] = None,
-    ) -> SerializedList:
+    ) -> STArray:
         """
-        Construct a SerializedList from a BinaryParser.
+        Construct a STArray from a BinaryParser.
 
         Args:
-            parser: The parser to construct a SerializedList from.
+            parser: The parser to construct a STArray from.
 
         Returns:
-            The SerializedList constructed from parser.
+            The STArray constructed from parser.
         """
         bytestring = b""
 
@@ -50,18 +50,18 @@ class SerializedList(SerializedType):
             bytestring += _OBJECT_END_MARKER
 
         bytestring += _ARRAY_END_MARKER
-        return SerializedList(bytestring)
+        return STArray(bytestring)
 
     @classmethod
-    def from_value(cls: Type[SerializedList], value: List[Any]) -> SerializedList:
+    def from_value(cls: Type[STArray], value: List[Any]) -> STArray:
         """
-        Create a SerializedList object from a dictionary.
+        Create a STArray object from a dictionary.
 
         Args:
-            value: The dictionary to construct a SerializedList from.
+            value: The dictionary to construct a STArray from.
 
         Returns:
-            The SerializedList object constructed from value.
+            The STArray object constructed from value.
 
         Raises:
             XRPLBinaryCodecException: If the provided value isn't a list or contains
@@ -69,13 +69,13 @@ class SerializedList(SerializedType):
         """
         if not isinstance(value, list):
             raise XRPLBinaryCodecException(
-                "Invalid type to construct a SerializedList:"
+                "Invalid type to construct a STArray:"
                 " expected list, received {value.__class__.__name__}."
             )
 
         if len(value) > 0 and not isinstance(value[0], dict):
             raise XRPLBinaryCodecException(
-                ("Cannot construct SerializedList from a list of non-dict" " objects")
+                ("Cannot construct STArray from a list of non-dict" " objects")
             )
 
         bytestring = b""
@@ -83,14 +83,14 @@ class SerializedList(SerializedType):
             transaction = STObject.from_value(obj)
             bytestring += bytes(transaction)
         bytestring += _ARRAY_END_MARKER
-        return SerializedList(bytestring)
+        return STArray(bytestring)
 
-    def to_json(self: SerializedList) -> List[Any]:
+    def to_json(self: STArray) -> List[Any]:
         """
-        Returns the JSON representation of a SerializedList.
+        Returns the JSON representation of a STArray.
 
         Returns:
-            The JSON representation of a SerializedList.
+            The JSON representation of a STArray.
         """
         result = []
         parser = BinaryParser(str(self))

--- a/xrpl/core/binarycodec/types/st_object.py
+++ b/xrpl/core/binarycodec/types/st_object.py
@@ -23,7 +23,7 @@ from xrpl.core.binarycodec.types.serialized_type import SerializedType
 
 _OBJECT_END_MARKER_BYTE: Final[bytes] = bytes([0xE1])
 _OBJECT_END_MARKER: Final[str] = "ObjectEndMarker"
-_SERIALIZED_DICT: Final[str] = "STObject"
+_ST_OBJECT: Final[str] = "STObject"
 _DESTINATION: Final[str] = "Destination"
 _ACCOUNT: Final[str] = "Account"
 _SOURCE_TAG: Final[str] = "SourceTag"
@@ -81,23 +81,23 @@ def _enum_to_str(field: str, value: Any) -> Any:
     return value
 
 
-class SerializedDict(SerializedType):
+class STObject(SerializedType):
     """Class for serializing/deserializing Dicts of objects."""
 
     @classmethod
     def from_parser(
-        cls: Type[SerializedDict],
+        cls: Type[STObject],
         parser: BinaryParser,
         _length_hint: Optional[None] = None,
-    ) -> SerializedDict:
+    ) -> STObject:
         """
-        Construct a SerializedDict from a BinaryParser.
+        Construct a STObject from a BinaryParser.
 
         Args:
-            parser: The parser to construct a SerializedDict from.
+            parser: The parser to construct a STObject from.
 
         Returns:
-            The SerializedDict constructed from parser.
+            The STObject constructed from parser.
         """
         from xrpl.core.binarycodec.binary_wrappers.binary_serializer import (
             BinarySerializer,
@@ -112,27 +112,27 @@ class SerializedDict(SerializedType):
 
             associated_value = parser.read_field_value(field)
             serializer.write_field_and_value(field, associated_value)
-            if field.type == _SERIALIZED_DICT:
+            if field.type == _ST_OBJECT:
                 serializer.append(_OBJECT_END_MARKER_BYTE)
 
-        return SerializedDict(bytes(serializer))
+        return STObject(bytes(serializer))
 
     @classmethod
     def from_value(
-        cls: Type[SerializedDict], value: Dict[str, Any], only_signing: bool = False
-    ) -> SerializedDict:
+        cls: Type[STObject], value: Dict[str, Any], only_signing: bool = False
+    ) -> STObject:
         """
-        Create a SerializedDict object from a dictionary.
+        Create a STObject object from a dictionary.
 
         Args:
-            value: The dictionary to construct a SerializedDict from.
+            value: The dictionary to construct a STObject from.
             only_signing: whether only the signing fields should be included.
 
         Returns:
-            The SerializedDict object constructed from value.
+            The STObject object constructed from value.
 
         Raises:
-            XRPLBinaryCodecException: If the SerializedDict can't be constructed
+            XRPLBinaryCodecException: If the STObject can't be constructed
                 from value.
         """
         from xrpl.core.binarycodec.binary_wrappers.binary_serializer import (
@@ -212,17 +212,17 @@ class SerializedDict(SerializedType):
             serializer.write_field_and_value(
                 field, associated_value, is_unl_modify_workaround
             )
-            if field.type == _SERIALIZED_DICT:
+            if field.type == _ST_OBJECT:
                 serializer.append(_OBJECT_END_MARKER_BYTE)
 
-        return SerializedDict(bytes(serializer))
+        return STObject(bytes(serializer))
 
-    def to_json(self: SerializedDict) -> Dict[str, Any]:
+    def to_json(self: STObject) -> Dict[str, Any]:
         """
-        Returns the JSON representation of a SerializedDict.
+        Returns the JSON representation of a STObject.
 
         Returns:
-            The JSON representation of a SerializedDict.
+            The JSON representation of a STObject.
         """
         parser = BinaryParser(str(self))
         accumulator = {}


### PR DESCRIPTION
## High Level Overview of Change

This PR:
* Fixes a typing issue with the binary parser that was caused by a circular dependency (which we now know how to resolve)
* Renames `SerializedDict` -> `STObject` and `SerializedList` -> `STArray` (to match rippled names)
* Refactors the list of types in `FieldInstance` to pull directly from `xrpl.core.binarycodec.types`, so that doesn't need to be edited every time a new type is added

There are no feature changes here; this is just an internal refactor.

### Context of Change

I was adding some new types to the binary codec and thought that needing to add them in 2 places was unnecessary. I fixed a few other things to make the binary codecs more analogous as well.

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

## Test Plan

CI passes. Tests that test the internal objects were edited to use the new type names (the methods exposed externally have not changed at all).