### PR TITLE
feat: save algorithm as a part of the wallet

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,7 @@
         "altnet",
         "asyncio",
         "binarycodec",
+        "keypair",
         "nftoken",
         "rippletest",
         "ripplex",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AccountSetFlags for disallowing incoming objects (e.g. `asf_disallow_incoming_trustline`)
 - Added `getNFTokenID` to get the NFTokenID after minting a token.
 - Added `LedgerEntryType` enum and added `type` field to `Ledger` and `LedgerData` requests
+- Added the algorithm used to encode a wallet's seed to the wallet.
 
 ### Changed:
 - `check_fee` now has a higher limit that is less likely to be hit

--- a/tests/unit/wallet/test_wallet.py
+++ b/tests/unit/wallet/test_wallet.py
@@ -1,0 +1,53 @@
+from unittest import TestCase
+
+from xrpl import CryptoAlgorithm
+from xrpl.core.addresscodec.exceptions import XRPLAddressCodecException
+from xrpl.wallet import Wallet
+
+SEED = "ssQgsaM2ujhyWoDw3Yb1TNjkZTVT2"
+SECP_ADDRESS = "r9o97fQwt54s73b1UzgbhvZTPDHYgSqz7G"
+ED_ADDRESS = "rnbrEQ9U6TgPkBYuR4RWSWGR1XgaPWuFjh"
+
+SED_SEED = "sEdVRAkrcTVBt4jKfJyKzQzndPFARgs"
+SED_ADDRESS = "rLLYAFe2iEGaQrz3rqWfpziGAR4XfQrW3e"
+
+
+class TestWallet(TestCase):
+    def test_create_basic(self):
+        wallet = Wallet.create()
+        self.assertEqual(wallet.algorithm, CryptoAlgorithm.ED25519)
+        self.assertTrue(wallet.seed.startswith("sEd"))
+
+    def test_create_secp(self):
+        wallet = Wallet.create(crypto_algorithm=CryptoAlgorithm.SECP256K1)
+        self.assertEqual(wallet.algorithm, CryptoAlgorithm.SECP256K1)
+        self.assertFalse(wallet.seed.startswith("sEd"))
+        self.assertTrue(wallet.seed.startswith("s"))
+
+    def test_init_auto_with_s_seed(self):
+        wallet = Wallet(SEED, 0)
+        self.assertEqual(wallet.seed, SEED)
+        self.assertEqual(wallet.classic_address, SECP_ADDRESS)
+        self.assertEqual(wallet.algorithm, CryptoAlgorithm.SECP256K1)
+
+    def test_init_auto_with_sEd_seed(self):
+        wallet = Wallet(SED_SEED, 0)
+        self.assertEqual(wallet.seed, SED_SEED)
+        self.assertEqual(wallet.classic_address, SED_ADDRESS)
+        self.assertEqual(wallet.algorithm, CryptoAlgorithm.ED25519)
+
+    def test_init_secp256k1_with_s_seed(self):
+        wallet = Wallet(SEED, 0, algorithm=CryptoAlgorithm.SECP256K1)
+        self.assertEqual(wallet.seed, SEED)
+        self.assertEqual(wallet.classic_address, SECP_ADDRESS)
+        self.assertEqual(wallet.algorithm, CryptoAlgorithm.SECP256K1)
+
+    def test_init_ed25519_with_s_seed(self):
+        wallet = Wallet(SEED, 0, algorithm=CryptoAlgorithm.ED25519)
+        self.assertEqual(wallet.seed, SEED)
+        self.assertEqual(wallet.classic_address, ED_ADDRESS)
+        self.assertEqual(wallet.algorithm, CryptoAlgorithm.ED25519)
+
+    def test_init_secp256k1_with_sEd_seed_fail(self):
+        with self.assertRaises(XRPLAddressCodecException):
+            Wallet(SED_SEED, 0, algorithm=CryptoAlgorithm.SECP256K1)

--- a/xrpl/wallet/main.py
+++ b/xrpl/wallet/main.py
@@ -38,6 +38,19 @@ class Wallet:
         this wallet. MUST be kept secret!
         """
 
+        if algorithm is None:
+            if self.seed.startswith("sEd"):
+                wallet_algorithm = CryptoAlgorithm.ED25519
+            else:
+                wallet_algorithm = CryptoAlgorithm.SECP256K1
+        else:
+            wallet_algorithm = algorithm
+
+        self.algorithm = wallet_algorithm
+        """
+        The algorithm that is used to convert the seed into its public/private keypair.
+        """
+
         pk, sk = derive_keypair(self.seed, algorithm=algorithm)
         self.public_key = pk
         """


### PR DESCRIPTION
## High Level Overview of Change

This PR adds a `self.algorithm` to the wallet, to store the algorithm used to encode its seed.

### Context of Change

This is really useful for the xbridge-cli work.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
