### PR TITLE
Add final balances parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [[Unreleased]]
+### Added:
+- Add function to parse the final account balances from a transaction's metadata
 
 ## [1.6.0] - 2022-06-02
 ### Added:

--- a/tests/unit/utils/txn_parser/test_get_final_balances.py
+++ b/tests/unit/utils/txn_parser/test_get_final_balances.py
@@ -32,8 +32,8 @@ with open(path_to_json + "trustline_set_limit2.json", "r") as infile:
     trustline_set_limit2 = json.load(infile)
 
 
-class TestGetBalanceChanges(TestCase):
-    def test_payment_iou_destination_no_balance(self: TestGetBalanceChanges):
+class TestGetFinalBalances(TestCase):
+    def test_payment_iou_destination_no_balance(self: TestGetFinalBalances):
         actual = get_final_balances(payment_iou_destination_no_balance["meta"])
         expected = [
             {
@@ -75,7 +75,7 @@ class TestGetBalanceChanges(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_payment_iou_multipath(self: TestGetBalanceChanges):
+    def test_payment_iou_multipath(self: TestGetFinalBalances):
         actual = get_final_balances(payment_iou_multipath["meta"])
         expected = [
             {
@@ -135,7 +135,7 @@ class TestGetBalanceChanges(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_payment_iou_redeem_then_issue(self: TestGetBalanceChanges):
+    def test_payment_iou_redeem_then_issue(self: TestGetFinalBalances):
         actual = get_final_balances(payment_iou_redeem_then_issue["meta"])
         expected = [
             {
@@ -162,7 +162,7 @@ class TestGetBalanceChanges(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_payment_iou_redeem(self: TestGetBalanceChanges):
+    def test_payment_iou_redeem(self: TestGetFinalBalances):
         actual = get_final_balances(payment_iou_redeem["meta"])
         expected = [
             {
@@ -189,7 +189,7 @@ class TestGetBalanceChanges(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_payment_iou_spend_full_balance(self: TestGetBalanceChanges):
+    def test_payment_iou_spend_full_balance(self: TestGetFinalBalances):
         actual = get_final_balances(payment_iou_spend_full_balance["meta"])
         expected = [
             {
@@ -219,7 +219,7 @@ class TestGetBalanceChanges(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_payment_iou(self: TestGetBalanceChanges):
+    def test_payment_iou(self: TestGetFinalBalances):
         actual = get_final_balances(payment_iou["meta"])
         expected = [
             {
@@ -261,7 +261,7 @@ class TestGetBalanceChanges(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_payment_xrp_create_account(self: TestGetBalanceChanges):
+    def test_payment_xrp_create_account(self: TestGetFinalBalances):
         actual = get_final_balances(payment_xrp_create_account["meta"])
         expected = [
             {
@@ -275,7 +275,7 @@ class TestGetBalanceChanges(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_trustline_create(self: TestGetBalanceChanges):
+    def test_trustline_create(self: TestGetFinalBalances):
         actual = get_final_balances(trustline_create["meta"])
         expected = [
             {
@@ -302,7 +302,7 @@ class TestGetBalanceChanges(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_trustline_delete(self: TestGetBalanceChanges):
+    def test_trustline_delete(self: TestGetFinalBalances):
         actual = get_final_balances(trustline_delete["meta"])
         expected = [
             {
@@ -332,7 +332,7 @@ class TestGetBalanceChanges(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_trustline_set_limit_zero(self: TestGetBalanceChanges):
+    def test_trustline_set_limit_zero(self: TestGetFinalBalances):
         actual = get_final_balances(trustline_set_limit_zero["meta"])
         expected = [
             {
@@ -359,7 +359,7 @@ class TestGetBalanceChanges(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_trustline_set_limit(self: TestGetBalanceChanges):
+    def test_trustline_set_limit(self: TestGetFinalBalances):
         actual = get_final_balances(trustline_set_limit["meta"])
         expected = [
             {
@@ -386,7 +386,7 @@ class TestGetBalanceChanges(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_trustline_set_limit2(self: TestGetBalanceChanges):
+    def test_trustline_set_limit2(self: TestGetFinalBalances):
         actual = get_final_balances(trustline_set_limit2["meta"])
         expected = [
             {

--- a/tests/unit/utils/txn_parser/test_get_final_balances.py
+++ b/tests/unit/utils/txn_parser/test_get_final_balances.py
@@ -1,0 +1,457 @@
+from __future__ import annotations
+
+import json
+from unittest import TestCase
+
+from xrpl.utils import get_final_balances
+
+path_to_json = "tests/unit/utils/txn_parser/transaction_jsons/"
+with open(path_to_json + "payment_iou_destination_no_balance.json", "r") as infile:
+    payment_iou_destination_no_balance = json.load(infile)
+with open(path_to_json + "payment_iou_multipath.json", "r") as infile:
+    payment_iou_multipath = json.load(infile)
+with open(path_to_json + "payment_iou_redeem_then_issue.json", "r") as infile:
+    payment_iou_redeem_then_issue = json.load(infile)
+with open(path_to_json + "payment_iou_redeem.json", "r") as infile:
+    payment_iou_redeem = json.load(infile)
+with open(path_to_json + "payment_iou_spend_full_balance.json", "r") as infile:
+    payment_iou_spend_full_balance = json.load(infile)
+with open(path_to_json + "payment_iou.json", "r") as infile:
+    payment_iou = json.load(infile)
+with open(path_to_json + "payment_xrp_create_account.json", "r") as infile:
+    payment_xrp_create_account = json.load(infile)
+with open(path_to_json + "trustline_create.json", "r") as infile:
+    trustline_create = json.load(infile)
+with open(path_to_json + "trustline_delete.json", "r") as infile:
+    trustline_delete = json.load(infile)
+with open(path_to_json + "trustline_set_limit_zero.json", "r") as infile:
+    trustline_set_limit_zero = json.load(infile)
+with open(path_to_json + "trustline_set_limit.json", "r") as infile:
+    trustline_set_limit = json.load(infile)
+with open(path_to_json + "trustline_set_limit2.json", "r") as infile:
+    trustline_set_limit2 = json.load(infile)
+
+
+class TestGetBalanceChanges(TestCase):
+    def test_payment_iou_destination_no_balance(self: TestGetBalanceChanges):
+        actual = get_final_balances(payment_iou_destination_no_balance["meta"])
+        expected = [
+            {
+                "account": "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
+                "balances": [
+                    {
+                        "currency": "USD",
+                        "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+                        "value": "1.535330905250352"
+                    },
+                    {
+                        "currency": "XRP",
+                        "value": "239.807992"
+                    }
+                ]
+            },
+            {
+                "account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+                "balances": [
+                    {
+                        "currency": "USD",
+                        "issuer": "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
+                        "value": "-1.535330905250352"
+                    },
+                    {
+                        "currency": "USD",
+                        "issuer": "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+                        "value": "-0.01"
+                    }
+                ]
+            },
+            {
+                "account": "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+                "balances": [
+                    {
+                        "currency": "USD",
+                        "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+                        "value": "0.01"
+                    }
+                ]
+            }
+        ]
+        self.assertEqual(actual, expected)
+
+    def test_payment_iou_multipath(self: TestGetBalanceChanges):
+        actual = get_final_balances(payment_iou_multipath["meta"])
+        expected = [
+            {
+                "account": "r4nmQNH4Fhjfh6cHDbvVSsBv7KySbj4cBf",
+                "balances": [
+                    {
+                        "currency": "XRP",
+                        "value": "999.99999"
+                    }
+                ]
+            },
+            {
+                "account": "rnYDWQaRdMb5neCGgvFfhw3MBoxmv5LtfH",
+                "balances": [
+                    {
+                        "currency": "USD",
+                        "issuer": "rJsaPnGdeo7BhMnHjuc3n44Mf7Ra1qkSVJ",
+                        "value": "100"
+                    },
+                    {
+                        "currency": "USD",
+                        "issuer": "rrnsYgWn13Z28GtRgznrSUsLfMkvsXCZSu",
+                        "value": "100"
+                    },
+                    {
+                        "currency": "USD",
+                        "issuer": "rGpeQzUWFu4fMhJHZ1Via5aqFC3A5twZUD",
+                        "value": "100"
+                    }
+                ]
+            },
+            {
+                "account": "rJsaPnGdeo7BhMnHjuc3n44Mf7Ra1qkSVJ",
+                "balances": [
+                    {
+                        "currency": "USD",
+                        "issuer": "rnYDWQaRdMb5neCGgvFfhw3MBoxmv5LtfH",
+                        "value": "-100"
+                    }
+                ]
+            },
+            {
+                "account": "rrnsYgWn13Z28GtRgznrSUsLfMkvsXCZSu",
+                "balances": [
+                    {
+                        "currency": "USD",
+                        "issuer": "rnYDWQaRdMb5neCGgvFfhw3MBoxmv5LtfH",
+                        "value": "-100"
+                    }
+                ]
+            },
+            {
+                "account": "rGpeQzUWFu4fMhJHZ1Via5aqFC3A5twZUD",
+                "balances": [
+                    {
+                        "currency": "USD",
+                        "issuer": "rnYDWQaRdMb5neCGgvFfhw3MBoxmv5LtfH",
+                        "value": "-100"
+                    }
+                ]
+            }
+        ]
+        self.assertEqual(actual, expected)
+
+    def test_payment_iou_redeem_then_issue(self: TestGetBalanceChanges):
+        actual = get_final_balances(payment_iou_redeem_then_issue["meta"])
+        expected = [
+            {
+                "account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+                "balances": [
+                    {
+                        "currency": "USD",
+                        "issuer": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+                        "value": "100"
+                    }
+                ]
+            },
+            {
+                "account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+                "balances": [
+                    {
+                        "currency": "USD",
+                        "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+                        "value": "-100"
+                    },
+                    {
+                        "currency": "XRP",
+                        "value": "999.99997"
+                    }
+                ]
+            }
+        ]
+        self.assertEqual(actual, expected)
+
+    def test_payment_iou_redeem(self: TestGetBalanceChanges):
+        actual = get_final_balances(payment_iou_redeem["meta"])
+        expected = [
+            {
+                "account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+                "balances": [
+                    {
+                        "currency": "USD",
+                        "issuer": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+                        "value": "-100"
+                    }
+                ]
+            },
+            {
+                "account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+                "balances": [
+                    {
+                        "currency": "USD",
+                        "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+                        "value": "100"
+                    },
+                    {
+                        "currency": "XRP",
+                        "value": "999.99998"
+                    }
+                ]
+            }
+        ]
+        self.assertEqual(actual, expected)
+
+    def test_payment_iou_spend_full_balance(self: TestGetBalanceChanges):
+        actual = get_final_balances(payment_iou_spend_full_balance["meta"])
+        expected = [
+            {
+                "account": "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
+                "balances": [
+                    {
+                        "currency": "USD",
+                        "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+                        "value": "1.545330905250352"
+                    }
+                ]
+            },
+            {
+                "account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+                "balances": [
+                    {
+                        "currency": "USD",
+                        "issuer": "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
+                        "value": "-1.545330905250352"
+                    }
+                ]
+            },
+            {
+                "account": "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+                "balances": [
+                    {
+                        "currency": "XRP",
+                        "value": "99.976002"
+                    }
+                ]
+            }
+        ]
+        self.assertEqual(actual, expected)
+
+    def test_payment_iou(self: TestGetBalanceChanges):
+        actual = get_final_balances(payment_iou["meta"])
+        expected = [
+            {
+                "account": "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
+                "balances": [
+                    {
+                        "currency": "USD",
+                        "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+                        "value": "1.525330905250352"
+                    },
+                    {
+                        "currency": "XRP",
+                        "value": "239.555992"
+                    }
+                ]
+            },
+            {
+                "account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+                "balances": [
+                    {
+                        "currency": "USD",
+                        "issuer": "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
+                        "value": "-1.525330905250352"
+                    },
+                    {
+                        "currency": "USD",
+                        "issuer": "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+                        "value": "-0.02"
+                    }
+                ]
+            },
+            {
+                "account": "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+                "balances": [
+                    {
+                        "currency": "USD",
+                        "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+                        "value": "0.02"
+                    }
+                ]
+            }
+        ]
+        self.assertEqual(actual, expected)
+
+    def test_payment_xrp_create_account(self: TestGetBalanceChanges):
+        actual = get_final_balances(payment_xrp_create_account["meta"])
+        expected = [
+            {
+                "account": "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+                "balances": [
+                    {
+                        "currency": "XRP",
+                        "value": "100"
+                    }
+                ]
+            },
+            {
+                "account": "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
+                "balances": [
+                    {
+                        "currency": "XRP",
+                        "value": "339.903994"
+                    }
+                ]
+            }
+        ]
+        self.assertEqual(actual, expected)
+
+    def test_trustline_create(self: TestGetBalanceChanges):
+        actual = get_final_balances(trustline_create["meta"])
+        expected = [
+            {
+                "account": "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+                "balances": [
+                    {
+                        "currency": "USD",
+                        "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+                        "value": "10"
+                    },
+                    {
+                        "currency": "XRP",
+                        "value": "99.740302"
+                    }
+                ]
+            },
+            {
+                "account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+                "balances": [
+                    {
+                        "currency": "USD",
+                        "issuer": "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+                        "value": "-10"
+                    }
+                ]
+            }
+        ]
+        self.assertEqual(actual, expected)
+
+    def test_trustline_delete(self: TestGetBalanceChanges):
+        actual = get_final_balances(trustline_delete["meta"])
+        expected = [
+            {
+                "account": "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
+                "balances": [
+                    {
+                        "currency": "USD",
+                        "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+                        "value": "1.545330905250352"
+                    }
+                ]
+            },
+            {
+                "account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+                "balances": [
+                    {
+                        "currency": "USD",
+                        "issuer": "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
+                        "value": "-1.545330905250352"
+                    }
+                ]
+            },
+            {
+                "account": "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+                "balances": [
+                    {
+                        "currency": "XRP",
+                        "value": "99.752302"
+                    }
+                ]
+            }
+        ]
+        self.assertEqual(actual, expected)
+
+    def test_trustline_set_limit_zero(self: TestGetBalanceChanges):
+        actual = get_final_balances(trustline_set_limit_zero["meta"])
+        expected = [
+            {
+                "account": "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+                "balances": [
+                    {
+                        "currency": "USD",
+                        "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+                        "value": "0.02"
+                    },
+                    {
+                        "currency": "XRP",
+                        "value": "99.940002"
+                    }
+                ]
+            },
+            {
+                "account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+                "balances": [
+                    {
+                        "currency": "USD",
+                        "issuer": "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+                        "value": "-0.02"
+                    }
+                ]
+            }
+        ]
+        self.assertEqual(actual, expected)
+
+    def test_trustline_set_limit(self: TestGetBalanceChanges):
+        actual = get_final_balances(trustline_set_limit["meta"])
+        expected = [
+            {
+                "account": "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+                "balances": [
+                    {
+                        "currency": "USD",
+                        "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+                        "value": "0.02"
+                    },
+                    {
+                        "currency": "XRP",
+                        "value": "99.884302"
+                    }
+                ]
+            },
+            {
+                "account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+                "balances": [
+                    {
+                        "currency": "USD",
+                        "issuer": "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+                        "value": "-0.02"
+                    }
+                ]
+            }
+        ]
+        self.assertEqual(actual, expected)
+
+    def test_trustline_set_limit2(self: TestGetBalanceChanges):
+        actual = get_final_balances(trustline_set_limit2["meta"])
+        expected = [
+            {
+                "account": "rsApBGKJmMfExxZBrGnzxEXyq7TMhMRg4e",
+                "balances": [
+                    {
+                        "currency": "XRP",
+                        "value": "9248.902096"
+                    }
+                ]
+            },
+            {
+                "account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+                "balances": [
+                    {
+                        "currency": "XRP",
+                        "value": "149.99998"
+                    }
+                ]
+            }
+        ]
+        self.assertEqual(actual, expected)

--- a/tests/unit/utils/txn_parser/test_get_final_balances.py
+++ b/tests/unit/utils/txn_parser/test_get_final_balances.py
@@ -42,13 +42,10 @@ class TestGetBalanceChanges(TestCase):
                     {
                         "currency": "USD",
                         "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
-                        "value": "1.535330905250352"
+                        "value": "1.535330905250352",
                     },
-                    {
-                        "currency": "XRP",
-                        "value": "239.807992"
-                    }
-                ]
+                    {"currency": "XRP", "value": "239.807992"},
+                ],
             },
             {
                 "account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
@@ -56,14 +53,14 @@ class TestGetBalanceChanges(TestCase):
                     {
                         "currency": "USD",
                         "issuer": "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
-                        "value": "-1.535330905250352"
+                        "value": "-1.535330905250352",
                     },
                     {
                         "currency": "USD",
                         "issuer": "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
-                        "value": "-0.01"
-                    }
-                ]
+                        "value": "-0.01",
+                    },
+                ],
             },
             {
                 "account": "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
@@ -71,10 +68,10 @@ class TestGetBalanceChanges(TestCase):
                     {
                         "currency": "USD",
                         "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
-                        "value": "0.01"
+                        "value": "0.01",
                     }
-                ]
-            }
+                ],
+            },
         ]
         self.assertEqual(actual, expected)
 
@@ -83,12 +80,7 @@ class TestGetBalanceChanges(TestCase):
         expected = [
             {
                 "account": "r4nmQNH4Fhjfh6cHDbvVSsBv7KySbj4cBf",
-                "balances": [
-                    {
-                        "currency": "XRP",
-                        "value": "999.99999"
-                    }
-                ]
+                "balances": [{"currency": "XRP", "value": "999.99999"}],
             },
             {
                 "account": "rnYDWQaRdMb5neCGgvFfhw3MBoxmv5LtfH",
@@ -96,19 +88,19 @@ class TestGetBalanceChanges(TestCase):
                     {
                         "currency": "USD",
                         "issuer": "rJsaPnGdeo7BhMnHjuc3n44Mf7Ra1qkSVJ",
-                        "value": "100"
+                        "value": "100",
                     },
                     {
                         "currency": "USD",
                         "issuer": "rrnsYgWn13Z28GtRgznrSUsLfMkvsXCZSu",
-                        "value": "100"
+                        "value": "100",
                     },
                     {
                         "currency": "USD",
                         "issuer": "rGpeQzUWFu4fMhJHZ1Via5aqFC3A5twZUD",
-                        "value": "100"
-                    }
-                ]
+                        "value": "100",
+                    },
+                ],
             },
             {
                 "account": "rJsaPnGdeo7BhMnHjuc3n44Mf7Ra1qkSVJ",
@@ -116,9 +108,9 @@ class TestGetBalanceChanges(TestCase):
                     {
                         "currency": "USD",
                         "issuer": "rnYDWQaRdMb5neCGgvFfhw3MBoxmv5LtfH",
-                        "value": "-100"
+                        "value": "-100",
                     }
-                ]
+                ],
             },
             {
                 "account": "rrnsYgWn13Z28GtRgznrSUsLfMkvsXCZSu",
@@ -126,9 +118,9 @@ class TestGetBalanceChanges(TestCase):
                     {
                         "currency": "USD",
                         "issuer": "rnYDWQaRdMb5neCGgvFfhw3MBoxmv5LtfH",
-                        "value": "-100"
+                        "value": "-100",
                     }
-                ]
+                ],
             },
             {
                 "account": "rGpeQzUWFu4fMhJHZ1Via5aqFC3A5twZUD",
@@ -136,10 +128,10 @@ class TestGetBalanceChanges(TestCase):
                     {
                         "currency": "USD",
                         "issuer": "rnYDWQaRdMb5neCGgvFfhw3MBoxmv5LtfH",
-                        "value": "-100"
+                        "value": "-100",
                     }
-                ]
-            }
+                ],
+            },
         ]
         self.assertEqual(actual, expected)
 
