### PR TITLE
refactor: Make param order for signing/submitting consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Core keypairs formatting for ED25519 is now padded with zeros if length of keystring is less than 64
 - Removed deprecated request wrappers (the preferred method is to directly do client.request instead)
 - `sign` is now synchronous instead of async (done by removing the optional `check_fee` param & moving checks up to other functions)
+- In order to be internally consistent, all signing/submitting functions will follow the parameter order of `transaction`, `client`, `wallet`, and then other parameters. (This is because `wallet` is optional for `submit_and_wait` and so must come after `client`)
 
 ### Removed:
 - Longer aliases for signing/submitting functions have been removed. Specifically
   - `submit_transaction` is now `submit`
   - `safe_sign_transaction` is now `sign`
   - `safe_sign_and_submit_transaction` is now `sign_and_submit`
-  - `safe_sign_and_autofill_transaction` is now `sign_and_autofill`
+    - The param order for `sign_and_submit` moves `wallet` after `client` to be consistent with `submit_and_wait`
+  - `safe_sign_and_autofill_transaction` is now `autofill_and_sign`
+    - The param order for `autofill_and_sign` moves `wallet` after `client` to be consistent with `submit_and_wait`
 
 ## [[Unreleased]]
 ### Added:

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ my_tx_payment = Payment(
 
 # sign the transaction with the autofill method
 # (this will auto-populate the fee, sequence, and last_ledger_sequence)
-my_tx_payment_signed = autofill_and_sign(my_tx_payment, test_wallet, client)
+my_tx_payment_signed = autofill_and_sign(my_tx_payment, client, test_wallet)
 print(my_tx_payment_signed)
 # Payment(
 #     account='rMPUKmzmDWEX1tQhzQ8oGFNfAEhnWNFwz',

--- a/snippets/paths.py
+++ b/snippets/paths.py
@@ -47,4 +47,4 @@ payment_tx = Payment(
     paths=paths,
 )
 
-print("signed: ", autofill_and_sign(payment_tx, wallet, client))
+print("signed: ", autofill_and_sign(payment_tx, client, wallet))

--- a/tests/integration/it_utils.py
+++ b/tests/integration/it_utils.py
@@ -100,7 +100,7 @@ def fund_wallet_sync(wallet: Wallet) -> None:
         destination=wallet.classic_address,
         amount=FUNDING_AMOUNT,
     )
-    sign_and_submit(payment, MASTER_WALLET, client, check_fee=True)
+    sign_and_submit(payment, client, MASTER_WALLET, check_fee=True)
     client.request(LEDGER_ACCEPT_REQUEST)
 
 
@@ -112,7 +112,7 @@ async def fund_wallet(
         destination=wallet.classic_address,
         amount=FUNDING_AMOUNT,
     )
-    await sign_and_submit_async(payment, MASTER_WALLET, client, check_fee=True)
+    await sign_and_submit_async(payment, client, MASTER_WALLET, check_fee=True)
     await client.request(LEDGER_ACCEPT_REQUEST)
 
 
@@ -124,7 +124,7 @@ def submit_transaction(
     check_fee: bool = True,
 ) -> Response:
     """Signs and submits a transaction to the XRPL."""
-    return sign_and_submit(transaction, wallet, client, check_fee=check_fee)
+    return sign_and_submit(transaction, client, wallet, check_fee=check_fee)
 
 
 # just submits a transaction to the ledger, asynchronously
@@ -134,7 +134,7 @@ async def submit_transaction_async(
     client: AsyncClient,
     check_fee: bool = True,
 ) -> Response:
-    return await sign_and_submit_async(transaction, wallet, client, check_fee=check_fee)
+    return await sign_and_submit_async(transaction, client, wallet, check_fee=check_fee)
 
 
 # submits a transaction to the ledger and closes a ledger, synchronously

--- a/tests/integration/reqs/test_submit_only.py
+++ b/tests/integration/reqs/test_submit_only.py
@@ -21,7 +21,7 @@ TX = OfferCreate(
 class TestSubmitOnly(IntegrationTestCase):
     @test_async_and_sync(globals(), ["xrpl.transaction.autofill_and_sign"])
     async def test_basic_functionality(self, client):
-        transaction = await autofill_and_sign(TX, WALLET, client)
+        transaction = await autofill_and_sign(TX, client, WALLET)
 
         tx_json = transaction.to_xrpl()
         tx_blob = encode(tx_json)

--- a/tests/integration/sugar/test_transaction.py
+++ b/tests/integration/sugar/test_transaction.py
@@ -144,8 +144,8 @@ class TestTransaction(IntegrationTestCase):
                 fee=FEE,
                 destination=DESTINATION,
             ),
-            WALLET,
             client,
+            WALLET,
             check_fee=False,
         )
 
