### PR TITLE
fix: adjust `check_fee` logic to be more reasonable

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,4 +6,10 @@
     "esbonio.sphinx.confDir": "${workspaceFolder}/docs",
     "python.linting.mypyEnabled": true,
     "mypy.runUsingActiveInterpreter": true,
+    "cSpell.words": [
+        "addresscodec",
+        "asyncio",
+        "binarycodec",
+        "xaddress"
+    ],
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [[Unreleased]]
+### Changed:
+
 
 ## [1.7.0] - 2022-10-12
 ### Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [[Unreleased]]
 ### Changed:
-
+* `check_fee` now has a higher limit that is less likely to be hit
 
 ## [1.7.0] - 2022-10-12
 ### Added:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,1 +1,2 @@
 [mypy]
+exclude = dist

--- a/xrpl/asyncio/transaction/main.py
+++ b/xrpl/asyncio/transaction/main.py
@@ -269,7 +269,10 @@ async def _check_fee(transaction: Transaction, client: Optional[Client] = None) 
     Raises:
         XRPLException: if the transaction fee is higher than the expected fee.
     """
-    expected_fee = xrp_to_drops(0.1)  # a fee that is obviously too high
+    expected_fee = max(
+        xrp_to_drops(0.1),  # a fee that is obviously too high
+        await _calculate_fee_per_transaction_type(transaction, client),
+    )
 
     if transaction.fee and int(transaction.fee) > int(expected_fee):
         raise XRPLException(

--- a/xrpl/asyncio/transaction/main.py
+++ b/xrpl/asyncio/transaction/main.py
@@ -33,7 +33,7 @@ async def safe_sign_and_submit_transaction(
     wallet: Wallet,
     client: Client,
     autofill: bool = True,
-    check_fee: bool = False,
+    check_fee: bool = True,
 ) -> Response:
     """
     Signs a transaction (locally, without trusting external rippled nodes) and submits
