### PR TITLE
Make `sign` synchronous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Core keypairs generate seed must take in hexstring instead of bytestring
 - Core keypairs formatting for ED25519 is now padded with zeros if length of keystring is less than 64
 - Removed deprecated request wrappers (the preferred method is to directly do client.request instead)
+- `sign` is now synchronous instead of async
 
 ## [[Unreleased]]
 ### Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Core keypairs generate seed must take in hexstring instead of bytestring
 - Core keypairs formatting for ED25519 is now padded with zeros if length of keystring is less than 64
 - Removed deprecated request wrappers (the preferred method is to directly do client.request instead)
-- `sign` is now synchronous instead of async
+- `sign` is now synchronous instead of async (done by removing the optional `check_fee` param & moving checks up to other functions)
 
 ## [[Unreleased]]
 ### Added:

--- a/tests/integration/reqs/test_submit_multisigned.py
+++ b/tests/integration/reqs/test_submit_multisigned.py
@@ -130,8 +130,8 @@ class TestSubmitMultisigned(IntegrationTestCase):
 
         autofilled_tx = await autofill(tx, client, len(SIGNER_ENTRIES))
 
-        tx_1 = await sign(autofilled_tx, FIRST_SIGNER, multisign=True)
-        tx_2 = await sign(autofilled_tx, SECOND_SIGNER, multisign=True)
+        tx_1 = sign(autofilled_tx, FIRST_SIGNER, multisign=True)
+        tx_2 = sign(autofilled_tx, SECOND_SIGNER, multisign=True)
 
         multisigned_tx = multisign(autofilled_tx, [tx_1, tx_2])
 

--- a/tests/integration/sugar/test_transaction.py
+++ b/tests/integration/sugar/test_transaction.py
@@ -351,7 +351,7 @@ class TestSubmitAndWait(IntegrationTestCase):
             "destination": DESTINATION,
         }
         payment_transaction = Payment.from_dict(payment_dict)
-        signed_payment_transaction = await sign(payment_transaction, WALLET)
+        signed_payment_transaction = sign(payment_transaction, WALLET)
         with self.assertRaises(XRPLRequestFailureException):
             await submit_and_wait(signed_payment_transaction, client)
 
@@ -372,6 +372,6 @@ class TestSubmitAndWait(IntegrationTestCase):
             "destination": DESTINATION,
         }
         payment_transaction = Payment.from_dict(payment_dict)
-        signed_payment_transaction = await sign(payment_transaction, WALLET)
+        signed_payment_transaction = sign(payment_transaction, WALLET)
         with self.assertRaises(XRPLReliableSubmissionException):
             await submit_and_wait(signed_payment_transaction, client)

--- a/tests/unit/models/transactions/test_transaction.py
+++ b/tests/unit/models/transactions/test_transaction.py
@@ -1,4 +1,3 @@
-import asyncio
 from unittest import TestCase
 
 from xrpl.asyncio.transaction.main import sign

--- a/tests/unit/models/transactions/test_transaction.py
+++ b/tests/unit/models/transactions/test_transaction.py
@@ -134,7 +134,7 @@ class TestTransaction(TestCase):
 
     def test_is_signed_for_signed_transaction(self):
         tx = AccountSet(account=_WALLET.classic_address, domain=EXAMPLE_DOMAIN)
-        signed_tx = asyncio.run(sign(tx, _WALLET))
+        signed_tx = sign(tx, _WALLET)
         self.assertTrue(signed_tx.is_signed())
 
     def test_is_signed_for_unsigned_transaction(self):
@@ -143,8 +143,8 @@ class TestTransaction(TestCase):
 
     def test_is_signed_for_multisigned_transaction(self):
         tx = AccountSet(account=_WALLET.classic_address, domain=EXAMPLE_DOMAIN)
-        tx_1 = asyncio.run(sign(tx, _FIRST_SIGNER, multisign=True))
-        tx_2 = asyncio.run(sign(tx, _SECOND_SIGNER, multisign=True))
+        tx_1 = sign(tx, _FIRST_SIGNER, multisign=True)
+        tx_2 = sign(tx, _SECOND_SIGNER, multisign=True)
 
         multisigned_tx = multisign(tx, [tx_1, tx_2])
         self.assertTrue(multisigned_tx.is_signed())

