### PR TITLE
feat: add support for ED25519 seeds that don't use the `sEd` prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [[Unreleased]]
 ### Added:
 - Function to parse the final account balances from a transaction's metadata
+- Support for ED25519 seeds that don't use the `sEd` prefix
 
 ### Fixed:
 - Typing for factory classmethods on models

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [[Unreleased]]
 ### Added:
 - Function to parse the final account balances from a transaction's metadata
-- Support for ED25519 seeds that don't use the `sEd` prefix
+- Support for Ed25519 seeds that don't use the `sEd` prefix
 
 ### Fixed:
 - Typing for factory classmethods on models

--- a/tests/unit/core/addresscodec/test_codec.py
+++ b/tests/unit/core/addresscodec/test_codec.py
@@ -91,6 +91,17 @@ class TestCodec(TestCase):
         self.assertEqual(decode_result, hex_string_bytes)
         self.assertEqual(encoding_type, CryptoAlgorithm.ED25519)
 
+    def test_seed_decode_ed25519_different_prefix(self):
+        hex_string = "2275BCC966EF1FED4AD08B11189A4157"
+        encoded_string = "ssB9S5Mca2hGZ73xNs4gruS1GY7fB"
+        hex_string_bytes = bytes.fromhex(hex_string)
+
+        decode_result, encoding_type = addresscodec.decode_seed(
+            encoded_string, CryptoAlgorithm.ED25519
+        )
+        self.assertEqual(decode_result, hex_string_bytes)
+        self.assertEqual(encoding_type, CryptoAlgorithm.ED25519)
+
     def test_seed_encode_decode_too_small(self):
         hex_string = "CF2DE378FBDD7E2EE87D486DFB5A7B"
         hex_string_bytes = bytes.fromhex(hex_string)

--- a/tests/unit/core/addresscodec/test_codec.py
+++ b/tests/unit/core/addresscodec/test_codec.py
@@ -102,6 +102,16 @@ class TestCodec(TestCase):
         self.assertEqual(decode_result, hex_string_bytes)
         self.assertEqual(encoding_type, CryptoAlgorithm.ED25519)
 
+    def test_seed_decode_secp256k1_wrong_prefix(self):
+        encoded_string = "sEdV19BLfeQeKdEXyYA4NhjPJe6XBfG"
+
+        self.assertRaises(
+            addresscodec.XRPLAddressCodecException,
+            addresscodec.decode_seed,
+            encoded_string,
+            CryptoAlgorithm.SECP256K1,
+        )
+
     def test_seed_encode_decode_too_small(self):
         hex_string = "CF2DE378FBDD7E2EE87D486DFB5A7B"
         hex_string_bytes = bytes.fromhex(hex_string)

--- a/tests/unit/core/keypairs/test_main.py
+++ b/tests/unit/core/keypairs/test_main.py
@@ -49,6 +49,19 @@ class TestMain(TestCase):
         with self.assertRaises(XRPLKeypairsException):
             keypairs.derive_keypair("sEdSKaCy2JT7JaM7v95H9SxkhP9wS2r", validator=True)
 
+    def test_derive_keypair_ed25519_different_prefix(self):
+        public, private = keypairs.derive_keypair(
+            "ssB9S5Mca2hGZ73xNs4gruS1GY7fB", algorithm=CryptoAlgorithm.ED25519
+        )
+        self.assertEqual(
+            public,
+            "ED6BBFC23A490D021B87D25563C15DA953A7F0F1A493DAA3767FB27F82E2F80C3D",
+        )
+        self.assertEqual(
+            private,
+            "ED644E705250E4D736875E85DD3E5FBABA4E12E004549202010228E17D3D574576",
+        )
+
     def test_derive_keypair_secp256k1(self):
         public, private = keypairs.derive_keypair("sp5fghtJtpUorTwvof1NpDXAzNwf5")
         self.assertEqual(

--- a/xrpl/core/addresscodec/codec.py
+++ b/xrpl/core/addresscodec/codec.py
@@ -30,7 +30,7 @@ _ACCOUNT_PUBLIC_KEY_LENGTH: Final[int] = 33
 _ALGORITHM_TO_PREFIX_MAP: Final[Dict[CryptoAlgorithm, List[List[int]]]] = {
     CryptoAlgorithm.ED25519: [_ED25519_SEED_PREFIX, _FAMILY_SEED_PREFIX],
     CryptoAlgorithm.SECP256K1: [_FAMILY_SEED_PREFIX],
-}
+}  # first is default, rest are other options
 
 
 def _encode(bytestring: bytes, prefix: List[int], expected_length: int) -> str:
