### PR TITLE
add timeout to faucet

### DIFF
--- a/xrpl/asyncio/wallet/wallet_generation.py
+++ b/xrpl/asyncio/wallet/wallet_generation.py
@@ -140,7 +140,11 @@ async def _check_wallet_balance(address: str, client: Client) -> int:
 
 async def _request_funding(url: str, address: str) -> None:
     async with httpx.AsyncClient() as http_client:
-        response = await http_client.post(url=url, json={"destination": address})
+        response = await http_client.post(
+            json={"destination": address},
+            timeout=httpx.Timeout(5),
+            url=url,
+        )
     if not response.status_code == httpx.codes.OK:
         response.raise_for_status()
 


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

My faucet is slow and this PR adds a timeout to the faucet post request.

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

I used a default timeout of 5 however there are some sub-settings we could add if we wanted to get more fine grained with the timeout.

connect: float | UnsetType | None = UNSET,
read: float | UnsetType | None = UNSET,
write: float | UnsetType | None = UNSET,

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
