### PR TITLE
fix: fix `NestedModel` typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `check_fee` now has a higher limit that is less likely to be hit
 - When connected to nft devnet or hooks v2 testnet generate_faucet_wallet now defaults to using the faucet instead of requiring specification
 
+### Fixed:
+- Properly type the instance functions of NestedModel
+
 ## [1.7.0] - 2022-10-12
 ### Added:
 - Support for ExpandedSignerList amendment that expands the maximum signer list to 32 entries

--- a/xrpl/models/nested_model.py
+++ b/xrpl/models/nested_model.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Type, Union
+from typing import Any, Dict, Type, TypeVar, Union
 
 from xrpl.models.base_model import BaseModel, _key_to_json
+
+NM = TypeVar("NM", bound="NestedModel")  # any type inherited from BaseModel
 
 
 def _get_nested_name(cls: Union[NestedModel, Type[NestedModel]]) -> str:
@@ -19,7 +21,7 @@ class NestedModel(BaseModel):
     """The base class for models that involve a nested dictionary e.g. memos."""
 
     @classmethod
-    def is_dict_of_model(cls: Type[NestedModel], dictionary: Any) -> bool:
+    def is_dict_of_model(cls: Type[NM], dictionary: Any) -> bool:
         """
         Returns True if the input dictionary was derived by the `to_dict`
         method of an instance of this class. In other words, True if this is
@@ -43,7 +45,7 @@ class NestedModel(BaseModel):
         )
 
     @classmethod
-    def from_dict(cls: Type[NestedModel], value: Dict[str, Any]) -> NestedModel:
+    def from_dict(cls: Type[NM], value: Dict[str, Any]) -> NM:
         """
         Construct a new NestedModel from a dictionary of parameters.
 


### PR DESCRIPTION
## High Level Overview of Change

The instance methods of the `NestedModel` helper class weren't properly typed. This PR fixes that.

### Context of Change

This was uncovered while working on the sidechain CLI

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Works in the sidechain CLI
