### PR TITLE
Remove long aliases for signing/submitting functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Core keypairs formatting for ED25519 is now padded with zeros if length of keystring is less than 64
 - Removed deprecated request wrappers (the preferred method is to directly do client.request instead)
 
+### Removed:
+- Longer aliases for signing/submitting functions have been removed. Specifically
+  - `submit_transaction` is now `submit`
+  - `safe_sign_transaction` is now `sign`
+  - `safe_sign_and_submit_transaction` is now `sign_and_submit`
+  - `safe_sign_and_autofill_transaction` is now `sign_and_autofill`
+
 ## [[Unreleased]]
 ### Added:
 - Added `submit_and_wait` to sign (if needed), autofill, submit a transaction and wait for its final outcome

--- a/tests/integration/it_utils.py
+++ b/tests/integration/it_utils.py
@@ -9,18 +9,14 @@ from typing import cast
 import xrpl  # noqa: F401 - needed for sync tests
 from xrpl.asyncio.clients import AsyncJsonRpcClient, AsyncWebsocketClient
 from xrpl.asyncio.clients.async_client import AsyncClient
-from xrpl.asyncio.transaction import (
-    safe_sign_and_submit_transaction as sign_and_submit_async,
-)
+from xrpl.asyncio.transaction import sign_and_submit as sign_and_submit_async
 from xrpl.clients import Client, JsonRpcClient, WebsocketClient
 from xrpl.clients.sync_client import SyncClient
 from xrpl.constants import CryptoAlgorithm
 from xrpl.models import GenericRequest, Payment, Request, Response, Transaction
+from xrpl.transaction import sign_and_submit  # noqa: F401 - needed for sync tests
 from xrpl.transaction import (  # noqa: F401 - needed for sync tests
-    safe_sign_and_submit_transaction,
-)
-from xrpl.transaction import (  # noqa: F401 - needed for sync tests
-    submit_transaction as submit_transaction_alias,
+    submit as submit_transaction_alias,
 )
 from xrpl.wallet import Wallet
 
@@ -104,7 +100,7 @@ def fund_wallet_sync(wallet: Wallet) -> None:
         destination=wallet.classic_address,
         amount=FUNDING_AMOUNT,
     )
-    safe_sign_and_submit_transaction(payment, MASTER_WALLET, client, check_fee=True)
+    sign_and_submit(payment, MASTER_WALLET, client, check_fee=True)
     client.request(LEDGER_ACCEPT_REQUEST)
 
 
@@ -128,9 +124,7 @@ def submit_transaction(
     check_fee: bool = True,
 ) -> Response:
     """Signs and submits a transaction to the XRPL."""
-    return safe_sign_and_submit_transaction(
-        transaction, wallet, client, check_fee=check_fee
-    )
+    return sign_and_submit(transaction, wallet, client, check_fee=check_fee)
 
 
 # just submits a transaction to the ledger, asynchronously

--- a/tests/integration/sugar/test_transaction.py
+++ b/tests/integration/sugar/test_transaction.py
@@ -133,7 +133,7 @@ class TestTransaction(IntegrationTestCase):
         globals(),
         [
             "xrpl.transaction.autofill_and_sign",
-            "xrpl.transaction.submit_transaction",
+            "xrpl.transaction.submit",
         ],
     )
     async def test_payment_high_fee_authorized_with_submit_alias(self, client):

--- a/tests/integration/sugar/test_transaction.py
+++ b/tests/integration/sugar/test_transaction.py
@@ -13,11 +13,9 @@ from xrpl.asyncio.transaction import (
     autofill,
     autofill_and_sign,
     sign,
-    submit_and_wait,
 )
-from xrpl.asyncio.transaction import (
-    submit_transaction as submit_transaction_alias_async,
-)
+from xrpl.asyncio.transaction import submit as submit_transaction_alias_async
+from xrpl.asyncio.transaction import submit_and_wait
 from xrpl.clients import XRPLRequestFailureException
 from xrpl.core.addresscodec import classic_address_to_xaddress
 from xrpl.core.binarycodec.main import encode

