### PR TITLE
refactor: Alias function for safe_sign_transaction called sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [[Unreleased]]
 ### Added:
-- Created function alias to `safe_sign_transaction` called `sign`
+- Created function alias to `safe_sign_transaction` called `sign` - safe originally used to indicate local offline signing (keys aren't exposed)
 
 ### Changed:
 - `check_fee` now has a higher limit that is less likely to be hit
 - When connected to nft devnet or hooks v2 testnet generate_faucet_wallet now defaults to using the faucet instead of requiring specification
 - Deprecated `get_account_info`, `get_transaction_from_hash`, `get_account_payment_transactions` for direct requests
-- Private function `request_impl` has been renamed to `_request_impl`
+- Private function `request_impl` has been renamed to `_request_impl`. Users should always use `request` over `request_impl`.
 
 ### Fixed:
 - Properly type the instance functions of NestedModel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed:
 - `check_fee` now has a higher limit that is less likely to be hit
 - When connected to nft devnet or hooks v2 testnet generate_faucet_wallet now defaults to using the faucet instead of requiring specification
+- Created function alias to `safe_sign_transaction` called `sign`
 
 ## [1.7.0] - 2022-10-12
 ### Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [[Unreleased]]
+### Added:
+- Created function alias to `safe_sign_transaction` called `sign`
+
 ### Changed:
 - `check_fee` now has a higher limit that is less likely to be hit
 - When connected to nft devnet or hooks v2 testnet generate_faucet_wallet now defaults to using the faucet instead of requiring specification
-- Created function alias to `safe_sign_transaction` called `sign`
 
 ## [1.7.0] - 2022-10-12
 ### Added:

--- a/README.md
+++ b/README.md
@@ -155,14 +155,14 @@ Use the [`xrpl.transaction`](https://xrpl-py.readthedocs.io/en/stable/source/xrp
 
 * [`safe_sign_and_submit_transaction`](https://xrpl-py.readthedocs.io/en/stable/source/xrpl.transaction.html#xrpl.transaction.safe_sign_and_submit_transaction) — Signs a transaction locally, then submits it to the XRP Ledger. This method does not implement [reliable transaction submission](https://xrpl.org/reliable-transaction-submission.html#reliable-transaction-submission) best practices, so only use it for development or testing purposes.
 
-* [`safe_sign_transaction`](https://xrpl-py.readthedocs.io/en/stable/source/xrpl.transaction.html#xrpl.transaction.safe_sign_transaction) — Signs a transaction locally. This method **does  not** submit the transaction to the XRP Ledger.
+* [`sign`](https://xrpl-py.readthedocs.io/en/stable/source/xrpl.transaction.html#xrpl.transaction.sign) — Signs a transaction locally. This method **does  not** submit the transaction to the XRP Ledger.
 
 * [`send_reliable_submission`](https://xrpl-py.readthedocs.io/en/stable/source/xrpl.transaction.html#xrpl.transaction.send_reliable_submission) — An implementation of the [reliable transaction submission guidelines](https://xrpl.org/reliable-transaction-submission.html#reliable-transaction-submission), this method submits a signed transaction to the XRP Ledger and then verifies that it has been included in a validated ledger (or has failed to do so). Use this method to submit transactions for production purposes.
 
 
 ```py
 from xrpl.models.transactions import Payment
-from xrpl.transaction import safe_sign_transaction, send_reliable_submission
+from xrpl.transaction import sign, send_reliable_submission
 from xrpl.ledger import get_latest_validated_ledger_sequence
 from xrpl.account import get_next_valid_seq_number
 
@@ -181,7 +181,7 @@ my_tx_payment = Payment(
     fee="10",
 )
 # sign the transaction
-my_tx_payment_signed = safe_sign_transaction(my_tx_payment,test_wallet)
+my_tx_payment_signed = sign(my_tx_payment,test_wallet)
 
 # submit the transaction
 tx_response = send_reliable_submission(my_tx_payment_signed, client)
@@ -276,7 +276,7 @@ This sample code is the asynchronous equivalent of the above section on submitti
 ```py
 import asyncio
 from xrpl.models.transactions import Payment
-from xrpl.asyncio.transaction import safe_sign_transaction, send_reliable_submission
+from xrpl.asyncio.transaction import sign, send_reliable_submission
 from xrpl.asyncio.ledger import get_latest_validated_ledger_sequence
 from xrpl.asyncio.account import get_next_valid_seq_number
 from xrpl.asyncio.clients import AsyncJsonRpcClient
@@ -299,7 +299,7 @@ async def submit_sample_transaction():
         fee="10",
     )
     # sign the transaction
-    my_tx_payment_signed = await safe_sign_transaction(my_tx_payment,test_wallet)
+    my_tx_payment_signed = await sign(my_tx_payment,test_wallet)
 
     # submit the transaction
     tx_response = await send_reliable_submission(my_tx_payment_signed, async_client)

--- a/tests/integration/sugar/test_transaction.py
+++ b/tests/integration/sugar/test_transaction.py
@@ -14,8 +14,8 @@ from xrpl.asyncio.transaction import (
     autofill,
     get_transaction_from_hash,
     safe_sign_and_autofill_transaction,
-    safe_sign_transaction,
     send_reliable_submission,
+    sign,
 )
 from xrpl.clients import XRPLRequestFailureException
 from xrpl.core.addresscodec import classic_address_to_xaddress
@@ -389,7 +389,7 @@ class TestReliableSubmission(IntegrationTestCase):
     @test_async_and_sync(
         globals(),
         [
-            "xrpl.transaction.safe_sign_transaction",
+            "xrpl.transaction.sign",
             "xrpl.transaction.send_reliable_submission",
             "xrpl.account.get_next_valid_seq_number",
             "xrpl.ledger.get_fee",
@@ -405,16 +405,14 @@ class TestReliableSubmission(IntegrationTestCase):
             "destination": DESTINATION,
         }
         payment_transaction = Payment.from_dict(payment_dict)
-        signed_payment_transaction = await safe_sign_transaction(
-            payment_transaction, WALLET
-        )
+        signed_payment_transaction = await sign(payment_transaction, WALLET)
         with self.assertRaises(XRPLRequestFailureException):
             await send_reliable_submission(signed_payment_transaction, client)
 
     @test_async_and_sync(
         globals(),
         [
-            "xrpl.transaction.safe_sign_transaction",
+            "xrpl.transaction.sign",
             "xrpl.transaction.send_reliable_submission",
             "xrpl.account.get_next_valid_seq_number",
             "xrpl.ledger.get_fee",
@@ -430,8 +428,6 @@ class TestReliableSubmission(IntegrationTestCase):
             "destination": DESTINATION,
         }
         payment_transaction = Payment.from_dict(payment_dict)
-        signed_payment_transaction = await safe_sign_transaction(
-            payment_transaction, WALLET
-        )
+        signed_payment_transaction = await sign(payment_transaction, WALLET)
         with self.assertRaises(XRPLReliableSubmissionException):
             await send_reliable_submission(signed_payment_transaction, client)

--- a/tests/unit/models/transactions/test_better_transaction_flags.py
+++ b/tests/unit/models/transactions/test_better_transaction_flags.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 from xrpl import models
 from xrpl.models.exceptions import XRPLModelException
-from xrpl.transaction.main import safe_sign_transaction
+from xrpl.transaction.main import sign
 from xrpl.wallet.main import Wallet
 
 # from typing import Iterable
@@ -37,11 +37,11 @@ class TestBetterTransactionFlags(TestCase):
             account=ACCOUNT,
             flags=[*flags],
         )
-        signed_actual = safe_sign_transaction(
+        signed_actual = sign(
             transaction=actual,
             wallet=WALLET,
         )
-        signed_expected = safe_sign_transaction(
+        signed_expected = sign(
             transaction=expected,
             wallet=WALLET,
         )
@@ -70,11 +70,11 @@ class TestBetterTransactionFlags(TestCase):
             amount="1000000",
             flags=[*flags],
         )
-        signed_actual = safe_sign_transaction(
+        signed_actual = sign(
             transaction=actual,
             wallet=WALLET,
         )
-        signed_expected = safe_sign_transaction(
+        signed_expected = sign(
             transaction=expected,
             wallet=WALLET,
         )
@@ -102,11 +102,11 @@ class TestBetterTransactionFlags(TestCase):
             nftoken_taxon=0,
             flags=[*flags],
         )
-        signed_actual = safe_sign_transaction(
+        signed_actual = sign(
             transaction=actual,
             wallet=WALLET,
         )
-        signed_expected = safe_sign_transaction(
+        signed_expected = sign(
             transaction=expected,
             wallet=WALLET,
         )
@@ -145,11 +145,11 @@ class TestBetterTransactionFlags(TestCase):
                 flags.TF_SELL,
             ],
         )
-        signed_actual = safe_sign_transaction(
+        signed_actual = sign(
             transaction=actual,
             wallet=WALLET,
         )
-        signed_expected = safe_sign_transaction(
+        signed_expected = sign(
             transaction=expected,
             wallet=WALLET,
         )
@@ -188,11 +188,11 @@ class TestBetterTransactionFlags(TestCase):
                 flags.TF_SELL,
             ],
         )
-        signed_actual = safe_sign_transaction(
+        signed_actual = sign(
             transaction=actual,
             wallet=WALLET,
         )
-        signed_expected = safe_sign_transaction(
+        signed_expected = sign(
             transaction=expected,
             wallet=WALLET,
         )
@@ -218,11 +218,11 @@ class TestBetterTransactionFlags(TestCase):
             channel="C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749DCDD3B9E5992CA6198",
             flags=[*flags],
         )
-        signed_actual = safe_sign_transaction(
+        signed_actual = sign(
             transaction=actual,
             wallet=WALLET,
         )
-        signed_expected = safe_sign_transaction(
+        signed_expected = sign(
             transaction=expected,
             wallet=WALLET,
         )
@@ -253,11 +253,11 @@ class TestBetterTransactionFlags(TestCase):
             amount=amnt,
             flags=[*flags],
         )
-        signed_actual = safe_sign_transaction(
+        signed_actual = sign(
             transaction=actual,
             wallet=WALLET,
         )
-        signed_expected = safe_sign_transaction(
+        signed_expected = sign(
             transaction=expected,
             wallet=WALLET,
         )
@@ -291,11 +291,11 @@ class TestBetterTransactionFlags(TestCase):
             limit_amount=amnt,
             flags=[*flags],
         )
-        signed_actual = safe_sign_transaction(
+        signed_actual = sign(
             transaction=actual,
             wallet=WALLET,
         )
-        signed_expected = safe_sign_transaction(
+        signed_expected = sign(
             transaction=expected,
             wallet=WALLET,
         )
@@ -321,11 +321,11 @@ class TestBetterTransactionFlags(TestCase):
             ledger_sequence=seq,
             flags=[*flags],
         )
-        signed_actual = safe_sign_transaction(
+        signed_actual = sign(
             transaction=actual,
             wallet=WALLET,
         )
-        signed_expected = safe_sign_transaction(
+        signed_expected = sign(
             transaction=expected,
             wallet=WALLET,
         )
@@ -340,7 +340,7 @@ class TestBetterTransactionFlags(TestCase):
                 account=ACCOUNT,
                 offer_sequence=6,
             )
-            safe_sign_transaction(
+            sign(
                 transaction=cancel_offer,
                 wallet=WALLET,
             )
@@ -351,7 +351,7 @@ class TestBetterTransactionFlags(TestCase):
                 destination=dest,
                 amount=amnt,
             )
-            safe_sign_transaction(
+            sign(
                 transaction=pymnt,
                 wallet=WALLET,
             )
@@ -376,7 +376,7 @@ class TestBetterTransactionFlags(TestCase):
                     ),
                 ],
             )
-            safe_sign_transaction(transaction=tx, wallet=WALLET)
+            sign(transaction=tx, wallet=WALLET)
         with self.assertRaises(XRPLModelException):
             tx = models.Payment(
                 account=ACCOUNT,
@@ -384,7 +384,7 @@ class TestBetterTransactionFlags(TestCase):
                 amount=amnt,
                 flags=["1"],
             )
-            safe_sign_transaction(transaction=tx, wallet=WALLET)
+            sign(transaction=tx, wallet=WALLET)
         with self.assertRaises(XRPLModelException):
             tx = models.Payment(
                 account=ACCOUNT,
@@ -392,7 +392,7 @@ class TestBetterTransactionFlags(TestCase):
                 amount=amnt,
                 flags=[65536, models.PaymentFlagInterface(tf_limit_quality=True)],
             )
-            safe_sign_transaction(transaction=tx, wallet=WALLET)
+            sign(transaction=tx, wallet=WALLET)
 
     def test_transaction_has_no_flags(self):
         actual = models.OfferCancel(
@@ -403,11 +403,11 @@ class TestBetterTransactionFlags(TestCase):
             ),
         )
         expected = models.OfferCancel(account=ACCOUNT, offer_sequence=6, flags=0)
-        signed_actual = safe_sign_transaction(
+        signed_actual = sign(
             transaction=actual,
             wallet=WALLET,
         )
-        signed_expected = safe_sign_transaction(
+        signed_expected = sign(
             transaction=expected,
             wallet=WALLET,
         )

--- a/xrpl/asyncio/transaction/__init__.py
+++ b/xrpl/asyncio/transaction/__init__.py
@@ -5,6 +5,7 @@ from xrpl.asyncio.transaction.main import (
     safe_sign_and_autofill_transaction,
     safe_sign_and_submit_transaction,
     safe_sign_transaction,
+    sign,
     submit_transaction,
     transaction_json_to_binary_codec_form,
 )
@@ -19,6 +20,7 @@ __all__ = [
     "safe_sign_transaction",
     "safe_sign_and_autofill_transaction",
     "safe_sign_and_submit_transaction",
+    "sign",
     "submit_transaction",
     "transaction_json_to_binary_codec_form",
     "send_reliable_submission",

--- a/xrpl/asyncio/transaction/main.py
+++ b/xrpl/asyncio/transaction/main.py
@@ -10,7 +10,7 @@ from xrpl.asyncio.ledger import get_fee, get_latest_validated_ledger_sequence
 from xrpl.constants import XRPLException
 from xrpl.core.addresscodec import is_valid_xaddress, xaddress_to_classic_address
 from xrpl.core.binarycodec import encode, encode_for_signing
-from xrpl.core.keypairs.main import sign
+from xrpl.core.keypairs.main import sign as keypairs_sign
 from xrpl.models.requests import ServerState, SubmitOnly
 from xrpl.models.response import Response
 from xrpl.models.transactions import EscrowFinish
@@ -55,11 +55,11 @@ async def safe_sign_and_submit_transaction(
             transaction, wallet, client, check_fee
         )
     else:
-        transaction = await safe_sign_transaction(transaction, wallet, check_fee)
+        transaction = await sign(transaction, wallet, check_fee)
     return await submit_transaction(transaction, client)
 
 
-async def safe_sign_transaction(
+async def sign(
     transaction: Transaction,
     wallet: Wallet,
     check_fee: bool = True,
@@ -81,9 +81,12 @@ async def safe_sign_transaction(
     transaction_json = _prepare_transaction(transaction, wallet)
     serialized_for_signing = encode_for_signing(transaction_json)
     serialized_bytes = bytes.fromhex(serialized_for_signing)
-    signature = sign(serialized_bytes, wallet.private_key)
+    signature = keypairs_sign(serialized_bytes, wallet.private_key)
     transaction_json["TxnSignature"] = signature
     return Transaction.from_xrpl(transaction_json)
+
+
+safe_sign_transaction = sign
 
 
 async def safe_sign_and_autofill_transaction(
@@ -112,9 +115,7 @@ async def safe_sign_and_autofill_transaction(
     if check_fee:
         await _check_fee(transaction, client)
 
-    return await safe_sign_transaction(
-        await autofill(transaction, client), wallet, False
-    )
+    return await sign(await autofill(transaction, client), wallet, False)
 
 
 async def submit_transaction(

--- a/xrpl/transaction/__init__.py
+++ b/xrpl/transaction/__init__.py
@@ -9,6 +9,7 @@ from xrpl.transaction.main import (
     safe_sign_and_autofill_transaction,
     safe_sign_and_submit_transaction,
     safe_sign_transaction,
+    sign,
     submit_transaction,
 )
 from xrpl.transaction.reliable_submission import send_reliable_submission
@@ -19,6 +20,7 @@ __all__ = [
     "safe_sign_transaction",
     "safe_sign_and_autofill_transaction",
     "safe_sign_and_submit_transaction",
+    "sign",
     "submit_transaction",
     "transaction_json_to_binary_codec_form",
     "send_reliable_submission",

--- a/xrpl/transaction/main.py
+++ b/xrpl/transaction/main.py
@@ -66,7 +66,7 @@ def submit_transaction(
     )
 
 
-def safe_sign_transaction(
+def sign(
     transaction: Transaction,
     wallet: Wallet,
     check_fee: bool = True,
@@ -84,12 +84,15 @@ def safe_sign_transaction(
         The signed transaction.
     """
     return asyncio.run(
-        main.safe_sign_transaction(
+        main.sign(
             transaction,
             wallet,
             check_fee,
         )
     )
+
+
+safe_sign_transaction = sign
 
 
 def safe_sign_and_autofill_transaction(


### PR DESCRIPTION
## High Level Overview of Change

Added alias function for `safe_sign_transaction` called `sign`

### Context of Change

`safe_sign_transaction` is too long and unnecessary -- potentially deprecate/remove in xrpl-py 2.0

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release