### PR TITLE
refactor: create new abstract model for nested dict objects

### DIFF
--- a/xrpl/models/nested_model.py
+++ b/xrpl/models/nested_model.py
@@ -61,4 +61,6 @@ class NestedModel(BaseModel):
         Returns:
             The dictionary representation of a NestedModel.
         """
-        return {self.nested_name: super().to_dict()}
+        super_dict = super().to_dict()
+        del super_dict["nested_name"]
+        return {self.nested_name: super_dict}

--- a/xrpl/models/nested_model.py
+++ b/xrpl/models/nested_model.py
@@ -13,6 +13,30 @@ class NestedModel(BaseModel):
     nested_name: ClassVar[str]
 
     @classmethod
+    def is_dict_of_model(cls: Type[NestedModel], dictionary: Any) -> bool:
+        """
+        Returns True if the input dictionary was derived by the `to_dict`
+        method of an instance of this class. In other words, True if this is
+        a dictionary representation of an instance of this class.
+
+        NOTE: does not account for model inheritance, IE will only return True
+        if dictionary represents an instance of this class, but not if
+        dictionary represents an instance of a subclass of this class.
+
+        Args:
+            dictionary: The dictionary to check.
+
+        Returns:
+            True if dictionary is a dict representation of an instance of this
+            class.
+        """
+        return (
+            isinstance(dictionary, dict)
+            and cls.nested_name in dictionary
+            and super().is_dict_of_model(dictionary[cls.nested_name])
+        )
+
+    @classmethod
     def from_dict(cls: Type[NestedModel], value: Dict[str, Any]) -> NestedModel:
         """
         Construct a new NestedModel from a dictionary of parameters.

--- a/xrpl/models/nested_model.py
+++ b/xrpl/models/nested_model.py
@@ -1,0 +1,40 @@
+"""The base class for models that involve a nested dictionary e.g. memos."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Dict, Type
+
+from xrpl.models.base_model import BaseModel
+
+
+class NestedModel(BaseModel):
+    """The base class for models that involve a nested dictionary e.g. memos."""
+
+    nested_name: ClassVar[str]
+
+    @classmethod
+    def from_dict(cls: Type[NestedModel], value: Dict[str, Any]) -> NestedModel:
+        """
+        Construct a new NestedModel from a dictionary of parameters.
+
+        Args:
+            value: The value to construct the NestedModel from.
+
+        Returns:
+            A new NestedModel object, constructed using the given parameters.
+
+        Raises:
+            XRPLModelException: If the dictionary provided is invalid.
+        """
+        if cls.nested_name not in value:
+            return super(NestedModel, cls).from_dict(value)
+        return super(NestedModel, cls).from_dict(value[cls.nested_name])
+
+    def to_dict(self: NestedModel) -> Dict[str, Any]:
+        """
+        Returns the dictionary representation of a NestedModel.
+
+        Returns:
+            The dictionary representation of a NestedModel.
+        """
+        return {self.nested_name: super().to_dict()}

--- a/xrpl/models/transactions/signer_list_set.py
+++ b/xrpl/models/transactions/signer_list_set.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Type
+from typing import ClassVar, Dict, List, Optional
 
-from xrpl.models.base_model import BaseModel
+from xrpl.models.nested_model import NestedModel
 from xrpl.models.required import REQUIRED
 from xrpl.models.transactions.transaction import Transaction
 from xrpl.models.transactions.types import TransactionType
@@ -13,8 +13,10 @@ from xrpl.models.utils import require_kwargs_on_init
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class SignerEntry(BaseModel):
+class SignerEntry(NestedModel):
     """Represents one entry in a list of multi-signers authorized to an account."""
+
+    nested_name: ClassVar[str] = "signer_entry"
 
     account: str = REQUIRED  # type: ignore
     """