@@ -152,9 +144,9 @@ class TestGetBalanceChanges(TestCase):
                     {
                         "currency": "USD",
                         "issuer": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
-                        "value": "100"
+                        "value": "100",
                     }
-                ]
+                ],
             },
             {
                 "account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
@@ -162,14 +154,11 @@ class TestGetBalanceChanges(TestCase):
                     {
                         "currency": "USD",
                         "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
-                        "value": "-100"
+                        "value": "-100",
                     },
-                    {
-                        "currency": "XRP",
-                        "value": "999.99997"
-                    }
-                ]
-            }
+                    {"currency": "XRP", "value": "999.99997"},
+                ],
+            },
         ]
         self.assertEqual(actual, expected)
 
@@ -182,9 +171,9 @@ class TestGetBalanceChanges(TestCase):
                     {
                         "currency": "USD",
                         "issuer": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
-                        "value": "-100"
+                        "value": "-100",
                     }
-                ]
+                ],
             },
             {
                 "account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
@@ -192,14 +181,11 @@ class TestGetBalanceChanges(TestCase):
                     {
                         "currency": "USD",
                         "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
-                        "value": "100"
+                        "value": "100",
                     },
-                    {
-                        "currency": "XRP",
-                        "value": "999.99998"
-                    }
-                ]
-            }
+                    {"currency": "XRP", "value": "999.99998"},
+                ],
+            },
         ]
         self.assertEqual(actual, expected)
 
