### PR TITLE
refactor: Deprecate xrpl-py sugar that is just a wrapper on a request

### DIFF
--- a/xrpl/account/transaction_history.py
+++ b/xrpl/account/transaction_history.py
@@ -27,7 +27,7 @@ def get_latest_transaction(account: str, client: SyncClient) -> Response:
 
 
 @deprecated(
-    reason="Sending an AccountTx request directly allows you to page through all"
+    reason="Sending an AccountTx request directly allows you to page through all "
     "results and is just as easy to use.",
     version="1.6.0",
 )
@@ -64,7 +64,7 @@ def get_account_payment_transactions(
         client: the network client used to make network calls.
 
     Returns:
-        The most recent payment transaction history for the address. For the full
+        The first page of payment transaction history for the address. For the full
         history, page through the :class:`AccountTx` request directly.
     """
     return asyncio.run(

--- a/xrpl/asyncio/account/transaction_history.py
+++ b/xrpl/asyncio/account/transaction_history.py
@@ -35,7 +35,7 @@ async def get_latest_transaction(account: str, client: Client) -> Response:
 
 
 @deprecated(
-    reason="Sending an AccountTx request directly allows you to page through all"
+    reason="Sending an AccountTx request directly allows you to page through all "
     "results and is just as easy to use.",
     version="1.6.0",
 )

--- a/xrpl/asyncio/account/transaction_history.py
+++ b/xrpl/asyncio/account/transaction_history.py
@@ -82,7 +82,7 @@ async def get_account_payment_transactions(
         client: the network client used to make network calls.
 
     Returns:
-        The most page of payment transaction history for the address. For the full
+        The first page of payment transaction history for the address. For the full
         history, page through the :class:`AccountTx` request directly.
     """
     all_transactions = await get_account_transactions(address, client)


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->
Deprecated ___

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->
Some functions in xrpl-py are identical to a rippled request, but with less features since the return types are simplified. We should deprecate these, and instead recommend that people just directly do client.request(...) with the appropriate request type. 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release