### PR TITLE
Remove nft-devnet from tests

### DIFF
--- a/tests/integration/sugar/test_wallet.py
+++ b/tests/integration/sugar/test_wallet.py
@@ -3,9 +3,8 @@ import time
 from tests.integration.integration_test_case import IntegrationTestCase
 from tests.integration.it_utils import submit_transaction_async, test_async_and_sync
 from tests.integration.reusable_values import WALLET
-from xrpl.asyncio.clients import AsyncJsonRpcClient, AsyncWebsocketClient
+from xrpl.asyncio.clients import AsyncWebsocketClient
 from xrpl.asyncio.wallet import generate_faucet_wallet
-from xrpl.clients import JsonRpcClient, WebsocketClient
 from xrpl.core.addresscodec import classic_address_to_xaddress
 from xrpl.models.requests import AccountInfo
 from xrpl.models.transactions import Payment
@@ -78,32 +77,6 @@ class TestWallet(IntegrationTestCase):
         )
         self.assertTrue(response.is_successful())
 
-    async def test_generate_faucet_wallet_custom_host_async_websockets(self):
-        async with AsyncWebsocketClient(
-            "wss://xls20-sandbox.rippletest.net:51233"
-        ) as client:
-            await generate_faucet_wallet_and_fund_again(
-                self, client, "faucet-nft.ripple.com"
-            )
-
-    async def test_generate_faucet_wallet_custom_host_async_json_rpc(self):
-        client = AsyncJsonRpcClient("http://xls20-sandbox.rippletest.net:51234")
-        await generate_faucet_wallet_and_fund_again(
-            self, client, "faucet-nft.ripple.com"
-        )
-
-    def test_generate_faucet_wallet_custom_host_sync_websockets(self):
-        with WebsocketClient("wss://xls20-sandbox.rippletest.net:51233") as client:
-            sync_generate_faucet_wallet_and_fund_again(
-                self, client, "faucet-nft.ripple.com"
-            )
-
-    def test_generate_faucet_wallet_custom_host_sync_json_rpc(self):
-        client = JsonRpcClient("http://xls20-sandbox.rippletest.net:51234")
-        sync_generate_faucet_wallet_and_fund_again(
-            self, client, "faucet-nft.ripple.com"
-        )
-
     async def test_generate_faucet_wallet_testnet_async_websockets(self):
         async with AsyncWebsocketClient(
             "wss://s.altnet.rippletest.net:51233"
@@ -113,12 +86,6 @@ class TestWallet(IntegrationTestCase):
     async def test_generate_faucet_wallet_devnet_async_websockets(self):
         async with AsyncWebsocketClient(
             "wss://s.devnet.rippletest.net:51233"
-        ) as client:
-            await generate_faucet_wallet_and_fund_again(self, client)
-
-    async def test_generate_faucet_wallet_nft_devnet_async_websockets(self):
-        async with AsyncWebsocketClient(
-            "ws://xls20-sandbox.rippletest.net:51233"
         ) as client:
             await generate_faucet_wallet_and_fund_again(self, client)
 

--- a/tests/integration/sugar/test_wallet.py
+++ b/tests/integration/sugar/test_wallet.py
@@ -3,8 +3,9 @@ import time
 from tests.integration.integration_test_case import IntegrationTestCase
 from tests.integration.it_utils import submit_transaction_async, test_async_and_sync
 from tests.integration.reusable_values import WALLET
-from xrpl.asyncio.clients import AsyncWebsocketClient
+from xrpl.asyncio.clients import AsyncJsonRpcClient, AsyncWebsocketClient
 from xrpl.asyncio.wallet import generate_faucet_wallet
+from xrpl.clients import JsonRpcClient, WebsocketClient
 from xrpl.core.addresscodec import classic_address_to_xaddress
 from xrpl.models.requests import AccountInfo
 from xrpl.models.transactions import Payment
@@ -82,6 +83,32 @@ class TestWallet(IntegrationTestCase):
             "wss://s.altnet.rippletest.net:51233"
         ) as client:
             await generate_faucet_wallet_and_fund_again(self, client)