@@ -212,9 +198,9 @@ class TestGetBalanceChanges(TestCase):
                     {
                         "currency": "USD",
                         "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
-                        "value": "1.545330905250352"
+                        "value": "1.545330905250352",
                     }
-                ]
+                ],
             },
             {
                 "account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
@@ -222,19 +208,14 @@ class TestGetBalanceChanges(TestCase):
                     {
                         "currency": "USD",
                         "issuer": "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
-                        "value": "-1.545330905250352"
+                        "value": "-1.545330905250352",
                     }
-                ]
+                ],
             },
             {
                 "account": "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
-                "balances": [
-                    {
-                        "currency": "XRP",
-                        "value": "99.976002"
-                    }
-                ]
-            }
+                "balances": [{"currency": "XRP", "value": "99.976002"}],
+            },
         ]
         self.assertEqual(actual, expected)
 
@@ -247,13 +228,10 @@ class TestGetBalanceChanges(TestCase):
                     {
                         "currency": "USD",
                         "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
-                        "value": "1.525330905250352"
+                        "value": "1.525330905250352",
                     },
-                    {
-                        "currency": "XRP",
-                        "value": "239.555992"
-                    }
-                ]
+                    {"currency": "XRP", "value": "239.555992"},
+                ],
             },
             {
                 "account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
@@ -261,14 +239,14 @@ class TestGetBalanceChanges(TestCase):
                     {
                         "currency": "USD",
                         "issuer": "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
-                        "value": "-1.525330905250352"
+                        "value": "-1.525330905250352",
                     },
                     {
                         "currency": "USD",
                         "issuer": "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
-                        "value": "-0.02"
-                    }
-                ]
+                        "value": "-0.02",
+                    },
+                ],
             },
             {
                 "account": "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
@@ -276,10 +254,10 @@ class TestGetBalanceChanges(TestCase):
                     {
                         "currency": "USD",
                         "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
-                        "value": "0.02"
+                        "value": "0.02",
                     }
-                ]
-            }
+                ],
+            },
         ]
         self.assertEqual(actual, expected)
 
