### PR TITLE
fix: better error handling in reliable submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored `does_account_exist` and `get_balance` to avoid deprecated methods and use `ledger_index` parameter
 - Fixed crashes in the SignerListSet validation
 - Improved error messages in `send_reliable_submission`
+- Better error handling in reliable submission
 
 ### Removed:
 - RPCs and utils related to the old sidechain design

--- a/tests/integration/sugar/test_transaction.py
+++ b/tests/integration/sugar/test_transaction.py
@@ -346,8 +346,6 @@ class TestSubmitAndWait(IntegrationTestCase):
         globals(),
         [
             "xrpl.transaction.submit_and_wait",
-            "xrpl.account.get_next_valid_seq_number",
-            "xrpl.ledger.get_fee",
         ],
     )
     async def test_submit_and_wait_simple(self, client):
@@ -367,8 +365,6 @@ class TestSubmitAndWait(IntegrationTestCase):
         globals(),
         [
             "xrpl.transaction.submit_and_wait",
-            "xrpl.account.get_next_valid_seq_number",
-            "xrpl.ledger.get_fee",
         ],
     )
     async def test_submit_and_wait_payment(self, client):
@@ -390,8 +386,6 @@ class TestSubmitAndWait(IntegrationTestCase):
         [
             "xrpl.transaction.autofill_and_sign",
             "xrpl.transaction.submit_and_wait",
-            "xrpl.account.get_next_valid_seq_number",
-            "xrpl.ledger.get_fee",
         ],
     )
     async def test_submit_and_wait_signed(self, client):
@@ -416,9 +410,6 @@ class TestSubmitAndWait(IntegrationTestCase):
         [
             "xrpl.transaction.autofill_and_sign",
             "xrpl.transaction.submit_and_wait",
-            "xrpl.account.get_next_valid_seq_number",
-            "xrpl.ledger.get_fee",
-            "xrpl.core.binarycodec.main.encode",
         ],
     )
     async def test_submit_and_wait_blob(self, client):
@@ -443,7 +434,6 @@ class TestSubmitAndWait(IntegrationTestCase):
         globals(),
         [
             "xrpl.transaction.submit_and_wait",
-            "xrpl.account.get_next_valid_seq_number",
             "xrpl.ledger.get_latest_validated_ledger_sequence",
         ],
     )
@@ -451,8 +441,23 @@ class TestSubmitAndWait(IntegrationTestCase):
         payment_transaction = Payment(
             account=ACCOUNT,
             last_ledger_sequence=await get_latest_validated_ledger_sequence(client),
-            fee="10",
             amount="100",
+            destination=DESTINATION,
+        )
+        await accept_ledger_async(delay=1)
+        with self.assertRaises(XRPLReliableSubmissionException):
+            await submit_and_wait(payment_transaction, client, WALLET)
+
+    @test_async_and_sync(
+        globals(),
+        [
+            "xrpl.transaction.submit_and_wait",
+        ],
+    )
+    async def test_submit_and_wait_tec_error(self, client):
+        payment_transaction = Payment(
+            account=ACCOUNT,
+            amount=xrp_to_drops(10**10),  # tecINSUFFICIENT_FUNDS
             destination=DESTINATION,
         )
         await accept_ledger_async(delay=1)

--- a/tests/integration/sugar/test_transaction.py
+++ b/tests/integration/sugar/test_transaction.py
@@ -346,6 +346,7 @@ class TestSubmitAndWait(IntegrationTestCase):
         globals(),
         [
             "xrpl.transaction.submit_and_wait",
+            "xrpl.ledger.get_fee",
         ],
     )
     async def test_submit_and_wait_simple(self, client):
@@ -365,6 +366,7 @@ class TestSubmitAndWait(IntegrationTestCase):
         globals(),
         [
             "xrpl.transaction.submit_and_wait",
+            "xrpl.ledger.get_fee",
         ],
     )
     async def test_submit_and_wait_payment(self, client):
@@ -386,6 +388,7 @@ class TestSubmitAndWait(IntegrationTestCase):
         [
             "xrpl.transaction.autofill_and_sign",
             "xrpl.transaction.submit_and_wait",
+            "xrpl.ledger.get_fee",
         ],
     )
     async def test_submit_and_wait_signed(self, client):
@@ -410,6 +413,7 @@ class TestSubmitAndWait(IntegrationTestCase):
         [
             "xrpl.transaction.autofill_and_sign",
             "xrpl.transaction.submit_and_wait",
+            "xrpl.ledger.get_fee",
         ],
     )
     async def test_submit_and_wait_blob(self, client):

--- a/xrpl/asyncio/transaction/reliable_submission.py
+++ b/xrpl/asyncio/transaction/reliable_submission.py
@@ -63,6 +63,9 @@ async def _wait_for_final_transaction_outcome(
     result = transaction_response.result
     if "validated" in result and result["validated"]:
         # result is in a validated ledger, outcome is final
+        return_code = result["meta"]["TransactionResult"]
+        if return_code != "tesSUCCESS":
+            raise XRPLReliableSubmissionException(f"Transaction failed: {return_code}")
         return transaction_response
 
     # outcome is not yet final


### PR DESCRIPTION
## High Level Overview of Change

Errors that are validated (for example `tec` codes) weren't caught by any of the exceptions. This PR fixes that.

### Context of Change

It took me a while to uncover a bug that I had in my code - the error was a `tec` error, which meant that it was eventually validated and none of the other error paths caught it.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

CI passes. Added a test.

## Future Tasks
Potentially adding an option to `submit` on whether or not to error if the transaction has a non-`tesSUCCESS` code.
