### PR TITLE
[BREAKING] fix: XRP().to_amount now expects XRP instead of drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed deprecated request wrappers (the preferred method is to directly do client.request instead)
 - `sign` is now synchronous instead of async (done by removing the optional `check_fee` param & moving checks up to other functions)
 - In order to be internally consistent, all signing/submitting functions will follow the parameter order of `transaction`, `client`, `wallet`, and then other parameters. (This is because `wallet` is optional for `submit_and_wait` and so must come after `client`)
+- `XRP.to_amount` now converts from XRP to drops, instead of expecting a drops amount
 
 ### Removed:
 - Longer aliases for signing/submitting functions have been removed. Specifically
@@ -38,8 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed:
 - Replaced the flags defined in `AccountSetFlag` (now defines the transaction `tf` flags, previously not defined anywhere)
-
-### Changed:
 - Allowed keypairs.sign to take a hex string in addition to bytes
 
 ### Fixed:

--- a/tests/unit/models/currencies/test_xrp.py
+++ b/tests/unit/models/currencies/test_xrp.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from xrpl.models.currencies import XRP
+from xrpl.utils import xrp_to_drops
 
 
 class TestXRP(TestCase):
@@ -8,7 +9,8 @@ class TestXRP(TestCase):
         self.assertEqual(XRP().to_dict()["currency"], "XRP")
 
     def test_to_amount(self):
-        amount = "12"
-        issued_currency_amount = XRP().to_amount(amount)
+        amount = 12
+        expected = xrp_to_drops(amount)
+        result = XRP().to_amount(amount)
 
-        self.assertEqual(issued_currency_amount, amount)
+        self.assertEqual(result, expected)

--- a/xrpl/models/currencies/xrp.py
+++ b/xrpl/models/currencies/xrp.py
@@ -71,7 +71,7 @@ class XRP(BaseModel):
         Returns:
             A string representation of XRP amount.
         """
-        # needed to avoid circular dependency
+        # import needed here to avoid circular dependency
         from xrpl.utils.xrp_conversions import xrp_to_drops
 
         if isinstance(value, str):

--- a/xrpl/models/currencies/xrp.py
+++ b/xrpl/models/currencies/xrp.py
@@ -16,7 +16,6 @@ from typing import Any, Dict, Type, Union
 from xrpl.models.base_model import BaseModel
 from xrpl.models.exceptions import XRPLModelException
 from xrpl.models.utils import require_kwargs_on_init
-from xrpl.utils.xrp_conversions import xrp_to_drops
 
 
 @require_kwargs_on_init
@@ -72,6 +71,8 @@ class XRP(BaseModel):
         Returns:
             A string representation of XRP amount.
         """
+        from xrpl.utils.xrp_conversions import xrp_to_drops
+
         if isinstance(value, str):
             return xrp_to_drops(float(value))
         return xrp_to_drops(value)

--- a/xrpl/models/currencies/xrp.py
+++ b/xrpl/models/currencies/xrp.py
@@ -71,6 +71,7 @@ class XRP(BaseModel):
         Returns:
             A string representation of XRP amount.
         """
+        # needed to avoid circular dependency
         from xrpl.utils.xrp_conversions import xrp_to_drops
 
         if isinstance(value, str):

--- a/xrpl/models/currencies/xrp.py
+++ b/xrpl/models/currencies/xrp.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, Type, Union
 from xrpl.models.base_model import BaseModel
 from xrpl.models.exceptions import XRPLModelException
 from xrpl.models.utils import require_kwargs_on_init
+from xrpl.utils import xrp_to_drops
 
 
 @require_kwargs_on_init
@@ -61,7 +62,7 @@ class XRP(BaseModel):
         """
         return {**super().to_dict(), "currency": "XRP"}
 
-    def to_amount(self: XRP, value: Union[str, int]) -> str:
+    def to_amount(self: XRP, value: Union[str, int, float]) -> str:
         """
         Converts value to XRP.
 
@@ -71,4 +72,6 @@ class XRP(BaseModel):
         Returns:
             A string representation of XRP amount.
         """
-        return str(value)
+        if isinstance(value, str):
+            return xrp_to_drops(float(value))
+        return xrp_to_drops(value)

--- a/xrpl/models/currencies/xrp.py
+++ b/xrpl/models/currencies/xrp.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, Type, Union
 from xrpl.models.base_model import BaseModel
 from xrpl.models.exceptions import XRPLModelException
 from xrpl.models.utils import require_kwargs_on_init
-from xrpl.utils import xrp_to_drops
+from xrpl.utils.xrp_conversions import xrp_to_drops
 
 
 @require_kwargs_on_init


### PR DESCRIPTION
## High Level Overview of Change

This PR fixes a disconnect between the docs for the `XRP().to_amount` method and what the function actually did. The docs seemed to be expecting an XRP amount, but the code was expecting an amount in drops.

I think an amount in XRP makes more sense. This is technically a breaking change, but I think it's more of a bugfix.

### Context of Change

Ran into this issue while working on sidechain tooling

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

CI passes.