@@ -288,22 +266,12 @@ class TestGetBalanceChanges(TestCase):
         expected = [
             {
                 "account": "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
-                "balances": [
-                    {
-                        "currency": "XRP",
-                        "value": "100"
-                    }
-                ]
+                "balances": [{"currency": "XRP", "value": "100"}],
             },
             {
                 "account": "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
-                "balances": [
-                    {
-                        "currency": "XRP",
-                        "value": "339.903994"
-                    }
-                ]
-            }
+                "balances": [{"currency": "XRP", "value": "339.903994"}],
+            },
         ]
         self.assertEqual(actual, expected)
 
@@ -316,13 +284,10 @@ class TestGetBalanceChanges(TestCase):
                     {
                         "currency": "USD",
                         "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
-                        "value": "10"
+                        "value": "10",
                     },
-                    {
-                        "currency": "XRP",
-                        "value": "99.740302"
-                    }
-                ]
+                    {"currency": "XRP", "value": "99.740302"},
+                ],
             },
             {
                 "account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
@@ -330,10 +295,10 @@ class TestGetBalanceChanges(TestCase):
                     {
                         "currency": "USD",
                         "issuer": "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
-                        "value": "-10"
+                        "value": "-10",
                     }
-                ]
-            }
+                ],
+            },
         ]
         self.assertEqual(actual, expected)
 
