### PR TITLE
docs: Deprecate the underlying send_reliable_submission

### DIFF
--- a/tests/integration/sugar/test_transaction.py
+++ b/tests/integration/sugar/test_transaction.py
@@ -1,3 +1,5 @@
+import warnings
+
 from tests.integration.integration_test_case import IntegrationTestCase
 from tests.integration.it_utils import (
     accept_ledger_async,
@@ -58,6 +60,9 @@ class TestTransaction(IntegrationTestCase):
             amount="100",
             destination=classic_address_to_xaddress(DESTINATION, None, False),
         )
+
+        # Silence warnings from send_reliable_submission being deprecated
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
 
         # WHEN we sign locally, autofill, and submit the transaction
         response = await sign_and_reliable_submission_async(
@@ -236,6 +241,8 @@ class TestReliableSubmission(IntegrationTestCase):
         )
         signed_account_set = await autofill_and_sign(account_set, WALLET, client)
         await accept_ledger_async()
+        # Silence warnings from send_reliable_submission being deprecated
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
         response = await send_reliable_submission(signed_account_set, client)
         self.assertTrue(response.result["validated"])
         self.assertEqual(response.result["meta"]["TransactionResult"], "tesSUCCESS")
@@ -261,6 +268,8 @@ class TestReliableSubmission(IntegrationTestCase):
             payment_transaction, WALLET, client
         )
         await accept_ledger_async()
+        # Silence warnings from send_reliable_submission being deprecated
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
         response = await send_reliable_submission(signed_payment_transaction, client)
         self.assertTrue(response.result["validated"])
         self.assertEqual(response.result["meta"]["TransactionResult"], "tesSUCCESS")
@@ -290,6 +299,8 @@ class TestReliableSubmission(IntegrationTestCase):
 
         await accept_ledger_async()
 
+        # Silence warnings from send_reliable_submission being deprecated
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
         with self.assertRaises(XRPLReliableSubmissionException):
             await send_reliable_submission(signed_payment_transaction, client)
 
@@ -312,6 +323,8 @@ class TestReliableSubmission(IntegrationTestCase):
         }
         payment_transaction = Payment.from_dict(payment_dict)
         signed_payment_transaction = await sign(payment_transaction, WALLET)
+        # Silence warnings from send_reliable_submission being deprecated
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
         with self.assertRaises(XRPLRequestFailureException):
             await send_reliable_submission(signed_payment_transaction, client)
 
@@ -333,6 +346,8 @@ class TestReliableSubmission(IntegrationTestCase):
         }
         payment_transaction = Payment.from_dict(payment_dict)
         signed_payment_transaction = await sign(payment_transaction, WALLET)
+        # Silence warnings from send_reliable_submission being deprecated
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
         with self.assertRaises(XRPLReliableSubmissionException):
             await send_reliable_submission(signed_payment_transaction, client)
 

--- a/xrpl/transaction/reliable_submission.py
+++ b/xrpl/transaction/reliable_submission.py
@@ -13,6 +13,7 @@ from xrpl.models.transactions.transaction import Transaction
 from xrpl.wallet.main import Wallet
 
 
+# TODO: Remove this at the same time we remove async_send_reliable_submission
 def send_reliable_submission(
     transaction: Transaction,
     client: SyncClient,


### PR DESCRIPTION
## High Level Overview of Change

Title says it all.

### Context of Change

`submit_and_wait` is the newer version of that function with more features & future support.

Note: I moved the internals of `send_reliable_submission` into a private helper because `submit_and_wait` relies on that functionality, but should not trigger deprecation warnings each time it's called. (Basically separating the "public face" which is deprecated, from the helper)

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Documentation Updates

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

CI Passes (and does NOT mention the deprecation - I checked beforehand to verify the deprecation was working, but don't want to clog the logs going forward)

<!--
## Future Tasks
For future tasks related to PR.
-->
