### PR TITLE
unset hash128 using AccountSet

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -706,7 +706,7 @@ python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
-version = "4.3.0"
+version = "4.4.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
@@ -1172,8 +1172,8 @@ types-deprecated = [
     {file = "types_Deprecated-1.2.9-py3-none-any.whl", hash = "sha256:53d05621e1d75de537f5a57d93508c8df17e37c07ee60b9fb09d39e1b7586c1e"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
-    {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
+    {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
+    {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.10-py2.py3-none-any.whl", hash = "sha256:8298d6d56d39be0e3bc13c1c97d133f9b45d797169a0e11cdd0e0489d786f7ec"},

--- a/tests/unit/core/binarycodec/types/test_hash_types.py
+++ b/tests/unit/core/binarycodec/types/test_hash_types.py
@@ -34,6 +34,10 @@ class TestHash128(TestCase):
         invalid_value = 1
         self.assertRaises(XRPLBinaryCodecException, Hash128.from_value, invalid_value)
 
+    def test_unset_value(self):
+        unset_value = Hash128.from_value("")
+        self.assertEqual(str(unset_value), "")
+
 
 class TestHash160(TestCase):
     def setUp(self):

--- a/xrpl/core/binarycodec/types/hash128.py
+++ b/xrpl/core/binarycodec/types/hash128.py
@@ -5,8 +5,9 @@ of 128 bits (16 bytes).
 """
 from __future__ import annotations
 
-from typing import Type
+from typing import Optional, Type
 
+from xrpl.core.binarycodec.exceptions import XRPLBinaryCodecException
 from xrpl.core.binarycodec.types.hash import Hash
 
 
@@ -16,6 +17,33 @@ class Hash128(Hash):
     of 128 bits (16 bytes).
     `See Hash Fields <https://xrpl.org/serialization.html#hash-fields>`_
     """
+
+    def __init__(self: Hash128, buffer: Optional[bytes]) -> None:
+        """
+        Construct a Hash.
+
+        Args:
+            buffer: The byte buffer that will be used to store the serialized
+                encoding of this field.
+        """
+        buffer = (
+            buffer
+            if buffer is not None and len(buffer) > 0
+            else bytes(self._get_length())
+        )
+
+        if len(buffer) != self._get_length():
+            raise XRPLBinaryCodecException(
+                f"Invalid hash length {len(buffer)}. Expected {self._get_length()}"
+            )
+        super().__init__(buffer)
+
+    def __str__(self: Hash) -> str:
+        """Returns a hex-encoded string representation of the bytes buffer."""
+        hex = self.to_hex()
+        if hex == "0" * len(hex):
+            return ""
+        return hex
 
     @classmethod
     def _get_length(cls: Type[Hash128]) -> int:

--- a/xrpl/core/binarycodec/types/hash128.py
+++ b/xrpl/core/binarycodec/types/hash128.py
@@ -20,7 +20,7 @@ class Hash128(Hash):
 
     def __init__(self: Hash128, buffer: Optional[bytes]) -> None:
         """
-        Construct a Hash.
+        Construct a Hash128.
 
         Args:
             buffer: The byte buffer that will be used to store the serialized
@@ -38,7 +38,7 @@ class Hash128(Hash):
             )
         super().__init__(buffer)
 
-    def __str__(self: Hash) -> str:
+    def __str__(self: Hash128) -> str:
         """Returns a hex-encoded string representation of the bytes buffer."""
         hex = self.to_hex()
         if hex == "0" * len(hex):


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->
Allow users to unset Hash128 field (EmailHash) using AccountSet.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release