@@ -29,54 +31,6 @@ class SignerEntry(BaseModel):
 
     :meta hide-value:
     """
-
-    @classmethod
-    def is_dict_of_model(cls: Type[SignerEntry], dictionary: Dict[str, Any]) -> bool:
-        """
-        Returns True if the input dictionary was derived by the `to_dict`
-        method of an instance of this class. In other words, True if this is
-        a dictionary representation of an instance of this class.
-
-        NOTE: does not account for model inheritance, IE will only return True
-        if dictionary represents an instance of this class, but not if
-        dictionary represents an instance of a subclass of this class.
-
-        Args:
-            dictionary: The dictionary to check.
-
-        Returns:
-            True if dictionary is a dict representation of an instance of this
-            class.
-        """
-        return (
-            isinstance(dictionary, dict)
-            and "signer_entry" in dictionary
-            and super().is_dict_of_model(dictionary["signer_entry"])
-        )
-
-    @classmethod
-    def from_dict(cls: Type[SignerEntry], value: Dict[str, Any]) -> SignerEntry:
-        """
-        Construct a new SignerEntry from a dictionary of parameters.
-
-        Args:
-            value: The value to construct the SignerEntry from.
-
-        Returns:
-            A new SignerEntry object, constructed using the given parameters.
-        """
-        if len(value) == 1 and "signer_entry" in value:
-            return super(SignerEntry, cls).from_dict(value["signer_entry"])
-        return super(SignerEntry, cls).from_dict(value)
-
-    def to_dict(self: SignerEntry) -> Dict[str, Any]:
-        """
-        Returns the dictionary representation of a SignerEntry.
-
-        Returns:
-            The dictionary representation of a SignerEntry.
-        """
-        return {"signer_entry": super().to_dict()}
 
 
 @require_kwargs_on_init

--- a/xrpl/models/transactions/signer_list_set.py
+++ b/xrpl/models/transactions/signer_list_set.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import ClassVar, Dict, List, Optional
+from typing import Dict, List, Optional
 
 from xrpl.models.nested_model import NestedModel
 from xrpl.models.required import REQUIRED
@@ -15,8 +15,6 @@ from xrpl.models.utils import require_kwargs_on_init
 @dataclass(frozen=True)
 class SignerEntry(NestedModel):
     """Represents one entry in a list of multi-signers authorized to an account."""
-
-    nested_name: ClassVar[str] = "signer_entry"
 
     account: str = REQUIRED  # type: ignore
     """

--- a/xrpl/models/transactions/transaction.py
+++ b/xrpl/models/transactions/transaction.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from hashlib import sha512
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union
+from typing import Any, ClassVar, Dict, List, Optional, Type, TypeVar, Union
 
 from typing_extensions import Final
 
@@ -12,6 +12,7 @@ from xrpl.models.amounts import IssuedCurrencyAmount
 from xrpl.models.base_model import BaseModel
 from xrpl.models.exceptions import XRPLModelException
 from xrpl.models.flags import check_false_flag_definition, interface_to_flag_list
+from xrpl.models.nested_model import NestedModel
 from xrpl.models.requests import PathStep
 from xrpl.models.required import REQUIRED
 from xrpl.models.transactions.types import PseudoTransactionType, TransactionType
@@ -79,13 +80,15 @@ def _value_to_tx_json(value: XRPL_VALUE_TYPE) -> XRPL_VALUE_TYPE:
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class Memo(BaseModel):
+class Memo(NestedModel):
     """
     An arbitrary piece of data attached to a transaction. A transaction can
     have multiple Memo objects as an array in the Memos field.
     Must contain one or more of ``memo_data``, ``memo_format``, and
     ``memo_type``.
     """
+
+    nested_name: ClassVar[str] = "memo"
 
     memo_data: Optional[str] = None
     """The data of the memo, as a hexadecimal string."""
@@ -120,33 +123,6 @@ class Memo(BaseModel):
         if len(present_memo_fields) < 1:
             errors["Memo"] = "Memo must contain at least one field"
         return errors
-
-    @classmethod
-    def from_dict(cls: Type[Memo], value: Dict[str, Any]) -> Memo:
-        """
-        Construct a new Memo from a dictionary of parameters.
-
-        Args:
-            value: The value to construct the Memo from.
-
-        Returns:
-            A new Memo object, constructed using the given parameters.
-
-        Raises:
-            XRPLModelException: If the dictionary provided is invalid.
-        """
-        if "memo" not in value:
-            return super(Memo, cls).from_dict(value)
-        return super(Memo, cls).from_dict(value["memo"])
-
-    def to_dict(self: Memo) -> Dict[str, Any]:
-        """
-        Returns the dictionary representation of a Memo.
-
-        Returns:
-            The dictionary representation of a Memo.
-        """
-        return {"memo": super().to_dict()}
 
 
 @require_kwargs_on_init

