### PR TITLE
fix: properly encode transactions in signing requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed:
 - Typing for factory classmethods on models
 
+### Fixed:
+- Use properly encoded transactions in `Sign`, `SignFor`, and `SignAndSubmit`
+
 ## [1.6.0] - 2022-06-02
 ### Added:
 - Support for dynamic fee calculation

--- a/tests/unit/models/test_base_model.py
+++ b/tests/unit/models/test_base_model.py
@@ -122,7 +122,7 @@ class TestFromDict(TestCase):
 
         expected_dict = {
             **sign_dict,
-            "tx_json": transaction.to_dict(),
+            "tx_json": transaction.to_xrpl(),
             "method": "sign",
             "fee_mult_max": 10,
             "fee_div_max": 1,
@@ -138,7 +138,7 @@ class TestFromDict(TestCase):
 
         expected_dict = {
             **sign_dict,
-            "tx_json": transaction.to_dict(),
+            "tx_json": transaction.to_xrpl(),
             "method": "sign",
             "fee_mult_max": 10,
             "fee_div_max": 1,

--- a/xrpl/models/requests/sign.py
+++ b/xrpl/models/requests/sign.py
@@ -92,7 +92,7 @@ class Sign(Request):
         """
         return_dict = super().to_dict()
         del return_dict["transaction"]
-        return_dict["tx_json"] = self.transaction.to_dict()
+        return_dict["tx_json"] = self.transaction.to_xrpl()
         return return_dict
 
     def _get_errors(self: Sign) -> Dict[str, str]:

--- a/xrpl/models/requests/sign_and_submit.py
+++ b/xrpl/models/requests/sign_and_submit.py
@@ -101,7 +101,7 @@ class SignAndSubmit(Submit):
         """
         return_dict = super().to_dict()
         del return_dict["transaction"]
-        return_dict["tx_json"] = self.transaction.to_dict()
+        return_dict["tx_json"] = self.transaction.to_xrpl()
         return return_dict
 
     def _get_errors(self: SignAndSubmit) -> Dict[str, str]:

--- a/xrpl/models/requests/sign_for.py
+++ b/xrpl/models/requests/sign_for.py
@@ -83,7 +83,7 @@ class SignFor(Request):
         """
         return_dict = super().to_dict()
         del return_dict["transaction"]
-        return_dict["tx_json"] = self.transaction.to_dict()
+        return_dict["tx_json"] = self.transaction.to_xrpl()
         return return_dict
 
     def _get_errors(self: SignFor) -> Dict[str, str]:


### PR DESCRIPTION
## High Level Overview of Change

This PR replaces the use of `to_dict` with `to_xrpl` in the `Sign`, `SignFor`, and `SignAndSubmit` requests (the requests that make rippled do the signing of the transaction for you). This makes the requests and the transactions actually valid.

### Context of Change

I ran into this issue when working on sidechain tooling.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

CI passes. Works when I use it.
