### PR TITLE
fix: Used RIPEMD160 algorithm from PyCrypto rather than hashlib

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         # we have to use 3.7.1 to get around openssl issues
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7.1', '3.8', '3.9', '3.10', '3.11']
 
     services:
       rippled:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   integration-test:
     name: Integration test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       matrix:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -13,8 +13,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        # we have to use 3.7.1 to get around openssl issues
-        python-version: ['3.7.1', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     services:
       rippled:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         # we have to use 3.7.1 to get around openssl issues
-        python-version: ['3.7.1', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     services:
       rippled:

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         # we have to use 3.7.1 to get around openssl issues
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7.1', '3.8', '3.9', '3.10', '3.11']
 
     steps:
       - name: Checkout code

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -55,8 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # we have to use 3.7.1 to get around openssl issues
-        python-version: ['3.7.1', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
       - name: Checkout code

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         # we have to use 3.7.1 to get around openssl issues
-        python-version: ['3.7.1', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
       - name: Checkout code

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   lint-and-type-check:
     name: Lint and type-check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     env:
       PYTHON_VERSION: "3.11"
@@ -52,7 +52,7 @@ jobs:
 
   unit-test:
     name: Unit test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         # we have to use 3.7.1 to get around openssl issues

--- a/poetry.lock
+++ b/poetry.lock
@@ -97,7 +97,7 @@ optional = false
 python-versions = ">=3.6.0"
 
 [package.extras]
-unicode-backport = ["unicodedata2"]
+unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
@@ -150,7 +150,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 wrapt = ">=1.10,<2"
 
 [package.extras]
-dev = ["PyTest", "PyTest (<5)", "PyTest-Cov", "PyTest-Cov (<2.6)", "bump2version (<1)", "configparser (<5)", "importlib-metadata (<3)", "importlib-resources (<4)", "sphinx (<2)", "sphinxcontrib-websupport (<2)", "tox", "zipp (<2)"]
+dev = ["PyTest (<5)", "PyTest-Cov (<2.6)", "bump2version (<1)", "configparser (<5)", "importlib-metadata (<3)", "importlib-resources (<4)", "pytest", "pytest-cov", "sphinx (<2)", "sphinxcontrib-websupport (<2)", "tox", "zipp (<2)"]
 
 [[package]]
 name = "docutils"
@@ -334,9 +334,9 @@ python-versions = ">=3.6.1,<4.0"
 
 [package.extras]
 colors = ["colorama (>=0.4.3,<0.5.0)"]
-pipfile-deprecated-finder = ["pipreqs", "requirementslib"]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
 plugins = ["setuptools"]
-requirements-deprecated-finder = ["pip-api", "pipreqs"]
+requirements_deprecated_finder = ["pip-api", "pipreqs"]
 
 [[package]]
 name = "jinja2"
@@ -447,7 +447,7 @@ pastel = ">=0.2.1,<0.3.0"
 tomli = ">=1.2.2"
 
 [package.extras]
-poetry-plugin = ["poetry (>=1.0,<2.0)"]
+poetry_plugin = ["poetry (>=1.0,<2.0)"]
 
 [[package]]
 name = "pycodestyle"
@@ -456,6 +456,14 @@ description = "Python style guide checker"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pycryptodome"
+version = "3.16.0"
+description = "Cryptographic library for Python"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pydocstyle"
@@ -522,7 +530,7 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "rfc3986"
@@ -748,7 +756,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "e1b5110dfc70afa70ca971f87db7d1c294c2ae5cfb1a6e683a2e448b6a9f0159"
+content-hash = "db4658fe91ba3c280e0af38d3808031ea4f139e4414df7b873fb24959f902257"
 
 [metadata.files]
 aiounittest = [
@@ -1032,6 +1040,34 @@ poethepoet = [
 pycodestyle = [
     {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
     {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
+]
+pycryptodome = [
+    {file = "pycryptodome-3.16.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:e061311b02cefb17ea93d4a5eb1ad36dca4792037078b43e15a653a0a4478ead"},
+    {file = "pycryptodome-3.16.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:dab9359cc295160ba96738ba4912c675181c84bfdf413e5c0621cf00b7deeeaa"},
+    {file = "pycryptodome-3.16.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:0198fe96c22f7bc31e7a7c27a26b2cec5af3cf6075d577295f4850856c77af32"},
+    {file = "pycryptodome-3.16.0-cp27-cp27m-manylinux2014_aarch64.whl", hash = "sha256:58172080cbfaee724067a3c017add6a1a3cc167bbc8478dc5f2e5f45fa658763"},
+    {file = "pycryptodome-3.16.0-cp27-cp27m-win32.whl", hash = "sha256:4d950ed2a887905b3fa709b86be5a163e26e1b174703ed59d34eb6832f213222"},
+    {file = "pycryptodome-3.16.0-cp27-cp27m-win_amd64.whl", hash = "sha256:c69e19afc734b2a17b9d78b7bcb544aabd5a52ff628e14283b6e9404d27d0517"},
+    {file = "pycryptodome-3.16.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:1fc16c80a5da8231fd1f953a7b8dfeb415f68120248e8d68383c5c2c4b18708c"},
+    {file = "pycryptodome-3.16.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:5df582f2112dd72331de7e567837e136a9629181a8ab69ef8949e4bc294a0b99"},
+    {file = "pycryptodome-3.16.0-cp27-cp27mu-manylinux2014_aarch64.whl", hash = "sha256:2bf2a270906a02b7b255e1a0d7b3aea4f06b3983c51ddec1673c380e0dff5b30"},
+    {file = "pycryptodome-3.16.0-cp35-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b12a88566a98617b1a34b4e5a805dff2da98d83fc74262aff3c3d724d0f525d6"},
+    {file = "pycryptodome-3.16.0-cp35-abi3-manylinux2014_aarch64.whl", hash = "sha256:69adf32522b75968e1cbf25b5d83e87c04cd9a55610ce1e4a19012e58e7e4023"},
+    {file = "pycryptodome-3.16.0-cp35-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:d67a2d2fe344953e4572a7d30668cceb516b04287b8638170d562065e53ee2e0"},
+    {file = "pycryptodome-3.16.0-cp35-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e750a21d8a265b1f9bfb1a28822995ea33511ba7db5e2b55f41fb30781d0d073"},
+    {file = "pycryptodome-3.16.0-cp35-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:47c71a0347847b747ba1349767b16cde049bc36f21654eb09cc82306ef5fdcf8"},
+    {file = "pycryptodome-3.16.0-cp35-abi3-musllinux_1_1_i686.whl", hash = "sha256:856ebf822d08d754af62c22e2b93626509a72773214f92db1551e2b68d9e2a1b"},
+    {file = "pycryptodome-3.16.0-cp35-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:6016269bb56caf0327f6d42e7bad1247e08b78407446dff562240c65f85d5a5e"},
+    {file = "pycryptodome-3.16.0-cp35-abi3-win32.whl", hash = "sha256:1047ac2b9847ae84ea454e6e20db7dcb755a81c1b1631a879213d2b0ad835ff2"},
+    {file = "pycryptodome-3.16.0-cp35-abi3-win_amd64.whl", hash = "sha256:13b3e610a2f8938c61a90b20625069ab7a77ccea20d65a9a0f926cc0cc1314b1"},
+    {file = "pycryptodome-3.16.0-pp27-pypy_73-macosx_10_9_x86_64.whl", hash = "sha256:265bfcbbf20d58e6871ce695a7a08aac9b41a0553060d9c05363abd6f3391bdd"},
+    {file = "pycryptodome-3.16.0-pp27-pypy_73-manylinux2010_x86_64.whl", hash = "sha256:54d807314c66785c69cd25425933d4bd4c23547a593cdcf49d962fa3e0081336"},
+    {file = "pycryptodome-3.16.0-pp27-pypy_73-win32.whl", hash = "sha256:63165fbdc247450017eb9ef04cfe15cb3a72ca48ffcc3a3b75b08c0340bf3647"},
+    {file = "pycryptodome-3.16.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:95069fd9e2813668a2713a1efcc65cc26d2c7e741401ac46628f1ec957511f1b"},
+    {file = "pycryptodome-3.16.0-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:d1daec4d31bb00918e4e178297ac6ca6f86ec4c851ba584770533ece554d29e2"},
+    {file = "pycryptodome-3.16.0-pp37-pypy37_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:48d99869d58f3979d72f6fa0c50f48d16f14973bc4a3adb0ce3b8325fdd7e223"},
+    {file = "pycryptodome-3.16.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:c82e3bc1e70dde153b0956bffe20a15715a1fe3e00bc23e88d6973eda4505944"},
+    {file = "pycryptodome-3.16.0.tar.gz", hash = "sha256:0e45d2d852a66ecfb904f090c3f87dc0dfb89a499570abad8590f10d9cffb350"},
 ]
 pydocstyle = [
     {file = "pydocstyle-6.1.1-py3-none-any.whl", hash = "sha256:6987826d6775056839940041beef5c08cc7e3d71d63149b48e36727f70144dc4"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ websockets = [
 ]
 Deprecated = "^1.2.13"
 types-Deprecated = "^1.2.9"
+pycryptodome = "^3.16.0"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.8.4"

--- a/xrpl/core/keypairs/__init__.py
+++ b/xrpl/core/keypairs/__init__.py
@@ -2,8 +2,6 @@
 Low-level functions for creating and using cryptographic keys with the XRP
 Ledger.
 """
-from hashlib import algorithms_available
-
 from xrpl.core.keypairs.exceptions import XRPLKeypairsException
 from xrpl.core.keypairs.main import (
     derive_classic_address,
@@ -12,11 +10,6 @@ from xrpl.core.keypairs.main import (
     is_valid_message,
     sign,
 )
-
-assert (
-    "ripemd160" in algorithms_available
-), """Your OpenSSL implementation does not include the RIPEMD160 algorithm,
-    which is required by XRPL"""
 
 __all__ = [
     "derive_classic_address",

--- a/xrpl/core/keypairs/helpers.py
+++ b/xrpl/core/keypairs/helpers.py
@@ -1,6 +1,20 @@
 """Miscellaneous functions that are private to xrpl.core.keypairs."""
 import hashlib
 
+if "ripemd160" in hashlib.algorithms_available:
+    RIPEMD160_IN_HASHLIB = True
+else:
+    try:
+        import Crypto.Hash.RIPEMD160 as RIPEMD160
+
+        RIPEMD160_IN_HASHLIB = False
+    except ImportError:
+        raise ImportError(
+            """Your OpenSSL implementation does not include """
+            """the RIPEMD160 algorithm, which is required """
+            """by XRPL, or pycrypto needs installing"""
+        )
+
 
 def sha512_first_half(message: bytes) -> bytes:
     """
@@ -28,4 +42,7 @@ def get_account_id(public_key: bytes) -> bytes:
         The account ID for the given public key.
     """
     sha_hash = hashlib.sha256(public_key).digest()
-    return hashlib.new("ripemd160", sha_hash).digest()
+    if RIPEMD160_IN_HASHLIB:
+        return hashlib.new("ripemd160", sha_hash).digest()
+    else:
+        return bytes(RIPEMD160.new(sha_hash).digest())

--- a/xrpl/core/keypairs/helpers.py
+++ b/xrpl/core/keypairs/helpers.py
@@ -1,19 +1,7 @@
 """Miscellaneous functions that are private to xrpl.core.keypairs."""
 import hashlib
 
-if "ripemd160" in hashlib.algorithms_available:
-    RIPEMD160_IN_HASHLIB = True
-else:
-    try:
-        import Crypto.Hash.RIPEMD160 as RIPEMD160
-
-        RIPEMD160_IN_HASHLIB = False
-    except ImportError:
-        raise ImportError(
-            """Your OpenSSL implementation does not include """
-            """the RIPEMD160 algorithm, which is required """
-            """by XRPL, or pycrypto needs installing"""
-        )
+import Crypto.Hash.RIPEMD160 as RIPEMD160
 
 
 def sha512_first_half(message: bytes) -> bytes:
@@ -42,7 +30,4 @@ def get_account_id(public_key: bytes) -> bytes:
         The account ID for the given public key.
     """
     sha_hash = hashlib.sha256(public_key).digest()
-    if RIPEMD160_IN_HASHLIB:
-        return hashlib.new("ripemd160", sha_hash).digest()
-    else:
-        return bytes(RIPEMD160.new(sha_hash).digest())
+    return bytes(RIPEMD160.new(sha_hash).digest())


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->
Used RIPEMD160 algorithm from PyCrypto rather than hashlib since hashlib uses OpenSSL

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->
Apparently Ubuntu LTS 22.04 upgraded OpenSSL to version 3.0 which deprecated RIPEMD160. As a result, our tests fail since they require this algorithm. We have reverted tests back to Ubuntu 20.04 to make them work, but this doesn’t seem ideal. 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
