### PR TITLE
fix: handle relsub errors better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed:
 - Properly type the instance functions of NestedModel
-- Added additional check to `txnNotFound` error from `reliable_submission` due to race condition
-- Added `nft_offer` type in `AccountObjects`
+- Add additional check to `txnNotFound` error from `reliable_submission` due to race condition
+- Add `nft_offer` type in `AccountObjects`
+- Handle errors better in `send_reliable_submission`
 
 ## [1.7.0] - 2022-10-12
 ### Added:

--- a/xrpl/asyncio/transaction/reliable_submission.py
+++ b/xrpl/asyncio/transaction/reliable_submission.py
@@ -59,7 +59,9 @@ async def _wait_for_final_transaction_outcome(
     if last_ledger_sequence > latest_ledger_sequence:
         # outcome is not yet final
         return await _wait_for_final_transaction_outcome(
-            transaction_hash, client, prelim_result, 0
+            transaction_hash,
+            client,
+            prelim_result,
         )
 
     raise XRPLReliableSubmissionException(
@@ -107,5 +109,7 @@ async def send_reliable_submission(
         )
 
     return await _wait_for_final_transaction_outcome(
-        transaction_hash, client, prelim_result, 0
+        transaction_hash,
+        client,
+        prelim_result,
     )


### PR DESCRIPTION
## High Level Overview of Change

This PR handles request errors better. 

`XRPLRequestFailureException` is only triggered in one place upstream of the `tx` request, and that's when there's a `JSONDecodeError` (which occurs with an HTTP error and will therefore never have a value of `txnNotFound`). However, the response could have type `error`, and in that case the `"error"` value would be `txnNotFound` if that response error occurs. Other response errors should error normally now, instead of failing silently and getting caught elsewhere (namely in the opaque `KeyError: 'LastLedgerSequence'` that will occur on one of the immediately-following lines).

### Context of Change

A request failed in a semi-production environment and it was really difficult to debug.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

This is a difficult edge case to write a testcase for, since it involves a `tx` error. I replicated it locally with a special rippled setup, where the `tx` command was disabled. I wasn't able to replicate the `txnNotFound` error, since that's a very rare edge case.
