### PR TITLE
add check for txnNotFound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed:
 - Properly type the instance functions of NestedModel
-- Added additional check to `txnNotFound` error from `reliable_submission` due to racing condition
+- Added additional check to `txnNotFound` error from `reliable_submission` due to race condition
 
 ## [1.7.0] - 2022-10-12
 ### Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed:
 - Properly type the instance functions of NestedModel
+- Added additional check to `txnNotFound` error from `reliable_submission` due to racing condition
 
 ## [1.7.0] - 2022-10-12
 ### Added:

--- a/xrpl/asyncio/transaction/reliable_submission.py
+++ b/xrpl/asyncio/transaction/reliable_submission.py
@@ -43,7 +43,8 @@ async def _wait_for_final_transaction_outcome(
         if e.error == "txnNotFound" and attempts < 4:
 
             """
-            For the case if a submitted transaction is still in queue and not processed on the ledger yet.
+            For the case if a submitted transaction is still
+            in queue and not processed on the ledger yet.
             Retry 4 times before raising an exception.
             """
             return await _wait_for_final_transaction_outcome(

--- a/xrpl/asyncio/transaction/reliable_submission.py
+++ b/xrpl/asyncio/transaction/reliable_submission.py
@@ -42,10 +42,10 @@ async def _wait_for_final_transaction_outcome(
     except XRPLRequestFailureException as e:
         if e.error == "txnNotFound" and attempts < 4:
 
-            """err code for if the txn is not found on the ledger due to
-            when the transaction is still in queue and tx command is not
-            able to find it reason being it is not processed and hence
-            doesn't reflect on rippled databases."""
+            """
+            For the case if a submitted transaction is still in queue and not processed on the ledger yet.
+            Retry 4 times before raising an exception.
+            """
             return await _wait_for_final_transaction_outcome(
                 transaction_hash, client, prelim_result, attempts + 1
             )

--- a/xrpl/asyncio/transaction/reliable_submission.py
+++ b/xrpl/asyncio/transaction/reliable_submission.py
@@ -23,7 +23,7 @@ class XRPLReliableSubmissionException(XRPLException):
 
 
 async def _wait_for_final_transaction_outcome(
-    transaction_hash: str, client: Client, prelim_result: str, attempts: int
+    transaction_hash: str, client: Client, prelim_result: str, attempts: int = 0
 ) -> Response:
     """
     The core logic of reliable submission.  Polls the ledger until the result of the
@@ -41,7 +41,11 @@ async def _wait_for_final_transaction_outcome(
         )
     except XRPLRequestFailureException as e:
         if e.error == "txnNotFound" and attempts < 4:
-            # err code for if the txn is not found on the ledger due to race condition
+
+            """err code for if the txn is not found on the ledger due to
+            when the transaction is still in queue and tx command is not
+            able to find it reason being it is not processed and hence
+            doesn't reflect on rippled databases."""
             return await _wait_for_final_transaction_outcome(
                 transaction_hash, client, prelim_result, attempts + 1
             )

--- a/xrpl/asyncio/transaction/reliable_submission.py
+++ b/xrpl/asyncio/transaction/reliable_submission.py
@@ -41,7 +41,7 @@ async def _wait_for_final_transaction_outcome(
         )
     except XRPLRequestFailureException as e:
         if e.error == "txnNotFound":
-            # err code for if the txn is not found on the ledger due to racing condition
+            # err code for if the txn is not found on the ledger due to race condition
             return await _wait_for_final_transaction_outcome(
                 transaction_hash, client, prelim_result
             )


### PR DESCRIPTION
## High Level Overview of Change
solving txnNotFound issue https://github.com/XRPLF/xrpl-py/issues/312 due to racing condition - similar solution to JS  https://github.com/XRPLF/xrpl.js/pull/1883

### Context of Change
add a condition to check for exceptions - If the exception is  `txnNotFound`, rerun the function with sleeper activated to wait for mainnet queue to clear up. 

### Type of Change


- [X ] Bug fix (non-breaking change which fixes an issue)


## Test Plan
Integration and unit tests passed but haven't reproduced the spotty bug yet 