@@ -346,9 +311,9 @@ class TestGetBalanceChanges(TestCase):
                     {
                         "currency": "USD",
                         "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
-                        "value": "1.545330905250352"
+                        "value": "1.545330905250352",
                     }
-                ]
+                ],
             },
             {
                 "account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
@@ -356,19 +321,14 @@ class TestGetBalanceChanges(TestCase):
                     {
                         "currency": "USD",
                         "issuer": "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
-                        "value": "-1.545330905250352"
+                        "value": "-1.545330905250352",
                     }
-                ]
+                ],
             },
             {
                 "account": "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
-                "balances": [
-                    {
-                        "currency": "XRP",
-                        "value": "99.752302"
-                    }
-                ]
-            }
+                "balances": [{"currency": "XRP", "value": "99.752302"}],
+            },
         ]
         self.assertEqual(actual, expected)
 
@@ -381,13 +341,10 @@ class TestGetBalanceChanges(TestCase):
                     {
                         "currency": "USD",
                         "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
-                        "value": "0.02"
+                        "value": "0.02",
                     },
-                    {
-                        "currency": "XRP",
-                        "value": "99.940002"
-                    }
-                ]
+                    {"currency": "XRP", "value": "99.940002"},
+                ],
             },
             {
                 "account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
@@ -395,10 +352,10 @@ class TestGetBalanceChanges(TestCase):
                     {
                         "currency": "USD",
                         "issuer": "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
-                        "value": "-0.02"
+                        "value": "-0.02",
                     }
-                ]
-            }
+                ],
+            },
         ]
         self.assertEqual(actual, expected)
 
@@ -411,13 +368,10 @@ class TestGetBalanceChanges(TestCase):
                     {
                         "currency": "USD",
                         "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
-                        "value": "0.02"
+                        "value": "0.02",
                     },
-                    {
-                        "currency": "XRP",
-                        "value": "99.884302"
-                    }
-                ]
+                    {"currency": "XRP", "value": "99.884302"},
+                ],
             },
             {
                 "account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
@@ -425,10 +379,10 @@ class TestGetBalanceChanges(TestCase):
                     {
                         "currency": "USD",
                         "issuer": "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
-                        "value": "-0.02"
+                        "value": "-0.02",
                     }
-                ]
-            }
+                ],
+            },
         ]
         self.assertEqual(actual, expected)
 
