### PR TITLE
fix: fix Github Actions issues

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -9,12 +9,12 @@ on:
 jobs:
   integration-test:
     name: Integration test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       matrix:
-        # we have to use 3.7.1 to get around openssl issues
-        python-version: ['3.7.1', '3.8', '3.9', '3.10']
+        # we have to use 3.7.13 because that's the oldest version supported by the ubuntu 22.04 image
+        python-version: ['3.7.13', '3.8', '3.9', '3.10']
       fail-fast: false
 
     services:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         # we have to use 3.7.1 to get around openssl issues
         python-version: ['3.7.1', '3.8', '3.9', '3.10']
-      fail-fast: false
 
     services:
       rippled:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         # we have to use 3.7.1 to get around openssl issues
         python-version: ['3.7.1', '3.8', '3.9', '3.10']
+      fail-fast: false
 
     services:
       rippled:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         # we have to use 3.7.1 to get around openssl issues
-        python-version: ['3.7.1', '3.8', '3.9', '3.10']
+        python-version: ['3.7.1', '3.8', '3.9', '3.10', '3.11']
 
     services:
       rippled:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -9,12 +9,12 @@ on:
 jobs:
   integration-test:
     name: Integration test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     strategy:
       matrix:
-        # we have to use 3.7.13 because that's the oldest version supported by the ubuntu 22.04 image
-        python-version: ['3.7.13', '3.8', '3.9', '3.10']
+        # we have to use 3.7.1 to get around openssl issues
+        python-version: ['3.7.1', '3.8', '3.9', '3.10']
       fail-fast: false
 
     services:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   integration-test:
     name: Integration test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     strategy:
       matrix:

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     env:
-      PYTHON_VERSION: "3.10"
+      PYTHON_VERSION: "3.11"
 
     steps:
       - name: Checkout code
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         # we have to use 3.7.1 to get around openssl issues
-        python-version: ['3.7.1', '3.8', '3.9', '3.10']
+        python-version: ['3.7.1', '3.8', '3.9', '3.10', '3.11']
 
     steps:
       - name: Checkout code

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   lint-and-type-check:
     name: Lint and type-check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     env:
       PYTHON_VERSION: "3.10"
@@ -52,11 +52,11 @@ jobs:
 
   unit-test:
     name: Unit test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        # we have to use 3.7.1 to get around openssl issues
-        python-version: ['3.7.1', '3.8', '3.9', '3.10']
+        # we have to use 3.7.13 because that's the oldest version supported by the ubuntu 22.04 image
+        python-version: ['3.7.13', '3.8', '3.9', '3.10']
       fail-fast: false
 
     steps:

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   lint-and-type-check:
     name: Lint and type-check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     env:
       PYTHON_VERSION: "3.10"
@@ -52,11 +52,11 @@ jobs:
 
   unit-test:
     name: Unit test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        # we have to use 3.7.13 because that's the oldest version supported by the ubuntu 22.04 image
-        python-version: ['3.7.13', '3.8', '3.9', '3.10']
+        # we have to use 3.7.1 to get around openssl issues
+        python-version: ['3.7.1', '3.8', '3.9', '3.10']
       fail-fast: false
 
     steps:

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Python + Retrieve Poetry dependencies from cache
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: 'poetry'
 
       - name: Display Python version
@@ -57,6 +57,7 @@ jobs:
       matrix:
         # we have to use 3.7.1 to get around openssl issues
         python-version: ['3.7.1', '3.8', '3.9', '3.10']
+        fail-fast: false
 
     steps:
       - name: Checkout code

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -57,7 +57,7 @@ jobs:
       matrix:
         # we have to use 3.7.1 to get around openssl issues
         python-version: ['3.7.1', '3.8', '3.9', '3.10']
-        fail-fast: false
+      fail-fast: false
 
     steps:
       - name: Checkout code

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   lint-and-type-check:
     name: Lint and type-check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     env:
       PYTHON_VERSION: "3.10"
@@ -52,7 +52,7 @@ jobs:
 
   unit-test:
     name: Unit test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         # we have to use 3.7.1 to get around openssl issues

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -57,7 +57,6 @@ jobs:
       matrix:
         # we have to use 3.7.1 to get around openssl issues
         python-version: ['3.7.1', '3.8', '3.9', '3.10']
-      fail-fast: false
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## High Level Overview of Change

This PR switches the Github Actions from running on `ubuntu-latest` (which recently switched to 22.04) to `ubuntu-20.04`, which fixes tests.

It also adds testing support for Python 3.11.

### Context of Change

Ubuntu 22.04 upgraded OpenSSL to version 3.0, which deprecated ripemd160. Github will not add support to the runner, because they want to run only the default version.

https://github.com/openssl/openssl/issues/16994
https://github.com/actions/runner-images/issues/6676

### Type of Change

- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Test Plan

CI now passes.