+
+    async def test_generate_faucet_wallet_custom_host_async_websockets(self):
+        async with AsyncWebsocketClient(
+            "wss://s.devnet.rippletest.net:51233/"
+        ) as client:
+            await generate_faucet_wallet_and_fund_again(
+                self, client, "https://faucet.devnet.rippletest.net/accounts"
+            )
+
+    async def test_generate_faucet_wallet_custom_host_async_json_rpc(self):
+        client = AsyncJsonRpcClient("https://s.devnet.rippletest.net:51234/")
+        await generate_faucet_wallet_and_fund_again(
+            self, client, "https://faucet.devnet.rippletest.net/accounts"
+        )
+
+    def test_generate_faucet_wallet_custom_host_sync_websockets(self):
+        with WebsocketClient("wss://s.devnet.rippletest.net:51233/") as client:
+            sync_generate_faucet_wallet_and_fund_again(
+                self, client, "https://faucet.devnet.rippletest.net/accounts"
+            )
+
+    def test_generate_faucet_wallet_custom_host_sync_json_rpc(self):
+        client = JsonRpcClient("https://s.devnet.rippletest.net:51234/")
+        sync_generate_faucet_wallet_and_fund_again(
+            self, client, "https://faucet.devnet.rippletest.net/accounts"
+        )
 
     async def test_generate_faucet_wallet_devnet_async_websockets(self):
         async with AsyncWebsocketClient(

--- a/tests/integration/sugar/test_wallet.py
+++ b/tests/integration/sugar/test_wallet.py
@@ -89,25 +89,25 @@ class TestWallet(IntegrationTestCase):
             "wss://s.devnet.rippletest.net:51233/"
         ) as client:
             await generate_faucet_wallet_and_fund_again(
-                self, client, "https://faucet.devnet.rippletest.net/accounts"
+                self, client, "faucet.devnet.rippletest.net"
             )
 
     async def test_generate_faucet_wallet_custom_host_async_json_rpc(self):
         client = AsyncJsonRpcClient("https://s.devnet.rippletest.net:51234/")
         await generate_faucet_wallet_and_fund_again(
-            self, client, "https://faucet.devnet.rippletest.net/accounts"
+            self, client, "faucet.devnet.rippletest.net"
         )
 
     def test_generate_faucet_wallet_custom_host_sync_websockets(self):
         with WebsocketClient("wss://s.devnet.rippletest.net:51233/") as client:
             sync_generate_faucet_wallet_and_fund_again(
-                self, client, "https://faucet.devnet.rippletest.net/accounts"
+                self, client, "faucet.devnet.rippletest.net"
             )
 
     def test_generate_faucet_wallet_custom_host_sync_json_rpc(self):
         client = JsonRpcClient("https://s.devnet.rippletest.net:51234/")
         sync_generate_faucet_wallet_and_fund_again(
-            self, client, "https://faucet.devnet.rippletest.net/accounts"
+            self, client, "faucet.devnet.rippletest.net"
         )
 
     async def test_generate_faucet_wallet_devnet_async_websockets(self):

--- a/tests/unit/asyn/wallet/test_wallet_generation.py
+++ b/tests/unit/asyn/wallet/test_wallet_generation.py
@@ -4,7 +4,6 @@ from xrpl.asyncio.wallet.wallet_generation import (
     _AMM_DEV_FAUCET_URL,
     _DEV_FAUCET_URL,
     _HOOKS_V2_TEST_FAUCET_URL,
-    _NFT_DEV_FAUCET_URL,
     _TEST_FAUCET_URL,
     get_faucet_url,
 )
@@ -32,14 +31,6 @@ class TestWallet(TestCase):
         json_client_url = "https://testnet.xrpl-labs.com"
         ws_client_url = "wss://testnet.xrpl-labs.com"
         expected_faucet = _TEST_FAUCET_URL
-
-        self.assertEqual(get_faucet_url(json_client_url), expected_faucet)
-        self.assertEqual(get_faucet_url(ws_client_url), expected_faucet)
-
-    def test_get_faucet_wallet_nft_dev(self):
-        json_client_url = "https://xls20-sandbox.rippletest.net:51234"
-        ws_client_url = "ws://xls20-sandbox.rippletest.net:51233"
-        expected_faucet = _NFT_DEV_FAUCET_URL
 
         self.assertEqual(get_faucet_url(json_client_url), expected_faucet)
         self.assertEqual(get_faucet_url(ws_client_url), expected_faucet)

--- a/xrpl/asyncio/wallet/wallet_generation.py
+++ b/xrpl/asyncio/wallet/wallet_generation.py
@@ -13,6 +13,7 @@ from xrpl.wallet.main import Wallet
 _TEST_FAUCET_URL: Final[str] = "https://faucet.altnet.rippletest.net/accounts"
 _DEV_FAUCET_URL: Final[str] = "https://faucet.devnet.rippletest.net/accounts"
 _AMM_DEV_FAUCET_URL: Final[str] = "https://ammfaucet.devnet.rippletest.net/accounts"
+# TODO: Remove this once nft devnet is decomissioned
 _NFT_DEV_FAUCET_URL: Final[str] = "https://faucet-nft.ripple.com/accounts"
 _HOOKS_V2_TEST_FAUCET_URL: Final[
     str
@@ -119,6 +120,7 @@ def get_faucet_url(url: str, faucet_host: Optional[str] = None) -> str:
         return _AMM_DEV_FAUCET_URL
     if "devnet" in url:  # devnet
         return _DEV_FAUCET_URL
+    # TODO: Remove this once the network is fully decommissioned
     if "xls20-sandbox" in url:  # nft devnet
         return _NFT_DEV_FAUCET_URL
     raise XRPLFaucetException(


### PR DESCRIPTION
## High Level Overview of Change

The NFT Devnet was a temporary network, and now it's not necessary since those changes have been merged with mainnet.

### Context of Change

The network was recently unstable and it is blocking other PRs, so removing tests for it now.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Tests (You added tests for code that already exists, or your new feature included in this PR)

<!--
## Future Tasks
For future tasks related to PR.
-->

We should remove the automatic inferrence for NFT-Devnet from the client if / when the network is permanently taken down.