### PR TITLE
refactor(wallet): Rename `Wallet.classic_address` to `Wallet.address`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added:
 - Wallet support for regular key compatibility
 - Added new ways of wallet generation: `from_seed`, `from_secret`, `from_entropy`, `from_secret_numbers`
-- Added address alias to `Wallet.classic_address `
+- Replaced `Wallet.classic_address` with `Wallet.address` to avoid confusion. (`classic_address` is the same as your XRPL account `address`, and is only called classic since it's an older standard than `x-address`)
 
 ### Changed:
 - Updated params for Wallet class constructor
-- `Wallet.address` and `Wallet.classic_address` are now readonly
+- `Wallet.address` is now readonly
 - Removed Sequence from Wallet class
 - Core keypairs generate seed must take in hexstring instead of bytestring
 - Core keypairs formatting for ED25519 is now padded with zeros if length of keystring is less than 64

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Use [`xrpl.core.addresscodec`](https://xrpl-py.readthedocs.io/en/stable/source/x
 # convert classic address to x-address
 from xrpl.core import addresscodec
 testnet_xaddress = (
-    addresscodec.address_to_xaddress(
+    addresscodec.classic_classic_address_to_xaddress(
         "rMPUKmzmDWEX1tQhzQ8oGFNfAEhnWNFwz",
         tag=0,
         is_test_network=True,

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ test_wallet = generate_faucet_wallet(client)
 print(test_wallet)
 public_key: ED3CC1BBD0952A60088E89FA502921895FC81FBD79CAE9109A8FE2D23659AD5D56
 private_key: -HIDDEN-
-classic_address: rBtXmAdEYcno9LWRnAGfT9qBxCeDvuVRZo
+address: rBtXmAdEYcno9LWRnAGfT9qBxCeDvuVRZo
 
 # look up account info
 from xrpl.models.requests.account_info import AccountInfo
@@ -107,14 +107,14 @@ wallet_from_seed = xrpl.wallet.Wallet.from_seed(seed)
 print(wallet_from_seed)
 # pub_key: ED46949E414A3D6D758D347BAEC9340DC78F7397FEE893132AAF5D56E4D7DE77B0
 # priv_key: -HIDDEN-
-# classic_address: rG5ZvYsK5BPi9f1Nb8mhFGDTNMJhEhufn6
+# address: rG5ZvYsK5BPi9f1Nb8mhFGDTNMJhEhufn6
 ```
 
 To create a wallet from a Testnet faucet:
 
 ```py
 test_wallet = generate_faucet_wallet(client)
-test_account = test_wallet.classic_address
+test_account = test_wallet.address
 print("Classic address:", test_account)
 # Classic address: rEQB2hhp3rg7sHj6L8YyR4GG47Cb7pfcuw
 ```
@@ -130,7 +130,7 @@ Here's an example of how to generate a `seed` value and derive an [XRP Ledger "c
 from xrpl.core import keypairs
 seed = keypairs.generate_seed()
 public, private = keypairs.derive_keypair(seed)
-test_account = keypairs.derive_classic_address(public)
+test_account = keypairs.derive_address(public)
 print("Here's the public key:")
 print(public)
 print("Here's the private key:")
@@ -172,11 +172,11 @@ current_validated_ledger = get_latest_validated_ledger_sequence(client)
 # the amount is expressed in drops, not XRP
 # see https://xrpl.org/basic-data-types.html#specifying-currency-amounts
 my_tx_payment = Payment(
-    account=test_wallet.classic_address,
+    account=test_wallet.address,
     amount="2200000",
     destination="rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe",
     last_ledger_sequence=current_validated_ledger + 20,
-    sequence=get_next_valid_seq_number(test_wallet.classic_address, client),
+    sequence=get_next_valid_seq_number(test_wallet.address, client),
     fee="10",
 )
 # sign the transaction
@@ -209,7 +209,7 @@ from xrpl.transaction import submit_and_wait, autofill_and_sign
 # the amount is expressed in drops, not XRP
 # see https://xrpl.org/basic-data-types.html#specifying-currency-amounts
 my_tx_payment = Payment(
-    account=test_wallet.classic_address,
+    account=test_wallet.address,
     amount="2200000",
     destination="rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe"
 )
@@ -289,11 +289,11 @@ async def submit_sample_transaction():
     # the amount is expressed in drops, not XRP
     # see https://xrpl.org/basic-data-types.html#specifying-currency-amounts
     my_tx_payment = Payment(
-        account=test_wallet.classic_address,
+        account=test_wallet.address,
         amount="2200000",
         destination="rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe",
         last_ledger_sequence=current_validated_ledger + 20,
-        sequence=await get_next_valid_seq_number(test_wallet.classic_address, async_client),
+        sequence=await get_next_valid_seq_number(test_wallet.address, async_client),
         fee="10",
     )
     # sign and submit the transaction
@@ -310,7 +310,7 @@ Use [`xrpl.core.addresscodec`](https://xrpl-py.readthedocs.io/en/stable/source/x
 # convert classic address to x-address
 from xrpl.core import addresscodec
 testnet_xaddress = (
-    addresscodec.classic_address_to_xaddress(
+    addresscodec.address_to_xaddress(
         "rMPUKmzmDWEX1tQhzQ8oGFNfAEhnWNFwz",
         tag=0,
         is_test_network=True,

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Use [`xrpl.core.addresscodec`](https://xrpl-py.readthedocs.io/en/stable/source/x
 # convert classic address to x-address
 from xrpl.core import addresscodec
 testnet_xaddress = (
-    addresscodec.classic_classic_address_to_xaddress(
+    addresscodec.classic_address_to_xaddress(
         "rMPUKmzmDWEX1tQhzQ8oGFNfAEhnWNFwz",
         tag=0,
         is_test_network=True,

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Here's an example of how to generate a `seed` value and derive an [XRP Ledger "c
 from xrpl.core import keypairs
 seed = keypairs.generate_seed()
 public, private = keypairs.derive_keypair(seed)
-test_account = keypairs.derive_address(public)
+test_account = keypairs.derive_classic_address(public)
 print("Here's the public key:")
 print(public)
 print("Here's the private key:")

--- a/snippets/multisign.py
+++ b/snippets/multisign.py
@@ -14,11 +14,11 @@ signer_wallet_1 = generate_faucet_wallet(client, debug=True)
 signer_wallet_2 = generate_faucet_wallet(client, debug=True)
 
 signer_entries = [
-    SignerEntry(account=signer_wallet_1.classic_address, signer_weight=1),
-    SignerEntry(account=signer_wallet_2.classic_address, signer_weight=1),
+    SignerEntry(account=signer_wallet_1.address, signer_weight=1),
+    SignerEntry(account=signer_wallet_2.address, signer_weight=1),
 ]
 signer_list_set_tx = SignerListSet(
-    account=master_wallet.classic_address,
+    account=master_wallet.address,
     signer_quorum=2,
     signer_entries=signer_entries,
 )
@@ -34,7 +34,7 @@ print(signed_list_set_tx_response)
 # Now that we've set up multisigning, let's try using it to submit an AccountSet
 # transaction.
 account_set_tx = AccountSet(
-    account=master_wallet.classic_address, domain=str_to_hex("example.com")
+    account=master_wallet.address, domain=str_to_hex("example.com")
 )
 autofilled_account_set_tx = autofill(account_set_tx, client, len(signer_entries))
 print("AccountSet transaction is ready to be multisigned")

--- a/snippets/partial_payment.py
+++ b/snippets/partial_payment.py
@@ -21,11 +21,11 @@ wallet2 = generate_faucet_wallet(client, debug=True)
 
 # Create a TrustSet to issue an IOU `FOO` and set limit on it
 trust_set_tx = TrustSet(
-    account=wallet2.classic_address,
+    account=wallet2.address,
     limit_amount=IssuedCurrencyAmount(
         currency="FOO",
         value="10000000000",
-        issuer=wallet1.classic_address,
+        issuer=wallet1.address,
     ),
 )
 
@@ -34,19 +34,19 @@ submit_and_wait(trust_set_tx, client, wallet2)
 
 # Both balances should be zero since nothing has been sent yet
 print("Balances after trustline is claimed:")
-print((client.request(AccountLines(account=wallet1.classic_address))).result["lines"])
-print((client.request(AccountLines(account=wallet2.classic_address))).result["lines"])
+print((client.request(AccountLines(account=wallet1.address))).result["lines"])
+print((client.request(AccountLines(account=wallet2.address))).result["lines"])
 
 # Create a Payment to send 3840 FOO from wallet1 (issuer) to destination (wallet2)
 issue_quantity = "3840"
 payment_tx = Payment(
-    account=wallet1.classic_address,
+    account=wallet1.address,
     amount=IssuedCurrencyAmount(
         currency="FOO",
         value=issue_quantity,
-        issuer=wallet1.classic_address,
+        issuer=wallet1.address,
     ),
-    destination=wallet2.classic_address,
+    destination=wallet2.address,
 )
 
 # Sign and autofill, then send transaction to the ledger
@@ -55,8 +55,8 @@ print(payment_response)
 
 # Issuer (wallet1) should have -3840 FOO and destination (wallet2) should have 3840 FOO
 print("Balances after wallet1 sends 3840 FOO to wallet2:")
-print((client.request(AccountLines(account=wallet1.classic_address))).result["lines"])
-print((client.request(AccountLines(account=wallet2.classic_address))).result["lines"])
+print((client.request(AccountLines(account=wallet1.address))).result["lines"])
+print((client.request(AccountLines(account=wallet2.address))).result["lines"])
 
 # Send money less than the amount specified on 2 conditions:
 # 1. Sender has less money than the amount specified in the payment Tx.
@@ -68,18 +68,18 @@ print((client.request(AccountLines(account=wallet2.classic_address))).result["li
 
 # Create Payment to send 4000 (of 3840) FOO from wallet2 to wallet1
 partial_payment_tx = Payment(
-    account=wallet2.classic_address,
+    account=wallet2.address,
     amount=IssuedCurrencyAmount(
         currency="FOO",
         value="4000",
-        issuer=wallet1.classic_address,
+        issuer=wallet1.address,
     ),
-    destination=wallet1.classic_address,
+    destination=wallet1.address,
     flags=[PaymentFlag.TF_PARTIAL_PAYMENT],
     send_max=IssuedCurrencyAmount(
         currency="FOO",
         value="1000000",
-        issuer=wallet1.classic_address,
+        issuer=wallet1.address,
     ),
 )
 
@@ -89,5 +89,5 @@ print(partial_payment_response)
 
 # Tried sending 4000 of 3840 FOO -> wallet1 and wallet2 should have 0 FOO
 print("Balances after Partial Payment, when wallet2 tried to send 4000 FOOs")
-print((client.request(AccountLines(account=wallet1.classic_address))).result["lines"])
-print((client.request(AccountLines(account=wallet2.classic_address))).result["lines"])
+print((client.request(AccountLines(account=wallet1.address))).result["lines"])
+print((client.request(AccountLines(account=wallet2.address))).result["lines"])

--- a/snippets/paths.py
+++ b/snippets/paths.py
@@ -27,7 +27,7 @@ destination_amount = IssuedCurrencyAmount(
 
 # Create a RipplePathFind request and have the client call it
 path_request = RipplePathFind(
-    source_account=wallet.classic_address,
+    source_account=wallet.address,
     source_currencies=[XRP()],
     destination_account=destination_account,
     destination_amount=destination_amount,
@@ -41,7 +41,7 @@ print(paths)
 
 # # Create a Payment to send money from wallet to destination_account using path
 payment_tx = Payment(
-    account=wallet.classic_address,
+    account=wallet.address,
     amount=destination_amount,
     destination=destination_account,
     paths=paths,

--- a/snippets/send_escrow.py
+++ b/snippets/send_escrow.py
@@ -23,16 +23,16 @@ wallet2 = generate_faucet_wallet(client, debug=True)
 
 # Both balances should be zero since nothing has been sent yet
 print("Balances of wallets before Escrow tx was created:")
-print(get_balance(wallet1.classic_address, client))
-print(get_balance(wallet2.classic_address, client))
+print(get_balance(wallet1.address, client))
+print(get_balance(wallet2.address, client))
 
 # Create a finish time (2 seconds from current time)
 finish_after = datetime_to_ripple_time(datetime.now()) + 2
 
 # Create an EscrowCreate transaction, then sign, autofill, and send it
 create_tx = EscrowCreate(
-    account=wallet1.classic_address,
-    destination=wallet2.classic_address,
+    account=wallet1.address,
+    destination=wallet2.address,
     amount="1000000",
     finish_after=finish_after,
 )
@@ -41,7 +41,7 @@ create_escrow_response = submit_and_wait(create_tx, client, wallet1)
 print(create_escrow_response)
 
 # Create an AccountObjects request and have the client call it to see if escrow exists
-account_objects_request = AccountObjects(account=wallet1.classic_address)
+account_objects_request = AccountObjects(account=wallet1.address)
 account_objects = (client.request(account_objects_request)).result["account_objects"]
 
 print("Escrow object exists in wallet1's account:")
@@ -49,8 +49,8 @@ print(account_objects)
 
 # Create an EscrowFinish transaction, then sign, autofill, and send it
 finish_tx = EscrowFinish(
-    account=wallet1.classic_address,
-    owner=wallet1.classic_address,
+    account=wallet1.address,
+    owner=wallet1.address,
     offer_sequence=create_escrow_response.result["Sequence"],
 )
 
@@ -58,5 +58,5 @@ submit_and_wait(finish_tx, client, wallet1)
 
 # If escrow went through successfully, 1000000 exchanged
 print("Balances of wallets after Escrow was sent:")
-print(get_balance(wallet1.classic_address, client))
-print(get_balance(wallet2.classic_address, client))
+print(get_balance(wallet1.address, client))
+print(get_balance(wallet2.address, client))

--- a/snippets/set_regular_key.py
+++ b/snippets/set_regular_key.py
@@ -24,9 +24,7 @@ print(get_balance(wallet1.address, client))
 print(get_balance(wallet2.address, client))
 
 # Assign key pair (regular_key_wallet) to wallet1 using SetRegularKey transaction
-tx = SetRegularKey(
-    account=wallet1.address, regular_key=regular_key_wallet.address
-)
+tx = SetRegularKey(account=wallet1.address, regular_key=regular_key_wallet.address)
 
 set_regular_key_response = submit_and_wait(tx, client, wallet1)
 

--- a/snippets/set_regular_key.py
+++ b/snippets/set_regular_key.py
@@ -20,12 +20,12 @@ regular_key_wallet = generate_faucet_wallet(client, debug=True)
 
 # Both balances should be zero since nothing has been sent yet
 print("Balances before payment:")
-print(get_balance(wallet1.classic_address, client))
-print(get_balance(wallet2.classic_address, client))
+print(get_balance(wallet1.address, client))
+print(get_balance(wallet2.address, client))
 
 # Assign key pair (regular_key_wallet) to wallet1 using SetRegularKey transaction
 tx = SetRegularKey(
-    account=wallet1.classic_address, regular_key=regular_key_wallet.classic_address
+    account=wallet1.address, regular_key=regular_key_wallet.address
 )
 
 set_regular_key_response = submit_and_wait(tx, client, wallet1)
@@ -36,8 +36,8 @@ print(set_regular_key_response)
 # Since regular_key_wallet is linked to wallet1,
 # walet1 can send payment to wallet2 and have regular_key_wallet sign it
 payment = Payment(
-    account=wallet1.classic_address,
-    destination=wallet2.classic_address,
+    account=wallet1.address,
+    destination=wallet2.address,
     amount="1000",
 )
 
@@ -48,5 +48,5 @@ print(payment_response)
 
 # Balance after sending 1000 from wallet1 to wallet2
 print("Balances after payment:")
-print(get_balance(wallet1.classic_address, client))
-print(get_balance(wallet2.classic_address, client))
+print(get_balance(wallet1.address, client))
+print(get_balance(wallet2.address, client))

--- a/snippets/submit_payment.py
+++ b/snippets/submit_payment.py
@@ -20,14 +20,14 @@ wallet2 = generate_faucet_wallet(client, debug=True)
 
 # Both balances should be zero since nothing has been sent yet
 print("Balances of wallets before Payment tx")
-print(get_balance(wallet1.classic_address, client))
-print(get_balance(wallet2.classic_address, client))
+print(get_balance(wallet1.address, client))
+print(get_balance(wallet2.address, client))
 
 # Create a Payment transaction
 payment_tx = Payment(
-    account=wallet1.classic_address,
+    account=wallet1.address,
     amount="1000",
-    destination=wallet2.classic_address,
+    destination=wallet2.address,
 )
 
 # Signs, autofills, and submits transaction and waits for response (validated or rejected)
@@ -42,5 +42,5 @@ print("Validated:", tx_response.result["validated"])
 
 # Check balances after 1000 was sent from wallet1 to wallet2
 print("Balances of wallets after Payment tx:")
-print(get_balance(wallet1.classic_address, client))
-print(get_balance(wallet2.classic_address, client))
+print(get_balance(wallet1.address, client))
+print(get_balance(wallet2.address, client))

--- a/tests/integration/it_utils.py
+++ b/tests/integration/it_utils.py
@@ -97,7 +97,7 @@ def fund_wallet_sync(wallet: Wallet) -> None:
     client = JSON_RPC_CLIENT
     payment = Payment(
         account=MASTER_ACCOUNT,
-        destination=wallet.classic_address,
+        destination=wallet.address,
         amount=FUNDING_AMOUNT,
     )
     sign_and_submit(payment, client, MASTER_WALLET, check_fee=True)
@@ -109,7 +109,7 @@ async def fund_wallet(
 ) -> None:
     payment = Payment(
         account=MASTER_ACCOUNT,
-        destination=wallet.classic_address,
+        destination=wallet.address,
         amount=FUNDING_AMOUNT,
     )
     await sign_and_submit_async(payment, client, MASTER_WALLET, check_fee=True)

--- a/tests/integration/reqs/test_account_info.py
+++ b/tests/integration/reqs/test_account_info.py
@@ -9,7 +9,7 @@ class TestAccountInfo(IntegrationTestCase):
     async def test_basic_functionality(self, client):
         response = await client.request(
             AccountInfo(
-                account=WALLET.classic_address,
+                account=WALLET.address,
             )
         )
         self.assertTrue(response.is_successful())

--- a/tests/integration/reqs/test_account_objects.py
+++ b/tests/integration/reqs/test_account_objects.py
@@ -9,7 +9,7 @@ class TestAccountObjects(IntegrationTestCase):
     async def test_basic_functionality(self, client):
         response = await client.request(
             AccountObjects(
-                account=WALLET.classic_address,
+                account=WALLET.address,
             )
         )
         self.assertTrue(response.is_successful())

--- a/tests/integration/reqs/test_account_tx.py
+++ b/tests/integration/reqs/test_account_tx.py
@@ -9,7 +9,7 @@ class TestAccountTx(IntegrationTestCase):
     async def test_basic_functionality(self, client):
         response = await client.request(
             AccountTx(
-                account=WALLET.classic_address,
+                account=WALLET.address,
             )
         )
         self.assertTrue(response.is_successful())

--- a/tests/integration/reqs/test_book_offers.py
+++ b/tests/integration/reqs/test_book_offers.py
@@ -10,7 +10,7 @@ class TestBookOffers(IntegrationTestCase):
     async def test_basic_functionality(self, client):
         response = await client.request(
             BookOffers(
-                taker=WALLET.classic_address,
+                taker=WALLET.address,
                 taker_gets=XRP(),
                 taker_pays=IssuedCurrency(
                     currency="USD",

--- a/tests/integration/reqs/test_no_ripple_check.py
+++ b/tests/integration/reqs/test_no_ripple_check.py
@@ -9,7 +9,7 @@ class TestNoRippleCheck(IntegrationTestCase):
     async def test_basic_functionality(self, client):
         response = await client.request(
             NoRippleCheck(
-                account=WALLET.classic_address,
+                account=WALLET.address,
                 role=NoRippleCheckRole.USER,
             )
         )

--- a/tests/integration/reqs/test_ripple_path_find.py
+++ b/tests/integration/reqs/test_ripple_path_find.py
@@ -9,8 +9,8 @@ class TestRipplePathFind(IntegrationTestCase):
     async def test_basic_functionality(self, client):
         response = await client.request(
             RipplePathFind(
-                source_account=WALLET.classic_address,
-                destination_account=DESTINATION.classic_address,
+                source_account=WALLET.address,
+                destination_account=DESTINATION.address,
                 destination_amount="100",
             ),
         )

--- a/tests/integration/reqs/test_submit_multisigned.py
+++ b/tests/integration/reqs/test_submit_multisigned.py
@@ -26,17 +26,17 @@ FIRST_SIGNER = Wallet.create()
 SECOND_SIGNER = Wallet.create()
 SIGNER_ENTRIES = [
     SignerEntry(
-        account=FIRST_SIGNER.classic_address,
+        account=FIRST_SIGNER.address,
         signer_weight=1,
     ),
     SignerEntry(
-        account=SECOND_SIGNER.classic_address,
+        account=SECOND_SIGNER.address,
         signer_weight=1,
     ),
 ]
 LIST_SET_TX = sign_and_reliable_submission(
     SignerListSet(
-        account=WALLET.classic_address,
+        account=WALLET.address,
         signer_quorum=2,
         signer_entries=SIGNER_ENTRIES,
     ),
@@ -57,12 +57,12 @@ class TestSubmitMultisigned(IntegrationTestCase):
         # functionality.
         issuer = Wallet.create()
         tx = TrustSet(
-            account=WALLET.classic_address,
-            sequence=await get_next_valid_seq_number(WALLET.classic_address, client),
+            account=WALLET.address,
+            sequence=await get_next_valid_seq_number(WALLET.address, client),
             fee=FEE,
             flags=TrustSetFlag.TF_SET_NO_RIPPLE,
             limit_amount=IssuedCurrencyAmount(
-                issuer=issuer.classic_address,
+                issuer=issuer.address,
                 currency="USD",
                 value="10",
             ),
@@ -72,7 +72,7 @@ class TestSubmitMultisigned(IntegrationTestCase):
             bytes.fromhex(
                 encode_for_multisigning(
                     tx_json,
-                    FIRST_SIGNER.classic_address,
+                    FIRST_SIGNER.address,
                 )
             ),
             FIRST_SIGNER.private_key,
@@ -81,29 +81,29 @@ class TestSubmitMultisigned(IntegrationTestCase):
             bytes.fromhex(
                 encode_for_multisigning(
                     tx_json,
-                    SECOND_SIGNER.classic_address,
+                    SECOND_SIGNER.address,
                 )
             ),
             SECOND_SIGNER.private_key,
         )
         multisigned_tx = TrustSet(
-            account=WALLET.classic_address,
-            sequence=await get_next_valid_seq_number(WALLET.classic_address, client),
+            account=WALLET.address,
+            sequence=await get_next_valid_seq_number(WALLET.address, client),
             fee=FEE,
             flags=TrustSetFlag.TF_SET_NO_RIPPLE,
             limit_amount=IssuedCurrencyAmount(
-                issuer=issuer.classic_address,
+                issuer=issuer.address,
                 currency="USD",
                 value="10",
             ),
             signers=[
                 Signer(
-                    account=FIRST_SIGNER.classic_address,
+                    account=FIRST_SIGNER.address,
                     txn_signature=first_sig,
                     signing_pub_key=FIRST_SIGNER.public_key,
                 ),
                 Signer(
-                    account=SECOND_SIGNER.classic_address,
+                    account=SECOND_SIGNER.address,
                     txn_signature=second_sig,
                     signing_pub_key=SECOND_SIGNER.public_key,
                 ),
@@ -126,7 +126,7 @@ class TestSubmitMultisigned(IntegrationTestCase):
         ],
     )
     async def test_multisign_helper_functionality(self, client):
-        tx = AccountSet(account=WALLET.classic_address, domain=EXAMPLE_DOMAIN)
+        tx = AccountSet(account=WALLET.address, domain=EXAMPLE_DOMAIN)
 
         autofilled_tx = await autofill(tx, client, len(SIGNER_ENTRIES))
 

--- a/tests/integration/reqs/test_submit_only.py
+++ b/tests/integration/reqs/test_submit_only.py
@@ -8,11 +8,11 @@ from xrpl.models.requests import SubmitOnly
 from xrpl.models.transactions import OfferCreate
 
 TX = OfferCreate(
-    account=WALLET.classic_address,
+    account=WALLET.address,
     taker_gets="13100000",
     taker_pays=IssuedCurrencyAmount(
         currency="USD",
-        issuer=WALLET.classic_address,
+        issuer=WALLET.address,
         value="10",
     ),
 )

--- a/tests/integration/reqs/test_subscribe.py
+++ b/tests/integration/reqs/test_subscribe.py
@@ -76,9 +76,9 @@ class TestSubscribe(IntegrationTestCase):
         await client.send(Subscribe(streams=[StreamParameter.TRANSACTIONS]))
 
         payment_transaction = Payment(
-            account=WALLET.classic_address,
+            account=WALLET.address,
             amount="100",
-            destination=DESTINATION.classic_address,
+            destination=DESTINATION.address,
         )
 
         count = 0
@@ -105,9 +105,9 @@ class TestSubscribe(IntegrationTestCase):
         await client.send(Subscribe(streams=[StreamParameter.TRANSACTIONS_PROPOSED]))
 
         payment_transaction = Payment(
-            account=WALLET.classic_address,
+            account=WALLET.address,
             amount="100",
-            destination=DESTINATION.classic_address,
+            destination=DESTINATION.address,
         )
 
         count = 0

--- a/tests/integration/reusable_values.py
+++ b/tests/integration/reusable_values.py
@@ -17,11 +17,11 @@ async def _set_up_reusable_values():
 
     OFFER = await sign_and_reliable_submission_async(
         OfferCreate(
-            account=WALLET.classic_address,
+            account=WALLET.address,
             taker_gets="13100000",
             taker_pays=IssuedCurrencyAmount(
                 currency="USD",
-                issuer=WALLET.classic_address,
+                issuer=WALLET.address,
                 value="10",
             ),
         ),
@@ -30,9 +30,9 @@ async def _set_up_reusable_values():
 
     PAYMENT_CHANNEL = await sign_and_reliable_submission_async(
         PaymentChannelCreate(
-            account=WALLET.classic_address,
+            account=WALLET.address,
             amount="1",
-            destination=DESTINATION.classic_address,
+            destination=DESTINATION.address,
             settle_delay=86400,
             public_key=WALLET.public_key,
         ),

--- a/tests/integration/sugar/test_account.py
+++ b/tests/integration/sugar/test_account.py
@@ -7,7 +7,7 @@ from tests.integration.it_utils import (
 )
 from tests.integration.reusable_values import DESTINATION, WALLET
 from xrpl.asyncio.account import does_account_exist, get_balance, get_latest_transaction
-from xrpl.core.addresscodec import address_to_xaddress
+from xrpl.core.addresscodec import classic_address_to_xaddress
 from xrpl.models.transactions import Payment
 from xrpl.wallet import Wallet
 
@@ -28,7 +28,7 @@ class TestAccount(IntegrationTestCase):
 
     @test_async_and_sync(globals(), ["xrpl.account.does_account_exist"])
     async def test_does_account_exist_xaddress(self, client):
-        xaddress = address_to_xaddress(WALLET.address, None, True)
+        xaddress = classic_address_to_xaddress(WALLET.address, None, True)
         self.assertTrue(await does_account_exist(xaddress, client))
 
     @test_async_and_sync(globals(), ["xrpl.account.get_balance"])

--- a/tests/integration/sugar/test_account.py
+++ b/tests/integration/sugar/test_account.py
@@ -7,7 +7,7 @@ from tests.integration.it_utils import (
 )
 from tests.integration.reusable_values import DESTINATION, WALLET
 from xrpl.asyncio.account import does_account_exist, get_balance, get_latest_transaction
-from xrpl.core.addresscodec import classic_address_to_xaddress
+from xrpl.core.addresscodec import address_to_xaddress
 from xrpl.models.transactions import Payment
 from xrpl.wallet import Wallet
 
@@ -19,7 +19,7 @@ EMPTY_WALLET = Wallet.create()
 class TestAccount(IntegrationTestCase):
     @test_async_and_sync(globals(), ["xrpl.account.does_account_exist"])
     async def test_does_account_exist_true(self, client):
-        self.assertTrue(await does_account_exist(WALLET.classic_address, client))
+        self.assertTrue(await does_account_exist(WALLET.address, client))
 
     @test_async_and_sync(globals(), ["xrpl.account.does_account_exist"])
     async def test_does_account_exist_false(self, client):
@@ -28,13 +28,13 @@ class TestAccount(IntegrationTestCase):
 
     @test_async_and_sync(globals(), ["xrpl.account.does_account_exist"])
     async def test_does_account_exist_xaddress(self, client):
-        xaddress = classic_address_to_xaddress(WALLET.classic_address, None, True)
+        xaddress = address_to_xaddress(WALLET.address, None, True)
         self.assertTrue(await does_account_exist(xaddress, client))
 
     @test_async_and_sync(globals(), ["xrpl.account.get_balance"])
     async def test_get_balance(self, client):
         self.assertEqual(
-            await get_balance(NEW_WALLET.classic_address, client),
+            await get_balance(NEW_WALLET.address, client),
             int(FUNDING_AMOUNT),
         )
 
@@ -43,15 +43,15 @@ class TestAccount(IntegrationTestCase):
         # NOTE: this test may take a long time to run
         amount = "21000000"
         payment = Payment(
-            account=WALLET.classic_address,
-            destination=DESTINATION.classic_address,
+            account=WALLET.address,
+            destination=DESTINATION.address,
             amount=amount,
         )
         await sign_and_reliable_submission_async(payment, WALLET, client)
 
-        response = await get_latest_transaction(WALLET.classic_address, client)
+        response = await get_latest_transaction(WALLET.address, client)
         self.assertEqual(len(response.result["transactions"]), 1)
         transaction = response.result["transactions"][0]["tx"]
         self.assertEqual(transaction["TransactionType"], "Payment")
         self.assertEqual(transaction["Amount"], amount)
-        self.assertEqual(transaction["Account"], WALLET.classic_address)
+        self.assertEqual(transaction["Account"], WALLET.address)

--- a/tests/integration/sugar/test_transaction.py
+++ b/tests/integration/sugar/test_transaction.py
@@ -24,8 +24,8 @@ from xrpl.models.requests import ServerState, Tx
 from xrpl.models.transactions import AccountDelete, AccountSet, EscrowFinish, Payment
 from xrpl.utils import xrp_to_drops
 
-ACCOUNT = WALLET.classic_address
-DESTINATION = DESTINATION_WALLET.classic_address
+ACCOUNT = WALLET.address
+DESTINATION = DESTINATION_WALLET.address
 
 CLEAR_FLAG = 3
 DOMAIN = "6578616D706C652E636F6D".lower()
@@ -51,7 +51,7 @@ class TestTransaction(IntegrationTestCase):
     async def test_none_as_destination_tag(self, client):
         # GIVEN a new transaction (payment)
         payment_transaction = Payment(
-            account=WALLET.classic_address,
+            account=WALLET.address,
             amount="100",
             destination=classic_address_to_xaddress(DESTINATION, None, False),
         )
@@ -115,7 +115,7 @@ class TestTransaction(IntegrationTestCase):
         # GIVEN a new Payment transaction
         response = await sign_and_reliable_submission_async(
             Payment(
-                account=WALLET.classic_address,
+                account=WALLET.address,
                 amount="1",
                 # WITH the fee higher than 2 XRP
                 fee=FEE,
@@ -139,7 +139,7 @@ class TestTransaction(IntegrationTestCase):
     async def test_payment_high_fee_authorized_with_submit_alias(self, client):
         signed_and_autofilled = await autofill_and_sign(
             Payment(
-                account=WALLET.classic_address,
+                account=WALLET.address,
                 amount="1",
                 fee=FEE,
                 destination=DESTINATION,
@@ -204,7 +204,7 @@ class TestTransaction(IntegrationTestCase):
     async def test_calculate_payment_fee(self, client):
         # GIVEN a new Payment transaction
         payment = Payment(
-            account=WALLET.classic_address,
+            account=WALLET.address,
             amount="100",
             destination=DESTINATION,
         )

--- a/tests/integration/sugar/test_wallet.py
+++ b/tests/integration/sugar/test_wallet.py
@@ -6,7 +6,7 @@ from tests.integration.reusable_values import WALLET
 from xrpl.asyncio.clients import AsyncJsonRpcClient, AsyncWebsocketClient
 from xrpl.asyncio.wallet import generate_faucet_wallet
 from xrpl.clients import JsonRpcClient, WebsocketClient
-from xrpl.core.addresscodec import address_to_xaddress
+from xrpl.core.addresscodec import classic_address_to_xaddress
 from xrpl.models.requests import AccountInfo
 from xrpl.models.transactions import Payment
 from xrpl.wallet import generate_faucet_wallet as sync_generate_faucet_wallet
@@ -180,5 +180,5 @@ class TestWallet(IntegrationTestCase):
             self.assertTrue(new_balance > balance)
 
     def test_wallet_get_xaddress(self):
-        expected = address_to_xaddress(WALLET.address, None, False)
+        expected = classic_address_to_xaddress(WALLET.address, None, False)
         self.assertEqual(WALLET.get_xaddress(), expected)

--- a/tests/integration/sugar/test_wallet.py
+++ b/tests/integration/sugar/test_wallet.py
@@ -6,7 +6,7 @@ from tests.integration.reusable_values import WALLET
 from xrpl.asyncio.clients import AsyncJsonRpcClient, AsyncWebsocketClient
 from xrpl.asyncio.wallet import generate_faucet_wallet
 from xrpl.clients import JsonRpcClient, WebsocketClient
-from xrpl.core.addresscodec import classic_address_to_xaddress
+from xrpl.core.addresscodec import address_to_xaddress
 from xrpl.models.requests import AccountInfo
 from xrpl.models.transactions import Payment
 from xrpl.wallet import generate_faucet_wallet as sync_generate_faucet_wallet
@@ -19,7 +19,7 @@ def sync_generate_faucet_wallet_and_fund_again(self, client, faucet_host=None):
     wallet = sync_generate_faucet_wallet(client, faucet_host=faucet_host)
     result = client.request(
         AccountInfo(
-            account=wallet.classic_address,
+            account=wallet.address,
         ),
     )
     balance = int(result.result["account_data"]["Balance"])
@@ -28,7 +28,7 @@ def sync_generate_faucet_wallet_and_fund_again(self, client, faucet_host=None):
     new_wallet = sync_generate_faucet_wallet(client, wallet, faucet_host=faucet_host)
     new_result = client.request(
         AccountInfo(
-            account=new_wallet.classic_address,
+            account=new_wallet.address,
         ),
     )
     new_balance = int(new_result.result["account_data"]["Balance"])
@@ -39,7 +39,7 @@ async def generate_faucet_wallet_and_fund_again(self, client, faucet_host=None):
     wallet = await generate_faucet_wallet(client, faucet_host=faucet_host)
     result = await client.request(
         AccountInfo(
-            account=wallet.classic_address,
+            account=wallet.address,
         ),
     )
     balance = int(result.result["account_data"]["Balance"])
@@ -48,7 +48,7 @@ async def generate_faucet_wallet_and_fund_again(self, client, faucet_host=None):
     new_wallet = await generate_faucet_wallet(client, wallet, faucet_host=faucet_host)
     new_result = await client.request(
         AccountInfo(
-            account=new_wallet.classic_address,
+            account=new_wallet.address,
         ),
     )
     new_balance = int(new_result.result["account_data"]["Balance"])
@@ -68,10 +68,10 @@ class TestWallet(IntegrationTestCase):
         # TODO: refactor so this actually waits for validation
         response = await submit_transaction_async(
             Payment(
-                account=wallet.classic_address,
+                account=wallet.address,
                 fee="10",
                 amount="1",
-                destination=destination.classic_address,
+                destination=destination.address,
             ),
             wallet,
             client=client,
@@ -137,7 +137,7 @@ class TestWallet(IntegrationTestCase):
 
             result = await client.request(
                 AccountInfo(
-                    account=wallet.classic_address,
+                    account=wallet.address,
                 ),
             )
             balance = int(result.result["account_data"]["Balance"])
@@ -159,7 +159,7 @@ class TestWallet(IntegrationTestCase):
             await generate_faucet_wallet(client, wallet)
             result = await client.request(
                 AccountInfo(
-                    account=wallet.classic_address,
+                    account=wallet.address,
                 ),
             )
             balance = int(result.result["account_data"]["Balance"])
@@ -173,12 +173,12 @@ class TestWallet(IntegrationTestCase):
             new_wallet = await generate_faucet_wallet(client, wallet)
             new_result = await client.request(
                 AccountInfo(
-                    account=new_wallet.classic_address,
+                    account=new_wallet.address,
                 ),
             )
             new_balance = int(new_result.result["account_data"]["Balance"])
             self.assertTrue(new_balance > balance)
 
     def test_wallet_get_xaddress(self):
-        expected = classic_address_to_xaddress(WALLET.classic_address, None, False)
+        expected = address_to_xaddress(WALLET.address, None, False)
         self.assertEqual(WALLET.get_xaddress(), expected)

--- a/tests/integration/transactions/test_account_delete.py
+++ b/tests/integration/transactions/test_account_delete.py
@@ -10,7 +10,7 @@ from xrpl.utils import xrp_to_drops
 
 # We can re-use the shared wallet bc this test should fail to actually delete
 # the associated account.
-ACCOUNT = WALLET.classic_address
+ACCOUNT = WALLET.address
 
 # AccountDelete transactions have a special fee.
 # See https://xrpl.org/accountdelete.html#special-transaction-cost.
@@ -24,7 +24,7 @@ class TestAccountDelete(IntegrationTestCase):
         account_delete = AccountDelete(
             account=ACCOUNT,
             fee=FEE,
-            destination=DESTINATION.classic_address,
+            destination=DESTINATION.address,
             destination_tag=DESTINATION_TAG,
         )
         response = await sign_and_reliable_submission_async(

--- a/tests/integration/transactions/test_account_set.py
+++ b/tests/integration/transactions/test_account_set.py
@@ -7,7 +7,7 @@ from tests.integration.reusable_values import WALLET
 from xrpl.models.response import ResponseStatus
 from xrpl.models.transactions import AccountSet
 
-ACCOUNT = WALLET.classic_address
+ACCOUNT = WALLET.address
 
 CLEAR_FLAG = 3
 DOMAIN = "6578616D706C652E636F6D".lower()

--- a/tests/integration/transactions/test_check_cancel.py
+++ b/tests/integration/transactions/test_check_cancel.py
@@ -7,7 +7,7 @@ from tests.integration.reusable_values import WALLET
 from xrpl.models.response import ResponseStatus
 from xrpl.models.transactions import CheckCancel
 
-ACCOUNT = WALLET.classic_address
+ACCOUNT = WALLET.address
 
 CHECK_ID = "49647F0D748DC3FE26BDACBC57F251AADEFFF391403EC9BF87C97F67E9977FB0"
 

--- a/tests/integration/transactions/test_check_cash.py
+++ b/tests/integration/transactions/test_check_cash.py
@@ -7,7 +7,7 @@ from tests.integration.reusable_values import WALLET
 from xrpl.models.response import ResponseStatus
 from xrpl.models.transactions import CheckCash
 
-ACCOUNT = WALLET.classic_address
+ACCOUNT = WALLET.address
 CHECK_ID = "838766BA2B995C00744175F69A1B11E32C3DBC40E64801A4056FCBD657F57334"
 AMOUNT = "100000000"
 DELIVER_MIN = "100000000"

--- a/tests/integration/transactions/test_check_create.py
+++ b/tests/integration/transactions/test_check_create.py
@@ -13,7 +13,7 @@ fund_wallet_sync(WALLET)
 DESTINATION = Wallet.create()
 fund_wallet_sync(DESTINATION)
 
-ACCOUNT = WALLET.classic_address
+ACCOUNT = WALLET.address
 DESTINATION_TAG = 1
 SENDMAX = "100000000"
 EXPIRATION = 970113521
@@ -25,7 +25,7 @@ class TestCheckCreate(IntegrationTestCase):
     async def test_all_fields(self, client):
         check_create = CheckCreate(
             account=ACCOUNT,
-            destination=DESTINATION.classic_address,
+            destination=DESTINATION.address,
             destination_tag=DESTINATION_TAG,
             send_max=SENDMAX,
             expiration=EXPIRATION,

--- a/tests/integration/transactions/test_deposit_preauth.py
+++ b/tests/integration/transactions/test_deposit_preauth.py
@@ -7,7 +7,7 @@ from tests.integration.reusable_values import WALLET
 from xrpl.models.response import ResponseStatus
 from xrpl.models.transactions import DepositPreauth
 
-ACCOUNT = WALLET.classic_address
+ACCOUNT = WALLET.address
 ADDRESS = "rEhxGqkqPPSxQ3P25J66ft5TwpzV14k2de"
 
 

--- a/tests/integration/transactions/test_escrow_cancel.py
+++ b/tests/integration/transactions/test_escrow_cancel.py
@@ -7,7 +7,7 @@ from tests.integration.reusable_values import WALLET
 from xrpl.models.response import ResponseStatus
 from xrpl.models.transactions import EscrowCancel
 
-ACCOUNT = WALLET.classic_address
+ACCOUNT = WALLET.address
 OWNER = "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"
 OFFER_SEQUENCE = 7
 

--- a/tests/integration/transactions/test_escrow_create.py
+++ b/tests/integration/transactions/test_escrow_create.py
@@ -7,7 +7,7 @@ from tests.integration.reusable_values import WALLET
 from xrpl.models.response import ResponseStatus
 from xrpl.models.transactions import EscrowCreate
 
-ACCOUNT = WALLET.classic_address
+ACCOUNT = WALLET.address
 
 AMOUNT = "10000"
 DESTINATION = "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW"

--- a/tests/integration/transactions/test_escrow_finish.py
+++ b/tests/integration/transactions/test_escrow_finish.py
@@ -11,7 +11,7 @@ from xrpl.models.transactions import EscrowFinish
 # See note here: https://xrpl.org/escrowfinish.html
 FEE = "600000000"
 
-ACCOUNT = WALLET.classic_address
+ACCOUNT = WALLET.address
 OWNER = "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"
 OFFER_SEQUENCE = 7
 CONDITION = (

--- a/tests/integration/transactions/test_offer_cancel.py
+++ b/tests/integration/transactions/test_offer_cancel.py
@@ -12,7 +12,7 @@ class TestOfferCancel(IntegrationTestCase):
     async def test_all_fields(self, client):
         response = await sign_and_reliable_submission_async(
             OfferCancel(
-                account=WALLET.classic_address,
+                account=WALLET.address,
                 offer_sequence=OFFER.result["tx_json"]["Sequence"],
             ),
             WALLET,

--- a/tests/integration/transactions/test_offer_create.py
+++ b/tests/integration/transactions/test_offer_create.py
@@ -13,11 +13,11 @@ class TestOfferCreate(IntegrationTestCase):
     async def test_basic_functionality(self, client):
         offer = await sign_and_reliable_submission_async(
             OfferCreate(
-                account=WALLET.classic_address,
+                account=WALLET.address,
                 taker_gets="13100000",
                 taker_pays=IssuedCurrencyAmount(
                     currency="USD",
-                    issuer=WALLET.classic_address,
+                    issuer=WALLET.address,
                     value="10",
                 ),
             ),

--- a/tests/integration/transactions/test_payment.py
+++ b/tests/integration/transactions/test_payment.py
@@ -12,9 +12,9 @@ class TestPayment(IntegrationTestCase):
     async def test_basic_functionality(self, client):
         response = await sign_and_reliable_submission_async(
             Payment(
-                account=WALLET.classic_address,
+                account=WALLET.address,
                 amount="1",
-                destination=DESTINATION.classic_address,
+                destination=DESTINATION.address,
             ),
             WALLET,
             client,

--- a/tests/integration/transactions/test_payment_channel_claim.py
+++ b/tests/integration/transactions/test_payment_channel_claim.py
@@ -12,7 +12,7 @@ class TestPaymentChannelClaim(IntegrationTestCase):
     async def test_receiver_claim(self, client):
         response = await sign_and_reliable_submission_async(
             PaymentChannelClaim(
-                account=WALLET.classic_address,
+                account=WALLET.address,
                 channel=PAYMENT_CHANNEL.result["tx_json"]["hash"],
             ),
             WALLET,

--- a/tests/integration/transactions/test_payment_channel_create.py
+++ b/tests/integration/transactions/test_payment_channel_create.py
@@ -12,9 +12,9 @@ class TestPaymentChannelCreate(IntegrationTestCase):
     async def test_basic_functionality(self, client):
         payment_channel = await sign_and_reliable_submission_async(
             PaymentChannelCreate(
-                account=WALLET.classic_address,
+                account=WALLET.address,
                 amount="1",
-                destination=DESTINATION.classic_address,
+                destination=DESTINATION.address,
                 settle_delay=86400,
                 public_key=WALLET.public_key,
             ),

--- a/tests/integration/transactions/test_payment_channel_fund.py
+++ b/tests/integration/transactions/test_payment_channel_fund.py
@@ -12,7 +12,7 @@ class TestPaymentChannelFund(IntegrationTestCase):
     async def test_basic_functionality(self, client):
         response = await sign_and_reliable_submission_async(
             PaymentChannelFund(
-                account=WALLET.classic_address,
+                account=WALLET.address,
                 channel=PAYMENT_CHANNEL.result["tx_json"]["hash"],
                 amount="1",
             ),

--- a/tests/integration/transactions/test_set_regular_key.py
+++ b/tests/integration/transactions/test_set_regular_key.py
@@ -11,10 +11,10 @@ from xrpl.wallet import Wallet
 class TestSetRegularKey(IntegrationTestCase):
     @test_async_and_sync(globals())
     async def test_all_fields(self, client):
-        regular_key = Wallet.create().classic_address
+        regular_key = Wallet.create().address
         response = await sign_and_reliable_submission_async(
             SetRegularKey(
-                account=WALLET.classic_address,
+                account=WALLET.address,
                 regular_key=regular_key,
             ),
             WALLET,

--- a/tests/integration/transactions/test_signer_list_set.py
+++ b/tests/integration/transactions/test_signer_list_set.py
@@ -15,11 +15,11 @@ class TestSignerListSet(IntegrationTestCase):
         other_signer = Wallet.create()
         response = await sign_and_reliable_submission_async(
             SignerListSet(
-                account=WALLET.classic_address,
+                account=WALLET.address,
                 signer_quorum=1,
                 signer_entries=[
                     SignerEntry(
-                        account=other_signer.classic_address,
+                        account=other_signer.address,
                         signer_weight=1,
                     ),
                 ],

--- a/tests/integration/transactions/test_ticket_create.py
+++ b/tests/integration/transactions/test_ticket_create.py
@@ -12,7 +12,7 @@ class TestTicketCreate(IntegrationTestCase):
     async def test_basic_functionality(self, client):
         response = await sign_and_reliable_submission_async(
             TicketCreate(
-                account=WALLET.classic_address,
+                account=WALLET.address,
                 ticket_count=2,
             ),
             WALLET,

--- a/tests/integration/transactions/test_trust_set.py
+++ b/tests/integration/transactions/test_trust_set.py
@@ -15,10 +15,10 @@ class TestTrustSet(IntegrationTestCase):
         issuer_wallet = Wallet.create()
         response = await sign_and_reliable_submission_async(
             TrustSet(
-                account=WALLET.classic_address,
+                account=WALLET.address,
                 flags=TrustSetFlag.TF_SET_NO_RIPPLE,
                 limit_amount=IssuedCurrencyAmount(
-                    issuer=issuer_wallet.classic_address,
+                    issuer=issuer_wallet.address,
                     currency="USD",
                     value="100",
                 ),

--- a/tests/unit/asyn/wallet/test_main.py
+++ b/tests/unit/asyn/wallet/test_main.py
@@ -21,12 +21,12 @@ constants = {
         "ed25519": {
             "public_key": "ED16FD02F7A7E52B6ACB35F8A4D7013DC94755951629DB6611483590AC0E9FC6D5",  # noqa:E501
             "private_key": "ED713A8C3171A3D8F69FE9526D9243834B3A30BF893B1EBC1824B1D96F18B44DCF",  # noqa:E501
-            "classic_address": "rPxLJ2GumwfLk3z9njmmpo8nAX7sfZYptV",
+            "address": "rPxLJ2GumwfLk3z9njmmpo8nAX7sfZYptV",
         },
         "secp256k1": {
             "public_key": "030E58CDD076E798C84755590AAF6237CA8FAE821070A59F648B517A30DC6F589D",  # noqa:E501
             "private_key": "00141BA006D3363D2FB2785E8DF4E44D3A49908780CB4FB51F6D217C08C021429F",  # noqa:E501
-            "classic_address": "rhvh5SrgBL5V8oeV9EpDuVszeJSSCEkbPc",
+            "address": "rhvh5SrgBL5V8oeV9EpDuVszeJSSCEkbPc",
         },
     },
     "entropy": {
@@ -35,13 +35,13 @@ constants = {
             "seed": "sEdSJHS4oiAdz7w2X2ni1gFiqtbJHqE",
             "public_key": "ED1A7C082846CFF58FF9A892BA4BA2593151CCF1DBA59F37714CC9ED39824AF85F",  # noqa:E501
             "private_key": "ED0B6CBAC838DFE7F47EA1BD0DF00EC282FDF45510C92161072CCFB84035390C4D",  # noqa:E501
-            "classic_address": "r9zRhGr7b6xPekLvT6wP4qNdWMryaumZS7",
+            "address": "r9zRhGr7b6xPekLvT6wP4qNdWMryaumZS7",
         },
         "secp256k1": {
             "seed": "sp6JS7f14BuwFY8Mw6bTtLKWauoUs",
             "public_key": "0390A196799EE412284A5D80BF78C3E84CBB80E1437A0AECD9ADF94D7FEAAFA284",  # noqa:E501
             "private_key": "002512BBDFDBB77510883B7DCCBEF270B86DEAC8B64AC762873D75A1BEE6298665",  # noqa:E501
-            "classic_address": "rGCkuB7PBr5tNy68tPEABEtcdno4hE6Y7f",
+            "address": "rGCkuB7PBr5tNy68tPEABEtcdno4hE6Y7f",
         },
     },
     "secret_numbers": {
@@ -60,17 +60,17 @@ constants = {
             "seed": "sEd77GiNwRkBYwqzZiTrmh21oovzSAC",
             "public_key": "ED8079E575450E256C496578480020A33E19B579D58A2DB8FF13FC6B05B9229DE3",  # noqa:E501
             "private_key": "EDD2AF6288A903DED9860FC62E778600A985BDF804E40BD8266505553E3222C3DA",  # noqa:E501
-            "classic_address": "rHnnXF4oYodLonx7P7MV4WaqPUvBWzskEw",
+            "address": "rHnnXF4oYodLonx7P7MV4WaqPUvBWzskEw",
         },
         "secp256k1": {
             "seed": "sh1HiK7SwjS1VxFdXi7qeMHRedrYX",
             "public_key": "03BFC2F7AE242C3493187FA0B72BE97B2DF71194FB772E507FF9DEA0AD13CA1625",  # noqa:E501
             "private_key": "00B6FE8507D977E46E988A8A94DB3B8B35E404B60F8B11AC5213FA8B5ABC8A8D19",  # noqa:E501
-            "classic_address": "rQKQsPeE3iTRyfUypLhuq74gZdcRdwWqDp",
+            "address": "rQKQsPeE3iTRyfUypLhuq74gZdcRdwWqDp",
         },
     },
     "prefix": {
-        "classic_address": "r",
+        "address": "r",
         "ed25519_key": "ED",
         "secp256k1_private_key": "00",
     },
@@ -102,20 +102,20 @@ def _test_wallet_values(
 
     if method == "regular_key_pair" or is_entropy_with_regular_key_pair:
         self.assertEqual(
-            wallet.classic_address, constants["regular_key_pair"]["master_address"]
+            wallet.address, constants["regular_key_pair"]["master_address"]
         )
     else:
-        self.assertEqual(wallet.classic_address, algorithm_constants["classic_address"])
+        self.assertEqual(wallet.address, algorithm_constants["address"])
 
 
 def _test_wallet_types(self, wallet, algorithm):
     self.assertIsInstance(wallet.public_key, str)
     self.assertIsInstance(wallet.private_key, str)
-    self.assertIsInstance(wallet.classic_address, str)
+    self.assertIsInstance(wallet.address, str)
     self.assertIsInstance(wallet.address, str)
     self.assertIsInstance(wallet.seed, str)
     self.assertTrue(
-        wallet.classic_address.startswith(constants["prefix"]["classic_address"])
+        wallet.address.startswith(constants["prefix"]["address"])
     )
 
     if algorithm == "ed25519":
@@ -395,7 +395,7 @@ class TestWalletMain(TestCase):
 
     def test_address_alias(self):
         wallet = Wallet.create()
-        self.assertEqual(wallet.address, wallet.classic_address)
+        self.assertEqual(wallet.address, wallet.address)
 
     def test_get_only_address(self):
         wallet = Wallet.create()
@@ -404,4 +404,4 @@ class TestWalletMain(TestCase):
             wallet.address = "rhvh5SrgBL5V8oeV9EpDuVszeJSSCEkbPc"
 
         with self.assertRaises(AttributeError):
-            wallet.classic_address = "rhvh5SrgBL5V8oeV9EpDuVszeJSSCEkbPc"
+            wallet.address = "rhvh5SrgBL5V8oeV9EpDuVszeJSSCEkbPc"

--- a/tests/unit/asyn/wallet/test_main.py
+++ b/tests/unit/asyn/wallet/test_main.py
@@ -114,9 +114,7 @@ def _test_wallet_types(self, wallet, algorithm):
     self.assertIsInstance(wallet.address, str)
     self.assertIsInstance(wallet.address, str)
     self.assertIsInstance(wallet.seed, str)
-    self.assertTrue(
-        wallet.address.startswith(constants["prefix"]["address"])
-    )
+    self.assertTrue(wallet.address.startswith(constants["prefix"]["address"]))
 
     if algorithm == "ed25519":
         self.assertTrue(

--- a/tests/unit/models/transactions/test_transaction.py
+++ b/tests/unit/models/transactions/test_transaction.py
@@ -132,16 +132,16 @@ class TestTransaction(TestCase):
             )
 
     def test_is_signed_for_signed_transaction(self):
-        tx = AccountSet(account=_WALLET.classic_address, domain=EXAMPLE_DOMAIN)
+        tx = AccountSet(account=_WALLET.address, domain=EXAMPLE_DOMAIN)
         signed_tx = sign(tx, _WALLET)
         self.assertTrue(signed_tx.is_signed())
 
     def test_is_signed_for_unsigned_transaction(self):
-        tx = AccountSet(account=_WALLET.classic_address, domain=EXAMPLE_DOMAIN)
+        tx = AccountSet(account=_WALLET.address, domain=EXAMPLE_DOMAIN)
         self.assertFalse(tx.is_signed())
 
     def test_is_signed_for_multisigned_transaction(self):
-        tx = AccountSet(account=_WALLET.classic_address, domain=EXAMPLE_DOMAIN)
+        tx = AccountSet(account=_WALLET.address, domain=EXAMPLE_DOMAIN)
         tx_1 = sign(tx, _FIRST_SIGNER, multisign=True)
         tx_2 = sign(tx, _SECOND_SIGNER, multisign=True)
 

--- a/tests/unit/wallet/test_wallet.py
+++ b/tests/unit/wallet/test_wallet.py
@@ -27,25 +27,25 @@ class TestWallet(TestCase):
     def test_init_auto_with_default_algorithm(self):
         wallet = Wallet.from_seed(SED_SEED)
         self.assertEqual(wallet.seed, SED_SEED)
-        self.assertEqual(wallet.classic_address, SED_ADDRESS)
+        self.assertEqual(wallet.address, SED_ADDRESS)
         self.assertEqual(wallet.algorithm, CryptoAlgorithm.ED25519)
 
     def test_init_auto_with_sEd_seed(self):
         wallet = Wallet.from_seed(SED_SEED)
         self.assertEqual(wallet.seed, SED_SEED)
-        self.assertEqual(wallet.classic_address, SED_ADDRESS)
+        self.assertEqual(wallet.address, SED_ADDRESS)
         self.assertEqual(wallet.algorithm, CryptoAlgorithm.ED25519)
 
     def test_init_secp256k1_with_s_seed(self):
         wallet = Wallet.from_seed(SEED, algorithm=CryptoAlgorithm.SECP256K1)
         self.assertEqual(wallet.seed, SEED)
-        self.assertEqual(wallet.classic_address, SECP_ADDRESS)
+        self.assertEqual(wallet.address, SECP_ADDRESS)
         self.assertEqual(wallet.algorithm, CryptoAlgorithm.SECP256K1)
 
     def test_init_ed25519_with_s_seed(self):
         wallet = Wallet.from_seed(SEED, algorithm=CryptoAlgorithm.ED25519)
         self.assertEqual(wallet.seed, SEED)
-        self.assertEqual(wallet.classic_address, ED_ADDRESS)
+        self.assertEqual(wallet.address, ED_ADDRESS)
         self.assertEqual(wallet.algorithm, CryptoAlgorithm.ED25519)
 
     def test_init_secp256k1_with_sEd_seed_fail(self):

--- a/xrpl/asyncio/transaction/main.py
+++ b/xrpl/asyncio/transaction/main.py
@@ -84,7 +84,7 @@ def sign(
             bytes.fromhex(
                 encode_for_multisigning(
                     transaction.to_xrpl(),
-                    wallet.classic_address,
+                    wallet.address,
                 )
             ),
             wallet.private_key,
@@ -92,7 +92,7 @@ def sign(
         tx_dict = transaction.to_dict()
         tx_dict["signers"] = [
             Signer(
-                account=wallet.classic_address,
+                account=wallet.address,
                 txn_signature=signature,
                 signing_pub_key=wallet.public_key,
             )

--- a/xrpl/asyncio/wallet/wallet_generation.py
+++ b/xrpl/asyncio/wallet/wallet_generation.py
@@ -57,7 +57,7 @@ async def generate_faucet_wallet(
     if wallet is None:
         wallet = Wallet.create()
 
-    address = wallet.classic_address
+    address = wallet.address
     # The faucet *can* be flakey... by printing info about this it's easier to
     # understand if tests are actually failing, or if it was just a faucet failure.
     if debug:

--- a/xrpl/wallet/main.py
+++ b/xrpl/wallet/main.py
@@ -19,10 +19,17 @@ class Wallet:
     @property
     def address(self: Wallet) -> str:
         """
-        The address that publicly identifies this wallet,
-        as a base58 string.
+        The XRPL address that publicly identifies this wallet,
+        as a base58 string. This is the same value as the `classic_address`.
         """  # noqa: DAR201
         return self._address
+
+    classic_address = address
+    """
+    `classic_address` is the same as `address`. It is called `classic_address` to
+    differentiate it from the x-address standard, which encodes the network,
+    destination tag, and XRPL address into a single value. It's also a base58 string.
+    """
 
     def __init__(
         self: Wallet,

--- a/xrpl/wallet/main.py
+++ b/xrpl/wallet/main.py
@@ -17,17 +17,12 @@ class Wallet:
     """
 
     @property
-    def classic_address(self: Wallet) -> str:
+    def address(self: Wallet) -> str:
         """
         The address that publicly identifies this wallet,
         as a base58 string.
         """  # noqa: DAR201
-        return self._classic_address
-
-    address = classic_address
-    """
-    The address that publicly identifies this wallet, as a base58 string.
-    """
+        return self._address
 
     def __init__(
         self: Wallet,
@@ -81,7 +76,7 @@ class Wallet:
         string. MUST be kept secret!
         """
 
-        self._classic_address = (
+        self._address = (
             ensure_classic_address(master_address)
             if master_address is not None
             else derive_classic_address(self.public_key)
@@ -244,7 +239,7 @@ class Wallet:
         Returns:
             The X-Address of the Wallet's account.
         """
-        return classic_address_to_xaddress(self.classic_address, tag, is_test)
+        return classic_address_to_xaddress(self.address, tag, is_test)
 
     def __str__(self: Wallet) -> str:
         """
@@ -257,6 +252,6 @@ class Wallet:
             [
                 f"public_key: {self.public_key}",
                 "private_key: -HIDDEN-",
-                f"classic_address: {self.classic_address}",
+                f"classic_address: {self.address}",
             ]
         )


### PR DESCRIPTION
## High Level Overview of Change

`classic_address` is jargon for most people - we should instead name it `address`

### Context of Change

We already were planning on adding a new alias, but in the spirit of having a clear API, this PR is instead planning to just set `address` to the new name. 

`classic_address` is only named that to differentiate itself from `x-address` which is a newer standard which is not supported at the ledger level. (You have to decode `x-addresses` back to `classic_addresses` before submitting a transaction to the ledger) - For a concept as basic as what an account on the XRPL is, we don't want to require understanding that nuance.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Refactor (non-breaking change that restructures how the code works)

## Test Plan

CI Passes

<!--
## Future Tasks
For future tasks related to PR.
-->
Note: Originally this was a breaking change, but after discussion we've changed it to just affect the defaults we use - while keeping `classic_address` as an alias.
