### PR TITLE
refactor: remove calls to deprecated methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [[Unreleased]]
+### Fixed:
+- Refactored `does_account_exist` to avoid deprecated methods and use `ledger_index` parameter
 
 ## [1.8.0] - 2023-04-10
 ### Added:

--- a/tests/integration/sugar/test_account.py
+++ b/tests/integration/sugar/test_account.py
@@ -6,13 +6,7 @@ from tests.integration.it_utils import (
     test_async_and_sync,
 )
 from tests.integration.reusable_values import DESTINATION, WALLET
-from xrpl.asyncio.account import (
-    does_account_exist,
-    get_account_info,
-    get_account_transactions,
-    get_balance,
-    get_latest_transaction,
-)
+from xrpl.asyncio.account import does_account_exist, get_balance, get_latest_transaction
 from xrpl.core.addresscodec import classic_address_to_xaddress
 from xrpl.models.transactions import Payment
 from xrpl.wallet import Wallet
@@ -44,39 +38,6 @@ class TestAccount(IntegrationTestCase):
             int(FUNDING_AMOUNT),
         )
 
-    @test_async_and_sync(globals(), ["xrpl.account.get_account_transactions"])
-    async def test_get_account_transactions(self, client):
-        transactions = await get_account_transactions(
-            NEW_WALLET.classic_address, client
-        )
-        self.assertEqual(len(transactions), 1)
-        self.assertEqual(transactions[0]["tx"]["TransactionType"], "Payment")
-        self.assertEqual(transactions[0]["tx"]["Amount"], FUNDING_AMOUNT)
-
-    @test_async_and_sync(globals(), ["xrpl.account.get_account_transactions"])
-    async def test_get_account_transactions_empty(self, client):
-        transactions = await get_account_transactions(
-            EMPTY_WALLET.classic_address, client
-        )
-        self.assertEqual(len(transactions), 0)
-
-    @test_async_and_sync(globals(), ["xrpl.account.get_account_transactions"])
-    async def test_payment_transactions(self, client):
-        transactions = await get_account_transactions(
-            NEW_WALLET.classic_address, client
-        )
-        self.assertEqual(len(transactions), 1)
-        self.assertEqual(transactions[0]["tx"]["TransactionType"], "Payment")
-        self.assertEqual(transactions[0]["tx"]["Amount"], FUNDING_AMOUNT)
-
-    @test_async_and_sync(globals(), ["xrpl.account.get_account_transactions"])
-    async def test_payment_transactions_xaddress(self, client):
-        xaddress = classic_address_to_xaddress(NEW_WALLET.classic_address, None, True)
-        transactions = await get_account_transactions(xaddress, client)
-        self.assertEqual(len(transactions), 1)
-        self.assertEqual(transactions[0]["tx"]["TransactionType"], "Payment")
-        self.assertEqual(transactions[0]["tx"]["Amount"], FUNDING_AMOUNT)
-
     @test_async_and_sync(globals(), ["xrpl.account.get_latest_transaction"])
     async def test_get_latest_transaction(self, client):
         # NOTE: this test may take a long time to run
@@ -95,12 +56,3 @@ class TestAccount(IntegrationTestCase):
         self.assertEqual(transaction["TransactionType"], "Payment")
         self.assertEqual(transaction["Amount"], amount)
         self.assertEqual(transaction["Account"], WALLET.classic_address)
-
-    @test_async_and_sync(globals(), ["xrpl.account.get_account_info"])
-    async def test_get_account_info(self, client):
-        response = await get_account_info(WALLET.classic_address, client)
-        self.assertTrue(response.is_successful())
-        self.assertEqual(
-            response.result["account_data"]["Account"],
-            WALLET.classic_address,
-        )

--- a/tests/integration/sugar/test_transaction.py
+++ b/tests/integration/sugar/test_transaction.py
@@ -13,7 +13,6 @@ from xrpl.asyncio.transaction import (
     XRPLReliableSubmissionException,
     autofill,
     autofill_and_sign,
-    get_transaction_from_hash,
     send_reliable_submission,
     sign,
 )
@@ -48,109 +47,6 @@ OWNER = "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"
 
 
 class TestTransaction(IntegrationTestCase):
