### PR TITLE
refactor: simplify `TypedDict` types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
         "addresscodec",
         "asyncio",
         "binarycodec",
+        "nftoken",
         "xaddress"
     ],
 }

--- a/xrpl/models/transactions/metadata.py
+++ b/xrpl/models/transactions/metadata.py
@@ -1,8 +1,8 @@
 """Models for a transaction's metadata."""
 
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Union
 
-from typing_extensions import Literal, TypedDict
+from typing_extensions import Literal, NotRequired, TypedDict
 
 from xrpl.models.amounts.amount import Amount
 
@@ -10,16 +10,16 @@ from xrpl.models.amounts.amount import Amount
 class Fields(TypedDict, total=False):
     """Model for possible fields."""
 
-    Account: Optional[str]
-    LowLimit: Optional[Dict[str, str]]
-    HighLimit: Optional[Dict[str, str]]
-    Balance: Optional[Union[Dict[str, str], str]]
-    TakerGets: Optional[Union[Dict[str, str], str]]
-    TakerPays: Optional[Union[Dict[str, str], str]]
+    Account: NotRequired[str]
+    LowLimit: NotRequired[Dict[str, str]]
+    HighLimit: NotRequired[Dict[str, str]]
+    Balance: NotRequired[Union[Dict[str, str], str]]
+    TakerGets: NotRequired[Union[Dict[str, str], str]]
+    TakerPays: NotRequired[Union[Dict[str, str], str]]
     Flags: int
     Sequence: int
-    BookDirectory: Optional[str]
-    Expiration: Optional[int]
+    BookDirectory: NotRequired[str]
+    Expiration: NotRequired[int]
 
 
 class CreatedNodeFields(TypedDict):
@@ -36,25 +36,15 @@ class CreatedNode(TypedDict):
     CreatedNode: CreatedNodeFields
 
 
-class OptionalModifiedNodeFields(TypedDict, total=False):
-    """The optional fields of `ModifiedNodeFields`."""
-
-    """
-    The fields are separated from `ModifiedNodeFields` to make them optional,
-    while keeping `LedgerEntryType` and `LedgerIndex` required.
-    """
-
-    FinalFields: Optional[Fields]
-    PreviousFields: Optional[Fields]
-    PreviousTxnID: Optional[str]
-    PreviousTxnLgrSeq: Optional[int]
-
-
-class ModifiedNodeFields(OptionalModifiedNodeFields):
+class ModifiedNodeFields(TypedDict):
     """Fields of a ModifiedNode."""
 
     LedgerEntryType: str
     LedgerIndex: str
+    FinalFields: NotRequired[Fields]
+    PreviousFields: NotRequired[Fields]
+    PreviousTxnID: NotRequired[str]
+    PreviousTxnLgrSeq: NotRequired[int]
 
 
 class ModifiedNode(TypedDict):
@@ -63,23 +53,13 @@ class ModifiedNode(TypedDict):
     ModifiedNode: ModifiedNodeFields
 
 
-class OptionalDeletedNodeFields(TypedDict, total=False):
-    """The optional fields of `DeletedNodeFields`."""
-
-    """
-    The fields are separated from `DeletedNodeFields` to make them optional,
-    while keeping `LedgerEntryType`, `LedgerIndex` and `FinalFields` required.
-    """
-
-    PreviousFields: Optional[Fields]
-
-
-class DeletedNodeFields(OptionalDeletedNodeFields):
+class DeletedNodeFields(TypedDict):
     """Fields of a DeletedNode."""
 
     LedgerEntryType: str
     LedgerIndex: str
     FinalFields: Fields
+    PreviousFields: NotRequired[Fields]
 
 
 class DeletedNode(TypedDict):
@@ -88,22 +68,12 @@ class DeletedNode(TypedDict):
     DeletedNode: DeletedNodeFields
 
 
-class OptionalTransactionMetadataFields(TypedDict, total=False):
-    """The optional fields of `TransactionMetadata`."""
-
-    """
-    The fields are separated from `TransactionMetadata` to make them optional,
-    while keeping `AffectedNodes`, `TransactionIndex` and `TransactionResult` required.
-    """
-
-    DeliveredAmount: Optional[Amount]
-    # "unavailable" possible for transactions before 2014-01-20
-    delivered_amount: Optional[Union[Amount, Literal["unavailable"]]]
-
-
-class TransactionMetadata(OptionalTransactionMetadataFields):
+class TransactionMetadata(TypedDict):
     """A model for a transaction's metadata."""
 
     AffectedNodes: List[Union[CreatedNode, ModifiedNode, DeletedNode]]
     TransactionIndex: int
     TransactionResult: str