--- a/xrpl/asyncio/transaction/main.py
+++ b/xrpl/asyncio/transaction/main.py
@@ -135,7 +135,7 @@ async def autofill_and_sign(
     if check_fee:
         await _check_fee(transaction, client)
 
-    return sign(await autofill(transaction, client), wallet, False)
+    return sign(await autofill(transaction, client), wallet, multisign=False)
 
 
 safe_sign_and_autofill_transaction = autofill_and_sign

--- a/xrpl/asyncio/transaction/main.py
+++ b/xrpl/asyncio/transaction/main.py
@@ -62,6 +62,10 @@ async def sign_and_submit(
 safe_sign_and_submit_transaction = sign_and_submit
 
 
+# Even though this is synchronous - this is here because it used to be async in
+# xrpl-py 1.0, and we decided it wasn't worth breaking people's imports to move
+# It to a central location as part of the xrpl-py 2.0 changes. It is aliased in
+# The synchronous half of the library as well.
 def sign(
     transaction: Transaction,
     wallet: Wallet,

--- a/xrpl/asyncio/transaction/reliable_submission.py
+++ b/xrpl/asyncio/transaction/reliable_submission.py
@@ -163,9 +163,9 @@ async def _get_signed_tx(
         transaction = await _autofill(transaction, client)
 
     if transaction.signers:
-        return await sign(transaction, wallet, True, True)
+        return sign(transaction, wallet, True)
 
-    return await sign(transaction, wallet, True, False)
+    return sign(transaction, wallet, False)
 
 
 async def submit_and_wait(

--- a/xrpl/asyncio/transaction/reliable_submission.py
+++ b/xrpl/asyncio/transaction/reliable_submission.py
@@ -163,9 +163,9 @@ async def _get_signed_tx(
         transaction = await _autofill(transaction, client)
 
     if transaction.signers:
-        return sign(transaction, wallet, True)
+        return sign(transaction, wallet, multisign=True)
 
-    return sign(transaction, wallet, False)
+    return sign(transaction, wallet, multisign=False)
 
 
 async def submit_and_wait(

--- a/xrpl/transaction/main.py
+++ b/xrpl/transaction/main.py
@@ -98,14 +98,7 @@ def sign(
     Returns:
         The signed transaction.
     """
-    return asyncio.run(
-        main.sign(
-            transaction,
-            wallet,
-            check_fee,
-            multisign,
-        )
-    )
+    return main.sign(transaction, wallet, multisign)
 
 
 safe_sign_transaction = sign

--- a/xrpl/transaction/main.py
+++ b/xrpl/transaction/main.py
@@ -82,7 +82,6 @@ submit_transaction = submit
 def sign(
     transaction: Transaction,
     wallet: Wallet,
-    check_fee: bool = True,
     multisign: bool = False,
 ) -> Transaction:
     """
@@ -91,8 +90,6 @@ def sign(
     Args:
         transaction: the transaction to be signed.
         wallet: the wallet with which to sign the transaction.
-        check_fee: whether to check if the fee is higher than the expected transaction
-            type fee. Defaults to True.
         multisign: whether to sign the transaction for a multisignature transaction.
 
     Returns:

--- a/xrpl/transaction/main.py
+++ b/xrpl/transaction/main.py
@@ -78,25 +78,7 @@ def submit(
 
 submit_transaction = submit
 
-
-def sign(
-    transaction: Transaction,
-    wallet: Wallet,
-    multisign: bool = False,
-) -> Transaction:
-    """
-    Signs a transaction locally, without trusting external rippled nodes.
-
-    Args:
-        transaction: the transaction to be signed.
-        wallet: the wallet with which to sign the transaction.
-        multisign: whether to sign the transaction for a multisignature transaction.
-
-    Returns:
-        The signed transaction.
-    """
-    return main.sign(transaction, wallet, multisign)
-
+sign = main.sign
 
 safe_sign_transaction = sign
 


### PR DESCRIPTION
## High Level Overview of Change

Sign is currently async, but doesn't need to be (and it's bad practice to do online operations during signing)

### Context of Change

Signing should happen offline (otherwise it may give the impression that keys are being leaked) - so having an asynchronous sign function is odd. The only reason for it is a single edge-case sanity check, which can be moved elsewhere to achieve similar coverage without clouding the purpose of `sign`. 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Test Plan

CI Passes

<!--
## Future Tasks
For future tasks related to PR.
-->