--- a/xrpl/models/transactions/transaction.py
+++ b/xrpl/models/transactions/transaction.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from hashlib import sha512
-from typing import Any, ClassVar, Dict, List, Optional, Type, TypeVar, Union
+from typing import Any, Dict, List, Optional, Type, TypeVar, Union
 
 from typing_extensions import Final
 
@@ -88,8 +88,6 @@ class Memo(NestedModel):
     ``memo_type``.
     """
 
-    nested_name: ClassVar[str] = "memo"
-
     memo_data: Optional[str] = None
     """The data of the memo, as a hexadecimal string."""
 
@@ -133,8 +131,6 @@ class Signer(NestedModel):
     array of up to 8 Signers, each contributing a signature, in the Signers
     field.
     """
-
-    nested_name: ClassVar[str] = "signer"
 
     account: str = REQUIRED  # type: ignore
     """

--- a/xrpl/models/transactions/transaction.py
+++ b/xrpl/models/transactions/transaction.py
@@ -127,12 +127,14 @@ class Memo(NestedModel):
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class Signer(BaseModel):
+class Signer(NestedModel):
     """
     One Signer in a multi-signature. A multi-signed transaction can have an
     array of up to 8 Signers, each contributing a signature, in the Signers
     field.
     """
+
+    nested_name: ClassVar[str] = "signer"
 
     account: str = REQUIRED  # type: ignore
     """
@@ -158,57 +160,6 @@ class Signer(BaseModel):
 
     :meta hide-value:
     """
-
-    @classmethod
-    def is_dict_of_model(cls: Type[Signer], dictionary: Any) -> bool:
-        """
-        Returns True if the input dictionary was derived by the `to_dict`
-        method of an instance of this class. In other words, True if this is
-        a dictionary representation of an instance of this class.
-
-        NOTE: does not account for model inheritance, IE will only return True
-        if dictionary represents an instance of this class, but not if
-        dictionary represents an instance of a subclass of this class.
-
-        Args:
-            dictionary: The dictionary to check.
-
-        Returns:
-            True if dictionary is a dict representation of an instance of this
-            class.
-        """
-        return (
-            isinstance(dictionary, dict)
-            and "signer" in dictionary
-            and super().is_dict_of_model(dictionary["signer"])
-        )
-
-    @classmethod
-    def from_dict(cls: Type[Signer], value: Dict[str, Any]) -> Signer:
-        """
-        Construct a new Signer from a dictionary of parameters.
-
-        Args:
-            value: The value to construct the Signer from.
-
-        Returns:
-            A new Signer object, constructed using the given parameters.
-
-        Raises:
-            XRPLModelException: If the dictionary provided is invalid.
-        """
-        if "signer" not in value:
-            return super(Signer, cls).from_dict(value)
-        return super(Signer, cls).from_dict(value["signer"])
-
-    def to_dict(self: Signer) -> Dict[str, Any]:
-        """
-        Returns the dictionary representation of a Signer.
-
-        Returns:
-            The dictionary representation of a Signer.
-        """
-        return {"signer": super().to_dict()}
 
 
 T = TypeVar("T", bound="Transaction")  # any type inherited from Transaction


### PR DESCRIPTION
## High Level Overview of Change

Some objects are of the form:
```
{
  "Memo": {
    ...
  }
}
```

xrpl-py abstracts this away and creates the outer dictionary for you. There are a few objects that do this (`Memo`, `Signer`, and `SignerList`). There is a lot of copy-pasted code between these 3 objects. This PR seeks to simplify that by creating a parent object that inherits from BaseModel that handles this extra code.

### Context of Change

I have a draft PR that has a few more of these objects, and it avoids having copy-pasted code.

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

## Test Plan

CI passes. No change in functionality.
