### PR TITLE
rename DisallowIncoming flag for NFTs

### DIFF
--- a/tests/unit/models/transactions/test_better_transaction_flags.py
+++ b/tests/unit/models/transactions/test_better_transaction_flags.py
@@ -28,7 +28,7 @@ class TestBetterTransactionFlags(TestCase):
                 asf_no_freeze=True,
                 asf_require_auth=True,
                 asf_require_dest=True,
-                asf_disable_incoming_nft_offer=True,
+                asf_disable_incoming_nftoken_offer=True,
                 asf_disable_incoming_check=True,
                 asf_disable_incoming_paychan=True,
                 asf_disable_incoming_trustline=True,

--- a/xrpl/models/transactions/account_set.py
+++ b/xrpl/models/transactions/account_set.py
@@ -89,7 +89,7 @@ class AccountSetFlag(int, Enum):
     ASF_AUTHORIZED_NFTOKEN_MINTER = 10
     """Allow another account to mint and burn tokens on behalf of this account."""
 
-    ASF_DISABLE_INCOMING_NFT_OFFER = 12
+    ASF_DISABLE_INCOMING_NFTOKEN_OFFER = 12
     """Disallow other accounts from creating NFTokenOffers directed at this account."""
 
     ASF_DISABLE_INCOMING_CHECK = 13
@@ -124,7 +124,7 @@ class AccountSetFlagInterface(FlagInterface):
     ASF_REQUIRE_AUTH: bool
     ASF_REQUIRE_DEST: bool
     ASF_AUTHORIZED_NFTOKEN_MINTER: bool
-    ASF_DISABLE_INCOMING_NFT_OFFER: bool
+    ASF_DISABLE_INCOMING_NFTOKEN_OFFER: bool
     ASF_DISABLE_INCOMING_CHECK: bool
     ASF_DISABLE_INCOMING_PAYCHAN: bool
     ASF_DISABLE_INCOMING_TRUSTLINE: bool


### PR DESCRIPTION
## High Level Overview of Change

`asfDisallowIncomingNFTOffer` to `asfDisallowIncomingNFTokenOffer`

Related to XRPLF/rippled#4442

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)