### PR TITLE
fix(test): move integration test out from unit tests

### DIFF
--- a/tests/integration/sugar/test_network_id.py
+++ b/tests/integration/sugar/test_network_id.py
@@ -9,6 +9,7 @@ from xrpl.wallet.wallet_generation import generate_faucet_wallet
 _FEE = "0.00001"
 
 
+# TODO: move to test_transaction and use the standard integration test setup
 class TestAutofill(TestCase):
     # Autofill should override tx networkID for network with ID > 1024
     # and build_version from 1.11.0 or later.

--- a/tests/integration/sugar/test_network_id.py
+++ b/tests/integration/sugar/test_network_id.py
@@ -10,7 +10,7 @@ _FEE = "0.00001"
 
 
 # TODO: move to test_transaction and use the standard integration test setup
-class TestAutofill(TestCase):
+class TestNetworkID(TestCase):
     # Autofill should override tx networkID for network with ID > 1024
     # and build_version from 1.11.0 or later.
     def test_networkid_override(self):


### PR DESCRIPTION
## High Level Overview of Change

There was an integration test that was in the unit test section. This PR moves that over.

### Context of Change

The test was added in #520. I noticed that unit tests were suddenly taking much longer to run.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Test Plan

CI passes.