+    DeliveredAmount: NotRequired[Amount]
+    # "unavailable" possible for transactions before 2014-01-20
+    delivered_amount: NotRequired[Union[Amount, Literal["unavailable"]]]

--- a/xrpl/models/transactions/metadata.py
+++ b/xrpl/models/transactions/metadata.py
@@ -7,17 +7,17 @@ from typing_extensions import Literal, NotRequired, TypedDict
 from xrpl.models.amounts.amount import Amount
 
 
-class Fields(TypedDict, total=False):
+class Fields(TypedDict):
     """Model for possible fields."""
 
+    Flags: int
+    Sequence: int
     Account: NotRequired[str]
     LowLimit: NotRequired[Dict[str, str]]
     HighLimit: NotRequired[Dict[str, str]]
     Balance: NotRequired[Union[Dict[str, str], str]]
     TakerGets: NotRequired[Union[Dict[str, str], str]]
     TakerPays: NotRequired[Union[Dict[str, str], str]]
-    Flags: int
-    Sequence: int
     BookDirectory: NotRequired[str]
     Expiration: NotRequired[int]
 

--- a/xrpl/utils/txn_parser/utils/nodes.py
+++ b/xrpl/utils/txn_parser/utils/nodes.py
@@ -16,27 +16,17 @@ from xrpl.models.transactions.metadata import (
 )
 
 
-class OptionalFieldNames(TypedDict, total=False):
-    """The optional fields of `NormalizedNode`."""
-
-    """
-    The fields are separated from `NormalizedNode` to make them optional,
-    while keeping `NodeType`, `LedgerEntryType` and `LedgerIndex` required.
-    """
-
-    NewFields: Optional[Fields]
-    FinalFields: Optional[Fields]
-    PreviousFields: Optional[Fields]
-    PreviousTxnID: Optional[str]
-    PreviousTxnLgrSeq: Optional[int]
-
-
-class NormalizedNode(OptionalFieldNames):
+class NormalizedNode(TypedDict):
     """A model representing an affected node in a standard format."""
 
     NodeType: Literal["CreatedNode", "ModifiedNode", "DeletedNode"]
     LedgerEntryType: str
     LedgerIndex: str
+    NewFields: Optional[Fields]
+    FinalFields: Optional[Fields]
+    PreviousFields: Optional[Fields]
+    PreviousTxnID: Optional[str]
+    PreviousTxnLgrSeq: Optional[int]
 
 
 def _normalize_node(

--- a/xrpl/utils/txn_parser/utils/types.py
+++ b/xrpl/utils/txn_parser/utils/types.py
@@ -2,27 +2,20 @@
 
 from typing import List
 
-from typing_extensions import Literal, TypedDict
+from typing_extensions import Literal, NotRequired, TypedDict
 
 
-class OptionalIssuer(TypedDict, total=False):
-    """The optional issuer field for an account's balance."""
-
-    """
-    The `issuer` field is separated from `Balance` to make it
-    optional, while keeping `currency` and `value` required.
-    """
-    issuer: str
-    """The issuer of the currency. This value is optional."""
-
-
-class Balance(OptionalIssuer):
+class Balance(TypedDict):
     """A account's balance model."""
 
     currency: str
     """The currency code."""
+
     value: str
     """The amount of the currency."""
+
+    issuer: NotRequired[str]
+    """The issuer of the currency. This value is optional."""
 
 
 class AccountBalance(TypedDict):
@@ -47,18 +40,7 @@ class CurrencyAmount(Balance):
     pass
 
 
-class OptionalExpiration(TypedDict, total=False):
-    """The optional expiration field for an offer."""
-
-    """
-    The `Expiration` field is separated from `OfferChange` to make it
-    optional, while keeping all other fields required.
-    """
-
-    expiration_time: int
-
-
-class OfferChange(OptionalExpiration):
+class OfferChange(TypedDict):
     """A single offer change."""
 
     flags: int
@@ -67,6 +49,7 @@ class OfferChange(OptionalExpiration):
     sequence: int
     status: Literal["created", "partially-filled", "filled", "cancelled"]
     maker_exchange_rate: str
+    expiration_time: NotRequired[int]
 
 
 class AccountOfferChange(TypedDict):


### PR DESCRIPTION
## High Level Overview of Change

This PR uses `NotRequired` (equivalent to TypeScript `?` in interfaces) to simplify the metadata `TypedDict` types, making the code both simpler and easier to read.

### Context of Change

I wanted to try out a new feature that was added in Python 3.11 and backported to previous Python versions.

The `TypedDict` metadata types were messy because `NotRequired` wasn't supported previously. But it has since been added to `typing_extensions`.

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

## Test Plan

CI passes.