@@ -62,7 +62,7 @@ async def safe_sign_and_submit_transaction(
 async def safe_sign_transaction(
     transaction: Transaction,
     wallet: Wallet,
-    check_fee: bool = False,
+    check_fee: bool = True,
 ) -> Transaction:
     """
     Signs a transaction locally, without trusting external rippled nodes.
@@ -90,7 +90,7 @@ async def safe_sign_and_autofill_transaction(
     transaction: Transaction,
     wallet: Wallet,
     client: Client,
-    check_fee: bool = False,
+    check_fee: bool = True,
 ) -> Transaction:
     """
     Signs a transaction locally, without trusting external rippled nodes. Autofills
@@ -269,18 +269,13 @@ async def _check_fee(transaction: Transaction, client: Optional[Client] = None) 
     Raises:
         XRPLException: if the transaction fee is higher than the expected fee.
     """
-    # Calculate the expected fee from the network load and transaction type
-    expected_fee = await _calculate_fee_per_transaction_type(transaction, client)
+    expected_fee = xrp_to_drops(0.1)  # a fee that is obviously too high
 
     if transaction.fee and int(transaction.fee) > int(expected_fee):
         raise XRPLException(
-            "Fee value: "
-            + str(drops_to_xrp(transaction.fee))
-            + " XRP exceeds the "
-            + str(drops_to_xrp(expected_fee))
-            + " maximum XRP fee limit for "
-            + transaction.transaction_type
-            + " transaction"
+            f"Fee value: {str(drops_to_xrp(transaction.fee))} XRP is likely entered "
+            "incorrectly, since it is much larger than the "
+            f"{str(drops_to_xrp(expected_fee))} maximum XRP fee limit."
         )
 
 
@@ -303,7 +298,7 @@ async def _calculate_fee_per_transaction_type(
     """
     # Reference Transaction (Most transactions)
     if client is None:
-        net_fee = int(xrp_to_drops(1))
+        net_fee = 10  # 10 drops
     else:
         net_fee = int(await get_fee(client))  # Usually 0.00001 XRP (10 drops)
 

--- a/xrpl/asyncio/transaction/main.py
+++ b/xrpl/asyncio/transaction/main.py
@@ -33,7 +33,7 @@ async def safe_sign_and_submit_transaction(
     wallet: Wallet,
     client: Client,
     autofill: bool = True,
-    check_fee: bool = True,
+    check_fee: bool = False,
 ) -> Response:
     """
     Signs a transaction (locally, without trusting external rippled nodes) and submits
@@ -62,7 +62,7 @@ async def safe_sign_and_submit_transaction(
 async def safe_sign_transaction(
     transaction: Transaction,
     wallet: Wallet,
-    check_fee: bool = True,
+    check_fee: bool = False,
 ) -> Transaction:
     """
     Signs a transaction locally, without trusting external rippled nodes.
@@ -90,7 +90,7 @@ async def safe_sign_and_autofill_transaction(
     transaction: Transaction,
     wallet: Wallet,
     client: Client,
-    check_fee: bool = True,
+    check_fee: bool = False,
 ) -> Transaction:
     """
     Signs a transaction locally, without trusting external rippled nodes. Autofills

--- a/xrpl/asyncio/transaction/main.py
+++ b/xrpl/asyncio/transaction/main.py
@@ -303,7 +303,7 @@ async def _calculate_fee_per_transaction_type(
     """
     # Reference Transaction (Most transactions)
     if client is None:
-        net_fee = 10  # 10 drops
+        net_fee = int(xrp_to_drops(1))
     else:
         net_fee = int(await get_fee(client))  # Usually 0.00001 XRP (10 drops)
 

--- a/xrpl/asyncio/transaction/main.py
+++ b/xrpl/asyncio/transaction/main.py
@@ -277,8 +277,8 @@ async def _check_fee(transaction: Transaction, client: Optional[Client] = None) 
     if transaction.fee and int(transaction.fee) > int(expected_fee):
         raise XRPLException(
             f"Fee value: {str(drops_to_xrp(transaction.fee))} XRP is likely entered "
-            "incorrectly, since it is much larger than the "
-            f"{str(drops_to_xrp(expected_fee))} maximum XRP fee limit."
+            "incorrectly, since it is much larger than the typical XRP transaction "
+            "cost. If this is intentional, use `check_fee=False`."
         )
 
 

--- a/xrpl/transaction/main.py
+++ b/xrpl/transaction/main.py
@@ -13,7 +13,7 @@ def safe_sign_and_submit_transaction(
     wallet: Wallet,
     client: SyncClient,
     autofill: bool = True,
-    check_fee: bool = True,
+    check_fee: bool = False,
 ) -> Response:
     """
     Signs a transaction (locally, without trusting external rippled nodes) and submits
@@ -69,7 +69,7 @@ def submit_transaction(
 def safe_sign_transaction(
     transaction: Transaction,
     wallet: Wallet,
-    check_fee: bool = True,
+    check_fee: bool = False,
 ) -> Transaction:
     """
     Signs a transaction locally, without trusting external rippled nodes.
@@ -96,7 +96,7 @@ def safe_sign_and_autofill_transaction(
     transaction: Transaction,
     wallet: Wallet,
     client: SyncClient,
-    check_fee: bool = True,
+    check_fee: bool = False,
 ) -> Transaction:
     """
     Signs a transaction locally, without trusting external rippled nodes. Autofills

--- a/xrpl/transaction/main.py
+++ b/xrpl/transaction/main.py
@@ -13,7 +13,7 @@ def safe_sign_and_submit_transaction(
     wallet: Wallet,
     client: SyncClient,
     autofill: bool = True,
-    check_fee: bool = False,
+    check_fee: bool = True,
 ) -> Response:
     """
     Signs a transaction (locally, without trusting external rippled nodes) and submits
@@ -69,7 +69,7 @@ def submit_transaction(
 def safe_sign_transaction(
     transaction: Transaction,
     wallet: Wallet,
-    check_fee: bool = False,
+    check_fee: bool = True,
 ) -> Transaction:
     """
     Signs a transaction locally, without trusting external rippled nodes.
@@ -96,7 +96,7 @@ def safe_sign_and_autofill_transaction(
     transaction: Transaction,
     wallet: Wallet,
     client: SyncClient,
-    check_fee: bool = False,
+    check_fee: bool = True,
 ) -> Transaction:
     """
     Signs a transaction locally, without trusting external rippled nodes. Autofills


### PR DESCRIPTION
## High Level Overview of Change

This PR makes the behavior of `check_fee` much more reasonable. It will object when a user types in a fee that is over 10 drops and is signing offline, which is really annoying.

### Context of Change

Previously, if you had a fee that was greater than 10 drops for any normal transaction, the method would object (unless you turned off `check_fee`, and it's hard to remember that you can do that).  There have been many previous complaints about this, but I can't find them right now (they don't appear to be in the repo's issues). Users should be able to enter in a higher fee if they want.

Relevant issue (and the reason why this feature exists): https://github.com/XRPLF/xrpl-py/issues/213

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