@@ -437,21 +391,11 @@ class TestGetBalanceChanges(TestCase):
         expected = [
             {
                 "account": "rsApBGKJmMfExxZBrGnzxEXyq7TMhMRg4e",
-                "balances": [
-                    {
-                        "currency": "XRP",
-                        "value": "9248.902096"
-                    }
-                ]
+                "balances": [{"currency": "XRP", "value": "9248.902096"}],
             },
             {
                 "account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
-                "balances": [
-                    {
-                        "currency": "XRP",
-                        "value": "149.99998"
-                    }
-                ]
-            }
+                "balances": [{"currency": "XRP", "value": "149.99998"}],
+            },
         ]
         self.assertEqual(actual, expected)

--- a/xrpl/utils/__init__.py
+++ b/xrpl/utils/__init__.py
@@ -9,7 +9,7 @@ from xrpl.utils.time_conversions import (
     ripple_time_to_datetime,
     ripple_time_to_posix,
 )
-from xrpl.utils.txn_parser import get_balance_changes
+from xrpl.utils.txn_parser import get_balance_changes, get_final_balances
 from xrpl.utils.xrp_conversions import XRPRangeException, drops_to_xrp, xrp_to_drops
 
 __all__ = [
@@ -25,4 +25,5 @@ __all__ = [
     "XRPLTimeRangeException",
     "create_cross_chain_payment",
     "get_balance_changes",
+    "get_final_balances",
 ]

--- a/xrpl/utils/txn_parser/__init__.py
+++ b/xrpl/utils/txn_parser/__init__.py
@@ -1,5 +1,6 @@
 """Functions to parse a transaction."""
 
 from xrpl.utils.txn_parser.get_balance_changes import get_balance_changes
+from xrpl.utils.txn_parser.get_final_balances import get_final_balances
 
-__all__ = ["get_balance_changes"]
+__all__ = ["get_balance_changes", "get_final_balances"]

--- a/xrpl/utils/txn_parser/get_balance_changes.py
+++ b/xrpl/utils/txn_parser/get_balance_changes.py
@@ -5,14 +5,14 @@ from typing import List, Optional
 
 from xrpl.models import TransactionMetadata
 from xrpl.utils.txn_parser.utils import (
-    ComputedBalances,
+    AccountBalances,
     NormalizedNode,
     derive_account_balances,
     get_value,
 )
 
 
-def get_balance_changes(metadata: TransactionMetadata) -> List[ComputedBalances]:
+def get_balance_changes(metadata: TransactionMetadata) -> List[AccountBalances]:
     """
     Parse all balance changes from a transaction's metadata.
 

--- a/xrpl/utils/txn_parser/get_balance_changes.py
+++ b/xrpl/utils/txn_parser/get_balance_changes.py
@@ -7,10 +7,8 @@ from xrpl.models import TransactionMetadata
 from xrpl.utils.txn_parser.utils import (
     ComputedBalances,
     NormalizedNode,
-    get_node_balance,
+    derive_account_balances,
     get_value,
-    group_by_account,
-    normalize_nodes,
 )
 
 
@@ -25,12 +23,7 @@ def get_balance_changes(metadata: TransactionMetadata) -> List[ComputedBalances]
         All balance changes caused by a transaction.
         The balance changes are grouped by the affected account addresses.
     """
-    quantities = [
-        quantity
-        for node in normalize_nodes(metadata)
-        for quantity in get_node_balance(node, _compute_balance_change(node))
-    ]
-    return group_by_account(quantities)
+    return derive_account_balances(metadata, _compute_balance_change)
 
 
 def _compute_balance_change(node: NormalizedNode) -> Optional[Decimal]:

--- a/xrpl/utils/txn_parser/get_balance_changes.py
+++ b/xrpl/utils/txn_parser/get_balance_changes.py
@@ -5,16 +5,16 @@ from typing import List, Optional
 
 from xrpl.models import TransactionMetadata
 from xrpl.utils.txn_parser.utils import (
-    BalanceChanges,
-    get_node_balance_changes,
+    ComputedBalances,
+    NormalizedNode,
+    get_node_balance,
     get_value,
     group_by_account,
     normalize_nodes,
 )
-from xrpl.utils.txn_parser.utils.nodes import NormalizedNode
 
 
-def get_balance_changes(metadata: TransactionMetadata) -> List[BalanceChanges]:
+def get_balance_changes(metadata: TransactionMetadata) -> List[ComputedBalances]:
     """
     Parse all balance changes from a transaction's metadata.
 
@@ -28,7 +28,7 @@ def get_balance_changes(metadata: TransactionMetadata) -> List[BalanceChanges]:
     quantities = [
         quantity
         for node in normalize_nodes(metadata)
-        for quantity in get_node_balance_changes(node, _compute_balance_change(node))
+        for quantity in get_node_balance(node, _compute_balance_change(node))
     ]
     return group_by_account(quantities)
 

--- a/xrpl/utils/txn_parser/get_final_balances.py
+++ b/xrpl/utils/txn_parser/get_final_balances.py
@@ -1,0 +1,59 @@
+"""Parse final balances of every account involved in the given transaction."""
+
+from decimal import Decimal
+from typing import List, Optional
+
+from xrpl.models import TransactionMetadata
+from xrpl.utils.txn_parser.utils import (
+    ComputedBalances,
+    NormalizedNode,
+    get_node_balance,
+    get_value,
+    group_by_account,
+    normalize_nodes,
+)
+
+
+def get_final_balances(metadata: TransactionMetadata) -> List[ComputedBalances]:
+    """
+    Parse all final balances from a transaction's metadata.
+
+    Args:
+        metadata: Transactions metadata.
+
+    Returns:
+        All final balances caused by a transaction.
+        The final balances are grouped by the affected account addresses.
+    """
+    quantities = [
+        quantity
+        for node in normalize_nodes(metadata)
+        for quantity in get_node_balance(node, _compute_final_balance(node))
+    ]
+    return group_by_account(quantities)
+
+
+def _compute_final_balance(node: NormalizedNode) -> Optional[Decimal]:
+    """
+    Get the final balance from a node.
+
+    Args:
+        node: The affected node.
+
+    Returns:
+        The final balance.
+    """
+    value: Optional[Decimal] = None
+    new_fields = node.get("NewFields")
+    final_fields = node.get("FinalFields")
+    if new_fields is not None:
+        balance = new_fields.get("Balance")
+        if balance is not None:
+            value = get_value(balance)
+    elif final_fields is not None:
+        balance = final_fields.get("Balance")
+        if balance is not None:
+            value = get_value(balance)
+    if value is None or value == Decimal(0):
+        return None
+    return value

--- a/xrpl/utils/txn_parser/get_final_balances.py
+++ b/xrpl/utils/txn_parser/get_final_balances.py
@@ -7,10 +7,8 @@ from xrpl.models import TransactionMetadata
 from xrpl.utils.txn_parser.utils import (
     ComputedBalances,
     NormalizedNode,
-    get_node_balance,
+    derive_account_balances,
     get_value,
-    group_by_account,
-    normalize_nodes,
 )
 
 
@@ -25,12 +23,7 @@ def get_final_balances(metadata: TransactionMetadata) -> List[ComputedBalances]:
         All final balances caused by a transaction.
         The final balances are grouped by the affected account addresses.
     """
-    quantities = [
-        quantity
-        for node in normalize_nodes(metadata)
-        for quantity in get_node_balance(node, _compute_final_balance(node))
-    ]
-    return group_by_account(quantities)
+    return derive_account_balances(metadata, _compute_final_balance)
 
 
 def _compute_final_balance(node: NormalizedNode) -> Optional[Decimal]:

--- a/xrpl/utils/txn_parser/get_final_balances.py
+++ b/xrpl/utils/txn_parser/get_final_balances.py
@@ -5,14 +5,14 @@ from typing import List, Optional
 
 from xrpl.models import TransactionMetadata
 from xrpl.utils.txn_parser.utils import (
-    ComputedBalances,
+    AccountBalances,
     NormalizedNode,
     derive_account_balances,
     get_value,
 )
 
 
-def get_final_balances(metadata: TransactionMetadata) -> List[ComputedBalances]:
+def get_final_balances(metadata: TransactionMetadata) -> List[AccountBalances]:
     """
     Parse all final balances from a transaction's metadata.
 

--- a/xrpl/utils/txn_parser/utils/__init__.py
+++ b/xrpl/utils/txn_parser/utils/__init__.py
@@ -1,17 +1,15 @@
 """Utility functions for the transaction parser."""
 
 from xrpl.utils.txn_parser.utils.balance_parser import (
-    get_node_balance,
+    derive_account_balances,
     get_value,
-    group_by_account,
 )
 from xrpl.utils.txn_parser.utils.nodes import NormalizedNode, normalize_nodes
 from xrpl.utils.txn_parser.utils.types import ComputedBalances
 
 __all__ = [
-    "get_node_balance",
     "get_value",
-    "group_by_account",
+    "derive_account_balances",
     "NormalizedNode",
     "normalize_nodes",
     "ComputedBalances",

--- a/xrpl/utils/txn_parser/utils/__init__.py
+++ b/xrpl/utils/txn_parser/utils/__init__.py
@@ -1,17 +1,18 @@
 """Utility functions for the transaction parser."""
 
 from xrpl.utils.txn_parser.utils.balance_parser import (
-    get_node_balance_changes,
+    get_node_balance,
     get_value,
     group_by_account,
 )
-from xrpl.utils.txn_parser.utils.nodes import normalize_nodes
-from xrpl.utils.txn_parser.utils.types import BalanceChanges
+from xrpl.utils.txn_parser.utils.nodes import NormalizedNode, normalize_nodes
+from xrpl.utils.txn_parser.utils.types import ComputedBalances
 
 __all__ = [
-    "get_node_balance_changes",
+    "get_node_balance",
     "get_value",
     "group_by_account",
+    "NormalizedNode",
     "normalize_nodes",
-    "BalanceChanges",
+    "ComputedBalances",
 ]

--- a/xrpl/utils/txn_parser/utils/__init__.py
+++ b/xrpl/utils/txn_parser/utils/__init__.py
@@ -5,12 +5,12 @@ from xrpl.utils.txn_parser.utils.balance_parser import (
     get_value,
 )
 from xrpl.utils.txn_parser.utils.nodes import NormalizedNode, normalize_nodes
-from xrpl.utils.txn_parser.utils.types import ComputedBalances
+from xrpl.utils.txn_parser.utils.types import AccountBalances
 
 __all__ = [
     "get_value",
     "derive_account_balances",
     "NormalizedNode",
     "normalize_nodes",
-    "ComputedBalances",
+    "AccountBalances",
 ]

--- a/xrpl/utils/txn_parser/utils/balance_parser.py
+++ b/xrpl/utils/txn_parser/utils/balance_parser.py
@@ -45,15 +45,15 @@ def _get_xrp_quantity(
     return None
 
 
-def _flip_trustline_perspective(balance_change: ComputedBalance) -> ComputedBalance:
-    balance = balance_change["balance"]
+def _flip_trustline_perspective(computed_balance: ComputedBalance) -> ComputedBalance:
+    balance = computed_balance["balance"]
     negated_value = Decimal(balance["value"]).copy_negate()
     issuer = balance["issuer"]
     return ComputedBalance(
         account=issuer,
         balance=Balance(
             currency=balance["currency"],
-            issuer=balance_change["account"],
+            issuer=computed_balance["account"],
             value=f"{negated_value.normalize():f}",
         ),
     )
@@ -64,15 +64,14 @@ def _get_trustline_quantity(
     value: Optional[Decimal],
 ) -> List[ComputedBalance]:
     """
-    Computes the complete list of every balance that changed in the ledger
-    as a result of the given transaction.
+    Computes the complete list of every balance affected by the transaction.
 
     Args:
         node: The affected node.
         value: The currency amount value.
 
     Returns:
-        A list of balance changes.
+        A list of computed balances.
     """
     if value is None:
         return []
@@ -105,16 +104,16 @@ def _get_trustline_quantity(
     return []
 
 
-def _group_balance_changes(
-    balance_changes: List[ComputedBalance],
+def _group_balance(
+    computed_balances: List[ComputedBalance],
 ) -> Dict[str, List[ComputedBalance]]:
-    grouped_balance_changes: Dict[str, List[ComputedBalance]] = {}
-    for change in balance_changes:
-        account = change["account"]
-        if account not in grouped_balance_changes:
-            grouped_balance_changes[account] = []
-        grouped_balance_changes[account].append(change)
-    return grouped_balance_changes
+    grouped_balances: Dict[str, List[ComputedBalance]] = {}
+    for balance in computed_balances:
+        account = balance["account"]
+        if account not in grouped_balances:
+            grouped_balances[account] = []
+        grouped_balances[account].append(balance)
+    return grouped_balances
 
 
 def get_value(balance: Union[Dict[str, str], str]) -> Decimal:
@@ -158,18 +157,18 @@ def get_node_balance(
 
 
 def group_by_account(
-    balance_changes: List[ComputedBalance],
+    computed_balance: List[ComputedBalance],
 ) -> List[ComputedBalances]:
     """
-    Groups the balance changes in one list for each account.
+    Groups the computed balances in one list for each account.
 
     Args:
-        balance_changes: All balance changes cause by a transaction.
+        computed_balance: All computed balances cause by a transaction.
 
     Returns:
-        The grouped balance changes.
+        The grouped computed balances.
     """
-    grouped = _group_balance_changes(balance_changes)
+    grouped = _group_balance(computed_balance)
     result = []
     for account, account_balances in grouped.items():
         balances: List[Balance] = []

--- a/xrpl/utils/txn_parser/utils/types.py
+++ b/xrpl/utils/txn_parser/utils/types.py
@@ -26,7 +26,7 @@ class Balance(OptionalIssuer):
 
 
 class AccountBalance(TypedDict):
-    """A single computed balance."""
+    """A single account balance."""
 
     account: str
     """The affected account."""
@@ -34,8 +34,8 @@ class AccountBalance(TypedDict):
     """The balance."""
 
 
-class ComputedBalances(TypedDict):
-    """A model representing an account's computed balances."""
+class AccountBalances(TypedDict):
+    """A model representing an account's balances."""
 
     account: str
     balances: List[Balance]

--- a/xrpl/utils/txn_parser/utils/types.py
+++ b/xrpl/utils/txn_parser/utils/types.py
@@ -25,7 +25,7 @@ class Balance(OptionalIssuer):
     """The amount of the currency."""
 
 
-class ComputedBalance(TypedDict):
+class AccountBalance(TypedDict):
     """A single computed balance."""
 
     account: str

--- a/xrpl/utils/txn_parser/utils/types.py
+++ b/xrpl/utils/txn_parser/utils/types.py
@@ -25,17 +25,17 @@ class Balance(OptionalIssuer):
     """The amount of the currency."""
 
 
-class BalanceChange(TypedDict):
-    """A single balance change."""
+class ComputedBalance(TypedDict):
+    """A single computed balance."""
 
     account: str
     """The affected account."""
     balance: Balance
-    """The balance change."""
+    """The balance."""
 
 
-class BalanceChanges(TypedDict):
-    """A model representing an account's balance changes."""
+class ComputedBalances(TypedDict):
+    """A model representing an account's computed balances."""
 
     account: str
     balances: List[Balance]


### PR DESCRIPTION
## High Level Overview of Change

- Add  and export `get_final_balances`
- Add `_compute_final_balance`
- Export `NormalizedNode`
- Change `BalanceChange` to `ComputedBalance`
- Change `BalanceChanges` to `ComputedBalances`
- Generally renamed some terms (function names and args) that indicate to only deal with balance changes. Now indicating to deal with computed balances.

### Context of Change

The https://github.com/XRPLF/xrpl-py/pull/342 PR was splitted. For each exported function (get_balance_changes (already merged #383), get_final_balances, get_previous_balances and get_order_book_changes) there will now be a separate PR to make it easier to review. This PR adds the functionality to parse the final balances from a transaction's metadata (get_final_balances).

### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Test Plan

I added tests that are testing the same transactions as `get_balance_changes`.

<!--
## Future Tasks
For future tasks related to PR.
-->