-    @test_async_and_sync(
-        globals(),
-        [
-            "xrpl.transaction.autofill_and_sign",
-            "xrpl.transaction.send_reliable_submission",
-            "xrpl.transaction.get_transaction_from_hash",
-        ],
-    )
-    async def test_get_transaction_from_hash(self, client):
-        # GIVEN a new transaction (payment)
-        payment_transaction = Payment(
-            account=WALLET.classic_address,
-            amount="100",
-            destination=DESTINATION,
-            sequence=WALLET.sequence,
-        )
-
-        # WHEN we sign locally, autofill, and submit the transaction
-        response = await sign_and_reliable_submission_async(payment_transaction, WALLET)
-
-        # THEN we expect to retrieve this transaction from its hash
-        payment = await get_transaction_from_hash(
-            response.result["tx_json"]["hash"], client
-        )
-
-        # AND we expect the result Account to be the same as the original payment Acct
-        self.assertEqual(payment.result["Account"], ACCOUNT)
-        # AND we expect the response to be successful (200)
-        self.assertTrue(payment.is_successful())
-
-        WALLET.sequence += 1
-
-    @test_async_and_sync(
-        globals(),
-        [
-            "xrpl.transaction.autofill_and_sign",
-            "xrpl.transaction.send_reliable_submission",
-            "xrpl.transaction.get_transaction_from_hash",
-        ],
-    )
-    async def test_get_transaction_from_hash_with_binary(self, client):
-        # GIVEN a new transaction (payment)
-        payment_transaction = Payment(
-            account=WALLET.classic_address,
-            amount="100",
-            destination=DESTINATION,
-            sequence=WALLET.sequence,
-        )
-
-        # WHEN we sign locally, autofill, and submit the transaction
-        response = await sign_and_reliable_submission_async(payment_transaction, WALLET)
-        payment_hash = response.result["tx_json"]["hash"]
-
-        # THEN we expect to retrieve this transaction from its hash with the
-        # binary parameter set to true
-        payment = await get_transaction_from_hash(payment_hash, client, True)
-
-        # AND we expect the result hash to be the same as the original payment hash
-        self.assertEqual(payment.result["hash"], payment_hash)
-        # AND we expect the response to be successful (200)
-        self.assertTrue(payment.is_successful())
-
-        WALLET.sequence += 1
-
-    @test_async_and_sync(
-        globals(),
-        [
-            "xrpl.transaction.autofill_and_sign",
-            "xrpl.transaction.send_reliable_submission",
-            "xrpl.transaction.get_transaction_from_hash",
-        ],
-    )
-    async def test_get_transaction_from_hash_with_min_max_ledgers(self, client):
-        # GIVEN a new transaction (payment)
-        payment_transaction = Payment(
-            account=WALLET.classic_address,
-            amount="100",
-            destination=DESTINATION,
-            sequence=WALLET.sequence,
-        )
-
-        # WHEN we sign locally, autofill, and submit the transaction
-        response = await sign_and_reliable_submission_async(payment_transaction, WALLET)
-        payment_hash = response.result["tx_json"]["hash"]
-        payment_ledger_index = response.result["validated_ledger_index"]
-
-        # THEN we expect to retrieve this transaction from its hash with
-        # min_ledger and max_ledger parameters
-        payment = await get_transaction_from_hash(
-            payment_hash,
-            client,
-            False,
-            payment_ledger_index - 5,
-            payment_ledger_index + 5,
-        )
-
-        # AND we expect the result Account to be the same as the original payment Acct
-        self.assertEqual(payment.result["Account"], ACCOUNT)
-        # AND we expect the response to be successful (200)
-        self.assertTrue(payment.is_successful())
-
-        WALLET.sequence += 1
-
     @test_async_and_sync(
         globals(),
     )

--- a/xrpl/asyncio/account/main.py
+++ b/xrpl/asyncio/account/main.py
@@ -32,7 +32,7 @@ async def does_account_exist(
         XRPLRequestFailureException: if the transaction fails.
     """
     try:
-        await get_account_info(address, client)
+        await get_account_root(address, client, ledger_index=ledger_index)
         return True
     except XRPLRequestFailureException as e:
         if e.error == "actNotFound":


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

The deprecation notices were clogging up the CI output, making it difficult to identify what was actually causing errors in a PR.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Test Plan

CI no longer has deprecation warnings.
