### PR TITLE
refactor: use `xrpl-codec-gen` for `definitions.json`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ poetry install
 Replace `python3.9` with whatever version of Python you want to use (you must have it installed with `pyenv` for it to work).
 
 
-### Generate reference docs
+## Generate reference docs
 
 You can see the complete reference documentation at [`xrpl-py` docs](https://xrpl-py.readthedocs.io/en/latest/index.html). You can also generate them locally using `poetry` and `sphinx`:
 
@@ -121,6 +121,9 @@ cd docs/_build/html/
 # Open the index file to view it in a browser:
 open _build/html/index.html
 ```
+
+## Update `definitions.json`
+Use [this repo](https://github.com/RichardAH/xrpl-codec-gen) to generate a new `definitions.json` file from the rippled source code. Instructions are available in that README.
 
 
 ## Release process

--- a/tests/unit/core/binarycodec/fixtures/data/data-driven-tests.json
+++ b/tests/unit/core/binarycodec/fixtures/data/data-driven-tests.json
@@ -485,13 +485,6 @@
     },
     {
       "type_name": "Hash256",
-      "name": "TicketID",
-      "nth_of_type": 20,
-      "type": 5,
-      "expected_hex": "5014"
-    },
-    {
-      "type_name": "Hash256",
       "name": "Digest",
       "nth_of_type": 21,
       "type": 5,
@@ -720,13 +713,6 @@
       "nth_of_type": 4,
       "type": 8,
       "expected_hex": "84"
-    },
-    {
-      "type_name": "AccountID",
-      "name": "Target",
-      "nth_of_type": 7,
-      "type": 8,
-      "expected_hex": "87"
     },
     {
       "type_name": "AccountID",

--- a/xrpl/core/binarycodec/definitions/definitions.json
+++ b/xrpl/core/binarycodec/definitions/definitions.json
@@ -1,29 +1,32 @@
 {
   "TYPES": {
-    "Validation": 10003,
     "Done": -1,
+    "Unknown": -2,
+    "NotPresent": 0,
+    "UInt16": 1,
+    "UInt32": 2,
+    "UInt64": 3,
     "Hash128": 4,
+    "Hash256": 5,
+    "Amount": 6,
     "Blob": 7,
     "AccountID": 8,
-    "Amount": 6,
-    "Hash256": 5,
-    "UInt8": 16,
-    "Vector256": 19,
     "STObject": 14,
-    "Unknown": -2,
-    "Transaction": 10001,
+    "STArray": 15,
+    "UInt8": 16,
     "Hash160": 17,
     "PathSet": 18,
+    "Vector256": 19,
+    "UInt96": 20,
+    "UInt192": 21,
+    "UInt384": 22,
+    "UInt512": 23,
+    "Transaction": 10001,
     "LedgerEntry": 10002,
-    "UInt16": 1,
-    "NotPresent": 0,
-    "UInt64": 3,
-    "UInt32": 2,
-    "STArray": 15
+    "Validation": 10003,
+    "Metadata": 10004
   },
   "LEDGER_ENTRY_TYPES": {
-    "Any": -3,
-    "Child": -2,
     "Invalid": -1,
     "AccountRoot": 97,
     "DirectoryNode": 100,
@@ -36,13 +39,16 @@
     "FeeSettings": 115,
     "Escrow": 117,
     "PayChannel": 120,
-    "DepositPreauth": 112,
     "Check": 67,
-    "Nickname": 110,
-    "Contract": 99,
+    "DepositPreauth": 112,
+    "NegativeUnl": 78,
     "NFTokenPage": 80,
     "NFTokenOffer": 55,
-    "NegativeUNL": 78
+    "Any": -3,
+    "Child": -2,
+    "Nickname": 110,
+    "Contract": 99,
+    "GeneratorMap": 103
   },
   "FIELDS": [
     [
@@ -63,6 +69,166 @@
         "isSerialized": false,
         "isSigningField": false,
         "type": "Unknown"
+      }
+    ],
+    [
+      "ObjectEndMarker",
+      {
+        "nth": 1,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STObject"
+      }
+    ],
+    [
+      "ArrayEndMarker",
+      {
+        "nth": 1,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STArray"
+      }
+    ],
+    [
+      "hash",
+      {
+        "nth": 257,
+        "isVLEncoded": false,
+        "isSerialized": false,
+        "isSigningField": false,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "index",
+      {
+        "nth": 258,
+        "isVLEncoded": false,
+        "isSerialized": false,
+        "isSigningField": false,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "taker_gets_funded",
+      {
+        "nth": 258,
+        "isVLEncoded": false,
+        "isSerialized": false,
+        "isSigningField": false,
+        "type": "Amount"
+      }
+    ],
+    [
+      "taker_pays_funded",
+      {
+        "nth": 259,
+        "isVLEncoded": false,
+        "isSerialized": false,
+        "isSigningField": false,
+        "type": "Amount"
+      }
+    ],
+    [
+      "LedgerEntry",
+      {
+        "nth": 1,
+        "isVLEncoded": false,
+        "isSerialized": false,
+        "isSigningField": true,
+        "type": "LedgerEntry"
+      }
+    ],
+    [
+      "Transaction",
+      {
+        "nth": 1,
+        "isVLEncoded": false,
+        "isSerialized": false,
+        "isSigningField": true,
+        "type": "Transaction"
+      }
+    ],
+    [
+      "Validation",
+      {
+        "nth": 1,
+        "isVLEncoded": false,
+        "isSerialized": false,
+        "isSigningField": true,
+        "type": "Validation"
+      }
+    ],
+    [
+      "Metadata",
+      {
+        "nth": 1,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Metadata"
+      }
+    ],
+    [
+      "CloseResolution",
+      {
+        "nth": 1,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt8"
+      }
+    ],
+    [
+      "Method",
+      {
+        "nth": 2,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt8"
+      }
+    ],
+    [
+      "TransactionResult",
+      {
+        "nth": 3,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt8"
+      }
+    ],
+    [
+      "TickSize",
+      {
+        "nth": 16,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt8"
+      }
+    ],
+    [
+      "UNLModifyDisabling",
+      {
+        "nth": 17,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt8"
+      }
+    ],
+    [
+      "HookResult",
+      {
+        "nth": 18,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt8"
       }
     ],
     [
@@ -99,6 +265,56 @@
       "TransferFee",
       {
         "nth": 4,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt16"
+      }
+    ],
+    [
+      "Version",
+      {
+        "nth": 16,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt16"
+      }
+    ],
+    [
+      "HookStateChangeCount",
+      {
+        "nth": 17,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt16"
+      }
+    ],
+    [
+      "HookEmitCount",
+      {
+        "nth": 18,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt16"
+      }
+    ],
+    [
+      "HookExecutionIndex",
+      {
+        "nth": 19,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt16"
+      }
+    ],
+    [
+      "HookApiVersion",
+      {
+        "nth": 20,
         "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
@@ -456,6 +672,96 @@
       }
     ],
     [
+      "SignerListID",
+      {
+        "nth": 38,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "SettleDelay",
+      {
+        "nth": 39,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "TicketCount",
+      {
+        "nth": 40,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "TicketSequence",
+      {
+        "nth": 41,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "NFTokenTaxon",
+      {
+        "nth": 42,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "MintedNFTokens",
+      {
+        "nth": 43,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "BurnedNFTokens",
+      {
+        "nth": 44,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "HookStateCount",
+      {
+        "nth": 45,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "EmitGeneration",
+      {
+        "nth": 46,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt32"
+      }
+    ],
+    [
       "IndexNext",
       {
         "nth": 1,
@@ -536,6 +842,96 @@
       }
     ],
     [
+      "DestinationNode",
+      {
+        "nth": 9,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt64"
+      }
+    ],
+    [
+      "Cookie",
+      {
+        "nth": 10,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt64"
+      }
+    ],
+    [
+      "ServerVersion",
+      {
+        "nth": 11,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt64"
+      }
+    ],
+    [
+      "NFTokenOfferNode",
+      {
+        "nth": 12,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt64"
+      }
+    ],
+    [
+      "EmitBurden",
+      {
+        "nth": 13,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt64"
+      }
+    ],
+    [
+      "HookOn",
+      {
+        "nth": 16,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt64"
+      }
+    ],
+    [
+      "HookInstructionCount",
+      {
+        "nth": 17,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt64"
+      }
+    ],
+    [
+      "HookReturnCode",
+      {
+        "nth": 18,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt64"
+      }
+    ],
+    [
+      "ReferenceCount",
+      {
+        "nth": 19,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt64"
+      }
+    ],
+    [
       "EmailHash",
       {
         "nth": 1,
@@ -543,6 +939,46 @@
         "isSerialized": true,
         "isSigningField": true,
         "type": "Hash128"
+      }
+    ],
+    [
+      "TakerPaysCurrency",
+      {
+        "nth": 1,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash160"
+      }
+    ],
+    [
+      "TakerPaysIssuer",
+      {
+        "nth": 2,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash160"
+      }
+    ],
+    [
+      "TakerGetsCurrency",
+      {
+        "nth": 3,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash160"
+      }
+    ],
+    [
+      "TakerGetsIssuer",
+      {
+        "nth": 4,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash160"
       }
     ],
     [
@@ -646,6 +1082,36 @@
       }
     ],
     [
+      "EmitParentTxnID",
+      {
+        "nth": 11,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "EmitNonce",
+      {
+        "nth": 12,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "EmitHookHash",
+      {
+        "nth": 13,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
       "BookDirectory",
       {
         "nth": 16,
@@ -686,16 +1152,6 @@
       }
     ],
     [
-      "TicketID",
-      {
-        "nth": 20,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash256"
-      }
-    ],
-    [
       "Digest",
       {
         "nth": 21,
@@ -706,22 +1162,122 @@
       }
     ],
     [
-      "hash",
+      "Channel",
       {
-        "nth": 257,
+        "nth": 22,
         "isVLEncoded": false,
-        "isSerialized": false,
-        "isSigningField": false,
+        "isSerialized": true,
+        "isSigningField": true,
         "type": "Hash256"
       }
     ],
     [
-      "index",
+      "ConsensusHash",
       {
-        "nth": 258,
+        "nth": 23,
         "isVLEncoded": false,
-        "isSerialized": false,
-        "isSigningField": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "CheckID",
+      {
+        "nth": 24,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "ValidatedHash",
+      {
+        "nth": 25,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "PreviousPageMin",
+      {
+        "nth": 26,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "NextPageMin",
+      {
+        "nth": 27,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "NFTokenBuyOffer",
+      {
+        "nth": 28,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "NFTokenSellOffer",
+      {
+        "nth": 29,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "HookStateKey",
+      {
+        "nth": 30,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "HookHash",
+      {
+        "nth": 31,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "HookNamespace",
+      {
+        "nth": 32,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "HookSetTxnID",
+      {
+        "nth": 33,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
         "type": "Hash256"
       }
     ],
@@ -862,26 +1418,6 @@
         "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
-        "type": "Amount"
-      }
-    ],
-    [
-      "taker_gets_funded",
-      {
-        "nth": 258,
-        "isVLEncoded": false,
-        "isSerialized": false,
-        "isSigningField": false,
-        "type": "Amount"
-      }
-    ],
-    [
-      "taker_pays_funded",
-      {
-        "nth": 259,
-        "isVLEncoded": false,
-        "isSerialized": false,
-        "isSigningField": false,
         "type": "Amount"
       }
     ],
@@ -1086,6 +1622,46 @@
       }
     ],
     [
+      "HookStateData",
+      {
+        "nth": 22,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Blob"
+      }
+    ],
+    [
+      "HookReturnString",
+      {
+        "nth": 23,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Blob"
+      }
+    ],
+    [
+      "HookParameterName",
+      {
+        "nth": 24,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Blob"
+      }
+    ],
+    [
+      "HookParameterValue",
+      {
+        "nth": 25,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Blob"
+      }
+    ],
+    [
       "Account",
       {
         "nth": 1,
@@ -1146,16 +1722,6 @@
       }
     ],
     [
-      "Target",
-      {
-        "nth": 7,
-        "isVLEncoded": true,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "AccountID"
-      }
-    ],
-    [
       "RegularKey",
       {
         "nth": 8,
@@ -1176,13 +1742,73 @@
       }
     ],
     [
-      "ObjectEndMarker",
+      "EmitCallback",
+      {
+        "nth": 10,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "AccountID"
+      }
+    ],
+    [
+      "HookAccount",
+      {
+        "nth": 16,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "AccountID"
+      }
+    ],
+    [
+      "Indexes",
+      {
+        "nth": 1,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Vector256"
+      }
+    ],
+    [
+      "Hashes",
+      {
+        "nth": 2,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Vector256"
+      }
+    ],
+    [
+      "Amendments",
+      {
+        "nth": 3,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Vector256"
+      }
+    ],
+    [
+      "NFTokenOffers",
+      {
+        "nth": 4,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Vector256"
+      }
+    ],
+    [
+      "Paths",
       {
         "nth": 1,
         "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
-        "type": "STObject"
+        "type": "PathSet"
       }
     ],
     [
@@ -1296,6 +1922,26 @@
       }
     ],
     [
+      "EmitDetails",
+      {
+        "nth": 13,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STObject"
+      }
+    ],
+    [
+      "Hook",
+      {
+        "nth": 14,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STObject"
+      }
+    ],
+    [
       "Signer",
       {
         "nth": 16,
@@ -1326,13 +1972,53 @@
       }
     ],
     [
-      "ArrayEndMarker",
+      "EmittedTxn",
       {
-        "nth": 1,
+        "nth": 20,
         "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
-        "type": "STArray"
+        "type": "STObject"
+      }
+    ],
+    [
+      "HookExecution",
+      {
+        "nth": 21,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STObject"
+      }
+    ],
+    [
+      "HookDefinition",
+      {
+        "nth": 22,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STObject"
+      }
+    ],
+    [
+      "HookParameter",
+      {
+        "nth": 23,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STObject"
+      }
+    ],
+    [
+      "HookGrant",
+      {
+        "nth": 24,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STObject"
       }
     ],
     [
@@ -1416,6 +2102,16 @@
       }
     ],
     [
+      "Hooks",
+      {
+        "nth": 11,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STArray"
+      }
+    ],
+    [
       "Majorities",
       {
         "nth": 16,
@@ -1436,363 +2132,33 @@
       }
     ],
     [
-      "CloseResolution",
+      "HookExecutions",
       {
-        "nth": 1,
+        "nth": 18,
         "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
-        "type": "UInt8"
+        "type": "STArray"
       }
     ],
     [
-      "Method",
+      "HookParameters",
       {
-        "nth": 2,
+        "nth": 19,
         "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
-        "type": "UInt8"
+        "type": "STArray"
       }
     ],
     [
-      "TransactionResult",
+      "HookGrants",
       {
-        "nth": 3,
+        "nth": 20,
         "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
-        "type": "UInt8"
-      }
-    ],
-    [
-      "TakerPaysCurrency",
-      {
-        "nth": 1,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash160"
-      }
-    ],
-    [
-      "TakerPaysIssuer",
-      {
-        "nth": 2,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash160"
-      }
-    ],
-    [
-      "TakerGetsCurrency",
-      {
-        "nth": 3,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash160"
-      }
-    ],
-    [
-      "TakerGetsIssuer",
-      {
-        "nth": 4,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash160"
-      }
-    ],
-    [
-      "Paths",
-      {
-        "nth": 1,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "PathSet"
-      }
-    ],
-    [
-      "Indexes",
-      {
-        "nth": 1,
-        "isVLEncoded": true,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Vector256"
-      }
-    ],
-    [
-      "Hashes",
-      {
-        "nth": 2,
-        "isVLEncoded": true,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Vector256"
-      }
-    ],
-    [
-      "Amendments",
-      {
-        "nth": 3,
-        "isVLEncoded": true,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Vector256"
-      }
-    ],
-    [
-      "NFTokenOffers",
-      {
-        "nth": 4,
-        "isVLEncoded": true,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Vector256"
-      }
-    ],
-    [
-      "Transaction",
-      {
-        "nth": 1,
-        "isVLEncoded": false,
-        "isSerialized": false,
-        "isSigningField": false,
-        "type": "Transaction"
-      }
-    ],
-    [
-      "LedgerEntry",
-      {
-        "nth": 1,
-        "isVLEncoded": false,
-        "isSerialized": false,
-        "isSigningField": false,
-        "type": "LedgerEntry"
-      }
-    ],
-    [
-      "Validation",
-      {
-        "nth": 1,
-        "isVLEncoded": false,
-        "isSerialized": false,
-        "isSigningField": false,
-        "type": "Validation"
-      }
-    ],
-    [
-      "SignerListID",
-      {
-        "nth": 38,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt32"
-      }
-    ],
-    [
-      "SettleDelay",
-      {
-        "nth": 39,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt32"
-      }
-    ],
-    [
-      "TicketCount",
-      {
-        "nth": 40,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt32"
-      }
-    ],
-    [
-      "TicketSequence",
-      {
-        "nth": 41,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt32"
-      }
-    ],
-    [
-      "NFTokenTaxon",
-      {
-        "nth": 42,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt32"
-      }
-    ],
-    [
-      "MintedNFTokens",
-      {
-        "nth": 43,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt32"
-      }
-    ],
-    [
-      "BurnedNFTokens",
-      {
-        "nth": 44,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt32"
-      }
-    ],
-    [
-      "Channel",
-      {
-        "nth": 22,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash256"
-      }
-    ],
-    [
-      "ConsensusHash",
-      {
-        "nth": 23,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash256"
-      }
-    ],
-    [
-      "CheckID",
-      {
-        "nth": 24,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash256"
-      }
-    ],
-    [
-      "ValidatedHash",
-      {
-        "nth": 25,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash256"
-      }
-    ],
-    [
-      "PreviousPageMin",
-      {
-        "nth": 26,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash256"
-      }
-    ],
-    [
-      "NextPageMin",
-      {
-        "nth": 27,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash256"
-      }
-    ],
-    [
-      "NFTokenBuyOffer",
-      {
-        "nth": 28,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash256"
-      }
-    ],
-    [
-      "NFTokenSellOffer",
-      {
-        "nth": 29,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash256"
-      }
-    ],
-    [
-      "TickSize",
-      {
-        "nth": 16,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt8"
-      }
-    ],
-    [
-      "UNLModifyDisabling",
-      {
-        "nth": 17,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt8"
-      }
-    ],
-    [
-      "DestinationNode",
-      {
-        "nth": 9,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt64"
-      }
-    ],
-    [
-      "Cookie",
-      {
-        "nth": 10,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt64"
-      }
-    ],
-    [
-      "ServerVersion",
-      {
-        "nth": 11,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt64"
-      }
-    ],
-    [
-      "NFTokenOfferNode",
-      {
-        "nth": 12,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt64"
+        "type": "STArray"
       }
     ]
   ],
@@ -1844,10 +2210,11 @@
     "temBAD_TICK_SIZE": -269,
     "temINVALID_ACCOUNT_ID": -268,
     "temCANNOT_PREAUTH_SELF": -267,
-    "temUNCERTAIN": -266,
-    "temUNKNOWN": -265,
-    "temSEQ_AND_TICKET": -264,
-    "temBAD_NFTOKEN_TRANSFER_FEE": -263,
+    "temINVALID_COUNT": -266,
+    "temUNCERTAIN": -265,
+    "temUNKNOWN": -264,
+    "temSEQ_AND_TICKET": -263,
+    "temBAD_NFTOKEN_TRANSFER_FEE": -262,
 
     "tefFAILURE": -199,
     "tefALREADY": -198,
@@ -1924,7 +2291,6 @@
     "tecKILLED": 150,
     "tecHAS_OBLIGATIONS": 151,
     "tecTOO_SOON": 152,
-
     "tecMAX_SEQUENCE_REACHED": 154,
     "tecNO_SUITABLE_NFTOKEN_PAGE": 155,
     "tecNFTOKEN_BUY_SELL_MISMATCH": 156,
@@ -1932,13 +2298,10 @@
     "tecCANT_ACCEPT_OWN_NFTOKEN_OFFER": 158,
     "tecINSUFFICIENT_FUNDS": 159,
     "tecOBJECT_NOT_FOUND": 160,
-    "tecINSUFFICIENT_PAYMENT": 161,
-    "tecINCORRECT_ASSET": 162,
-    "tecTOO_MANY": 163
+    "tecINSUFFICIENT_PAYMENT": 161
   },
   "TRANSACTION_TYPES": {
     "Invalid": -1,
-
     "Payment": 0,
     "EscrowCreate": 1,
     "EscrowFinish": 2,
@@ -1961,6 +2324,7 @@
     "DepositPreauth": 19,
     "TrustSet": 20,
     "AccountDelete": 21,
+    "SetHook": 22,
     "NFTokenMint": 25,
     "NFTokenBurn": 26,
     "NFTokenCreateOffer": 27,

--- a/xrpl/core/binarycodec/definitions/definitions.json
+++ b/xrpl/core/binarycodec/definitions/definitions.json
@@ -41,7 +41,7 @@
     "PayChannel": 120,
     "Check": 67,
     "DepositPreauth": 112,
-    "NegativeUnl": 78,
+    "NegativeUNL": 78,
     "NFTokenPage": 80,
     "NFTokenOffer": 55,
     "Any": -3,


### PR DESCRIPTION
## High Level Overview of Change

This PR uses [xrpl-codec-gen](https://github.com/RichardAH/xrpl-codec-gen) to generate the `definitions.json` file. This rearranges the file a bit. It also removes some legacy bits of code that aren't actually in the rippled source code. 

No change in functionality.

### Context of Change

@RichardAH mentioned this repo to me.

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

## Test Plan

Tests pass. A couple of the data-driven tests needed to be removed because they weren't actually in the source code.