--- a/xrpl/asyncio/transaction/__init__.py
+++ b/xrpl/asyncio/transaction/__init__.py
@@ -2,13 +2,9 @@
 from xrpl.asyncio.transaction.main import (
     autofill,
     autofill_and_sign,
-    safe_sign_and_autofill_transaction,
-    safe_sign_and_submit_transaction,
-    safe_sign_transaction,
     sign,
     sign_and_submit,
     submit,
-    submit_transaction,
     transaction_json_to_binary_codec_form,
 )
 from xrpl.asyncio.transaction.reliable_submission import (
@@ -19,14 +15,10 @@ from xrpl.asyncio.transaction.reliable_submission import (
 __all__ = [
     "autofill",
     "autofill_and_sign",
-    "safe_sign_transaction",
-    "safe_sign_and_autofill_transaction",
-    "safe_sign_and_submit_transaction",
     "sign",
     "sign_and_submit",
     "submit",
     "submit_and_wait",
-    "submit_transaction",
     "transaction_json_to_binary_codec_form",
     "XRPLReliableSubmissionException",
 ]

--- a/xrpl/asyncio/transaction/main.py
+++ b/xrpl/asyncio/transaction/main.py
@@ -167,9 +167,6 @@ async def submit(
     raise XRPLRequestFailureException(response.result)
 
 
-submit_transaction = submit
-
-
 def _prepare_transaction(
     transaction: Transaction,
     wallet: Wallet,

--- a/xrpl/asyncio/transaction/main.py
+++ b/xrpl/asyncio/transaction/main.py
@@ -57,9 +57,6 @@ async def sign_and_submit(
     return await submit(transaction, client)
 
 
-safe_sign_and_submit_transaction = sign_and_submit
-
-
 async def sign(
     transaction: Transaction,
     wallet: Wallet,
@@ -109,9 +106,6 @@ async def sign(
     return Transaction.from_xrpl(transaction_json)
 
 
-safe_sign_transaction = sign
-
-
 async def autofill_and_sign(
     transaction: Transaction,
     wallet: Wallet,
@@ -139,9 +133,6 @@ async def autofill_and_sign(
         await _check_fee(transaction, client)
 
     return await sign(await autofill(transaction, client), wallet, False)
-
-
-safe_sign_and_autofill_transaction = autofill_and_sign
 
 
 async def submit(

--- a/xrpl/transaction/__init__.py
+++ b/xrpl/transaction/__init__.py
@@ -6,13 +6,9 @@ from xrpl.asyncio.transaction import (
 from xrpl.transaction.main import (
     autofill,
     autofill_and_sign,
-    safe_sign_and_autofill_transaction,
-    safe_sign_and_submit_transaction,
-    safe_sign_transaction,
     sign,
     sign_and_submit,
     submit,
-    submit_transaction,
 )
 from xrpl.transaction.multisign import multisign
 from xrpl.transaction.reliable_submission import submit_and_wait
@@ -20,14 +16,10 @@ from xrpl.transaction.reliable_submission import submit_and_wait
 __all__ = [
     "autofill",
     "autofill_and_sign",
-    "safe_sign_transaction",
-    "safe_sign_and_autofill_transaction",
-    "safe_sign_and_submit_transaction",
     "sign",
     "sign_and_submit",
     "submit",
     "submit_and_wait",
-    "submit_transaction",
     "transaction_json_to_binary_codec_form",
     "multisign",
     "XRPLReliableSubmissionException",

--- a/xrpl/transaction/main.py
+++ b/xrpl/transaction/main.py
@@ -73,9 +73,6 @@ def submit(
     )
 
 
-submit_transaction = submit
-
-
 def sign(
     transaction: Transaction,
     wallet: Wallet,

--- a/xrpl/transaction/main.py
+++ b/xrpl/transaction/main.py
@@ -42,9 +42,6 @@ def sign_and_submit(
     )
 
 
-safe_sign_and_submit_transaction = sign_and_submit
-
-
 def submit(
     transaction: Transaction,
     client: SyncClient,
@@ -108,9 +105,6 @@ def sign(
     )
 
 
-safe_sign_transaction = sign
-
-
 def autofill_and_sign(
     transaction: Transaction,
     wallet: Wallet,
@@ -139,9 +133,6 @@ def autofill_and_sign(
             check_fee,
         )
     )
-
-
-safe_sign_and_autofill_transaction = autofill_and_sign
 
 
 def autofill(


### PR DESCRIPTION
## High Level Overview of Change

- Longer aliases for signing/submitting functions have been removed. Specifically
  - `submit_transaction` is now `submit`
  - `safe_sign_transaction` is now `sign`
  - `safe_sign_and_submit_transaction` is now `sign_and_submit`
  - `safe_sign_and_autofill_transaction` is now `sign_and_autofill`

### Context of Change

xrpl-py started with the longer versions of these names. In 1.8 we added the shorter aliases. Now we can simplify the interface by just having one name for the functions since `safe` and `transaction` weren't adding much meaning to the functions.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Test Plan

CI Passes

<!--
## Future Tasks
For future tasks related to PR.
-->
