### PR TITLE
feat: Shorten ledger close time from 4 to 1

### DIFF
--- a/xrpl/asyncio/transaction/reliable_submission.py
+++ b/xrpl/asyncio/transaction/reliable_submission.py
@@ -12,7 +12,7 @@ from xrpl.constants import XRPLException
 from xrpl.models.response import Response
 from xrpl.models.transactions.transaction import Transaction
 
-_LEDGER_CLOSE_TIME: Final[int] = 4
+_LEDGER_CLOSE_TIME: Final[int] = 1
 
 
 class XRPLReliableSubmissionException(XRPLException):


### PR DESCRIPTION
## High Level Overview of Change

Changed reliable submission ledger close time from 4 to 1 to enhance transaction speed

### Context of Change

An example of where that might actually make the function run faster in a normal operation: according to [livenet.xrpl.org](http://livenet.xrpl.org/) a normal ledger on mainnet closes every 4.068 seconds right now. If the relsub method checks after 4 seconds, it would have to wait another 4 seconds before checking again, and take 8 seconds to finish, even if the transaction was validated after 4.068 seconds. If we switch to checking every 1 second, then it would take 5 seconds to finish.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

Ran CI tests
