### PR TITLE
feat: remove nft-devnet faucet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When connected to nft devnet or hooks v2 testnet generate_faucet_wallet now defaults to using the faucet instead of requiring specification
 - Deprecated `get_account_info`, `get_transaction_from_hash`, `get_account_payment_transactions` for direct requests
 - Private function `request_impl` has been renamed to `_request_impl`. Users should always use `request` over `request_impl`.
+- Removed nft-devnet faucet support as it has been decommissioned ([Blog Post](https://xrpl.org/blog/2023/nft-devnet-decommission.html))
 
 ### Fixed:
 - Properly type the instance functions of NestedModel

--- a/xrpl/asyncio/wallet/wallet_generation.py
+++ b/xrpl/asyncio/wallet/wallet_generation.py
@@ -13,8 +13,6 @@ from xrpl.wallet.main import Wallet
 _TEST_FAUCET_URL: Final[str] = "https://faucet.altnet.rippletest.net/accounts"
 _DEV_FAUCET_URL: Final[str] = "https://faucet.devnet.rippletest.net/accounts"
 _AMM_DEV_FAUCET_URL: Final[str] = "https://ammfaucet.devnet.rippletest.net/accounts"
-# TODO: Remove this once nft devnet is decomissioned
-_NFT_DEV_FAUCET_URL: Final[str] = "https://faucet-nft.ripple.com/accounts"
 _HOOKS_V2_TEST_FAUCET_URL: Final[
     str
 ] = "https://hooks-testnet-v2.xrpl-labs.com/accounts"
@@ -120,9 +118,6 @@ def get_faucet_url(url: str, faucet_host: Optional[str] = None) -> str:
         return _AMM_DEV_FAUCET_URL
     if "devnet" in url:  # devnet
         return _DEV_FAUCET_URL
-    # TODO: Remove this once the network is fully decommissioned
-    if "xls20-sandbox" in url:  # nft devnet
-        return _NFT_DEV_FAUCET_URL
     raise XRPLFaucetException(
         "Cannot fund an account with a client that is not on the testnet or devnet."
     )


### PR DESCRIPTION
## High Level Overview of Change

The nft-devnet was decommissioned on January 31st 2023 ([Blog Post](https://xrpl.org/blog/2023/nft-devnet-decommission.html)).

### Type of Change

- [x] New feature (non-breaking change which adds functionality)