@@ -107,6 +107,7 @@ def decode_seed(
         XRPLAddressCodecException: If the seed is invalid.
     """
     if algorithm is not None:
+        # check all algorithm prefixes
         for prefix in _ALGORITHM_TO_PREFIX_MAP[algorithm]:
             try:
                 decoded_result = _decode(seed, bytes(prefix))
@@ -115,7 +116,8 @@ def decode_seed(
                 # prefix is incorrect, wrong prefix
                 continue
         raise XRPLAddressCodecException("Wrong algorithm for the seed type.")
-    for algorithm in CryptoAlgorithm:
+
+    for algorithm in CryptoAlgorithm:  # use default prefix
         prefix = _ALGORITHM_TO_PREFIX_MAP[algorithm][0]
         try:
             decoded_result = _decode(seed, bytes(prefix))

--- a/xrpl/core/addresscodec/codec.py
+++ b/xrpl/core/addresscodec/codec.py
@@ -50,10 +50,12 @@ def _encode(bytestring: bytes, prefix: List[int], expected_length: int) -> str:
 
 def _decode(b58_string: str, prefix: bytes) -> bytes:
     """
-    b58_string: A base58 value
-    prefix: The prefix prepended to the bytestring
+    Args:
+        b58_string: A base58 value.
+        prefix: The prefix prepended to the bytestring.
 
-    Returns the byte decoding of the base58-encoded string.
+    Returns:
+        The byte decoding of the base58-encoded string.
     """
     prefix_length = len(prefix)
     decoded = base58.b58decode_check(b58_string, alphabet=XRPL_ALPHABET)
@@ -95,7 +97,8 @@ def decode_seed(
     Returns (decoded seed, its algorithm).
 
     Args:
-        seed: b58 encoding of a seed.
+        seed: The b58 encoding of a seed.
+        algorithm: The encoding algorithm. Inferred from the seed if not included.
 
     Returns:
         (decoded seed, its algorithm).

--- a/xrpl/core/keypairs/main.py
+++ b/xrpl/core/keypairs/main.py
@@ -45,7 +45,9 @@ def generate_seed(
     return addresscodec.encode_seed(parsed_entropy, algorithm)
 
 
-def derive_keypair(seed: str, validator: bool = False) -> Tuple[str, str]:
+def derive_keypair(
+    seed: str, validator: bool = False, algorithm: Optional[CryptoAlgorithm] = None
+) -> Tuple[str, str]:
     """
     Derive the public and private keys from a given seed value.
 
@@ -62,7 +64,7 @@ def derive_keypair(seed: str, validator: bool = False) -> Tuple[str, str]:
         XRPLKeypairsException: If the derived keypair did not generate a
             verifiable signature.
     """
-    decoded_seed, algorithm = addresscodec.decode_seed(seed)
+    decoded_seed, algorithm = addresscodec.decode_seed(seed, algorithm)
     module = _ALGORITHM_TO_MODULE_MAP[algorithm]
     public_key, private_key = module.derive_keypair(decoded_seed, validator)
     signature = module.sign(_VERIFICATION_MESSAGE, private_key)

--- a/xrpl/core/keypairs/main.py
+++ b/xrpl/core/keypairs/main.py
@@ -56,6 +56,8 @@ def derive_keypair(
             :func:`generate_seed() <xrpl.core.keypairs.generate_seed>` to generate an
             appropriate value.
         validator: Whether the keypair is a validator keypair.
+        algorithm: The algorithm used to encode the keys. Inferred from the seed if not
+            included.
 
     Returns:
         A (public key, private key) pair derived from the given seed.

--- a/xrpl/wallet/main.py
+++ b/xrpl/wallet/main.py
@@ -29,6 +29,8 @@ class Wallet:
         Args:
             seed: The seed from which the public and private keys are derived.
             sequence: The next sequence number for the account.
+            algorithm: The algorithm used to encode the keys. Inferred from the seed if
+                not included.
         """
         self.seed = seed
         """

--- a/xrpl/wallet/main.py
+++ b/xrpl/wallet/main.py
@@ -16,7 +16,13 @@ class Wallet:
     details.
     """
 
-    def __init__(self: Wallet, seed: str, sequence: int) -> None:
+    def __init__(
+        self: Wallet,
+        seed: str,
+        sequence: int,
+        *,
+        algorithm: Optional[CryptoAlgorithm] = None,
+    ) -> None:
         """
         Generate a new Wallet.
 
@@ -30,7 +36,7 @@ class Wallet:
         this wallet. MUST be kept secret!
         """
 
-        pk, sk = derive_keypair(self.seed)
+        pk, sk = derive_keypair(self.seed, algorithm=algorithm)
         self.public_key = pk
         """
         The public key that is used to identify this wallet's signatures, as
@@ -70,7 +76,7 @@ class Wallet:
             The wallet that is generated from the given seed.
         """
         seed = generate_seed(algorithm=crypto_algorithm)
-        return cls(seed, sequence=0)
+        return cls(seed, sequence=0, algorithm=crypto_algorithm)
 
     def get_xaddress(
         self: Wallet, *, tag: Optional[int] = None, is_test: bool = False


### PR DESCRIPTION
## High Level Overview of Change

The library currently assumes that all `ed25519` seeds use the `sEd` prefix. However, this is not necessarily true - they can also just have the `s` prefix, like the `secp256k1` seeds.

This PR adds support for those `ed25519` seeds.

### Context of Change

needed for sidechains work

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

CI passes. Added tests to test the new functionality.