@@ -275,7 +275,7 @@ class TestSubmitAndWait(IntegrationTestCase):
             destination=DESTINATION,
         )
         payment_transaction_signed = await autofill_and_sign(
-            payment_transaction, WALLET, client
+            payment_transaction, client, WALLET
         )
         await accept_ledger_async(delay=1)
         response = await submit_and_wait(payment_transaction_signed, client)
@@ -301,7 +301,7 @@ class TestSubmitAndWait(IntegrationTestCase):
             destination=DESTINATION,
         )
         payment_transaction_signed = await autofill_and_sign(
-            payment_transaction, WALLET, client
+            payment_transaction, client, WALLET
         )
         await accept_ledger_async(delay=1)
         payment_transaction_signed_blob = encode(payment_transaction_signed.to_xrpl())

--- a/xrpl/asyncio/transaction/main.py
+++ b/xrpl/asyncio/transaction/main.py
@@ -30,8 +30,8 @@ _ACCOUNT_DELETE_FEE: Final[int] = int(xrp_to_drops(2))
 
 async def sign_and_submit(
     transaction: Transaction,
-    wallet: Wallet,
     client: Client,
+    wallet: Wallet,
     autofill: bool = True,
     check_fee: bool = True,
 ) -> Response:
@@ -41,8 +41,8 @@ async def sign_and_submit(
 
     Args:
         transaction: the transaction to be signed and submitted.
-        wallet: the wallet with which to sign the transaction.
         client: the network client with which to submit the transaction.
+        wallet: the wallet with which to sign the transaction.
         autofill: whether to autofill the relevant fields. Defaults to True.
         check_fee: whether to check if the fee is higher than the expected transaction
             type fee. Defaults to True.
@@ -51,7 +51,7 @@ async def sign_and_submit(
         The response from the ledger.
     """
     if autofill:
-        transaction = await autofill_and_sign(transaction, wallet, client, check_fee)
+        transaction = await autofill_and_sign(transaction, client, wallet, check_fee)
     else:
         if check_fee:
             await _check_fee(transaction, client)
@@ -109,8 +109,8 @@ def sign(
 
 async def autofill_and_sign(
     transaction: Transaction,
-    wallet: Wallet,
     client: Client,
+    wallet: Wallet,
     check_fee: bool = True,
 ) -> Transaction:
     """

--- a/xrpl/transaction/main.py
+++ b/xrpl/transaction/main.py
@@ -11,8 +11,8 @@ from xrpl.wallet.main import Wallet
 
 def sign_and_submit(
     transaction: Transaction,
-    wallet: Wallet,
     client: SyncClient,
+    wallet: Wallet,
     autofill: bool = True,
     check_fee: bool = True,
 ) -> Response:
@@ -22,8 +22,8 @@ def sign_and_submit(
 
     Args:
         transaction: the transaction to be signed and submitted.
-        wallet: the wallet with which to sign the transaction.
         client: the network client with which to submit the transaction.
+        wallet: the wallet with which to sign the transaction.
         autofill: whether to autofill the relevant fields. Defaults to True.
         check_fee: whether to check if the fee is higher than the expected transaction
             type fee. Defaults to True.
@@ -34,8 +34,8 @@ def sign_and_submit(
     return asyncio.run(
         main.sign_and_submit(
             transaction,
-            wallet,
             client,
+            wallet,
             autofill,
             check_fee,
         )
@@ -78,8 +78,8 @@ sign = main.sign
 
 def autofill_and_sign(
     transaction: Transaction,
-    wallet: Wallet,
     client: SyncClient,
+    wallet: Wallet,
     check_fee: bool = True,
 ) -> Transaction:
     """
@@ -88,8 +88,8 @@ def autofill_and_sign(
 
     Args:
         transaction: the transaction to be signed.
-        wallet: the wallet with which to sign the transaction.
         client: a network client.
+        wallet: the wallet with which to sign the transaction.
         check_fee: whether to check if the fee is higher than the expected transaction
             type fee. Defaults to True.
 
@@ -99,8 +99,8 @@ def autofill_and_sign(
     return asyncio.run(
         main.autofill_and_sign(
             transaction,
-            wallet,
             client,
+            wallet,
             check_fee,
         )
     )


### PR DESCRIPTION
## High Level Overview of Change

`submit_and_wait` changed the param order since `Wallet` is optional, so we want to make all similar functions follow the same order to reduce confusion/frustration.

### Context of Change

In order to be internally consistent, all signing/submitting functions will follow the parameter order of `transaction`, `client`, `wallet`, and then other parameters. (This is because `wallet` is optional for `submit_and_wait` and so must come after `client`)

This affects `autofill_and_sign` and `sign_and_submit`. 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Test Plan

CI Passes

<!--
## Future Tasks
For future tasks related to PR.
-->
