### PR TITLE
feat: Add missing `nft_page`, `ledger_index` and `ledger_hash` fields to requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed:
 - Added a sort of the account IDs in `multisign`, so that the `multisign` always works.
 - Add `ledger_hash` and `ledger_index` to `account_nfts`, `nft_buy_offers`, and `nft_sell_offers` requests.
+- Add `nft_page` to `ledger_entry` request.
 
 ## [1.9.0] - 2023-06-13
 ### Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [[Unreleased]]
 ### Fixed:
 - Added a sort of the account IDs in `multisign`, so that the `multisign` always works.
+- Add `ledger_hash` and `ledger_index` to `account_nfts`, `nft_buy_offers`, and `nft_sell_offers` requests.
 
 ## [1.9.0] - 2023-06-13
 ### Added:

--- a/xrpl/models/requests/account_channels.py
+++ b/xrpl/models/requests/account_channels.py
@@ -8,16 +8,16 @@ All information retrieved is relative to a particular version of the ledger.
 `See account_channels <https://xrpl.org/account_channels.html>`_
 """
 from dataclasses import dataclass, field
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
-from xrpl.models.requests.request import Request, RequestMethod
+from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
 from xrpl.models.required import REQUIRED
 from xrpl.models.utils import require_kwargs_on_init
 
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class AccountChannels(Request):
+class AccountChannels(Request, LookupByLedgerRequest):
     """
     This request returns information about an account's Payment Channels. This includes
     only channels where the specified account is the channel's source, not the
@@ -41,5 +41,3 @@ class AccountChannels(Request):
     # marker data shape is actually undefined in the spec, up to the
     # implementation of an individual server
     marker: Optional[Any] = None
-    ledger_hash: Optional[str] = None
-    ledger_index: Optional[Union[str, int]] = None

--- a/xrpl/models/requests/account_currencies.py
+++ b/xrpl/models/requests/account_currencies.py
@@ -8,16 +8,15 @@ interfaces.
 `See account_currencies <https://xrpl.org/account_currencies.html>`_
 """
 from dataclasses import dataclass, field
-from typing import Optional, Union
 
-from xrpl.models.requests.request import Request, RequestMethod
+from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
 from xrpl.models.required import REQUIRED
 from xrpl.models.utils import require_kwargs_on_init
 
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class AccountCurrencies(Request):
+class AccountCurrencies(Request, LookupByLedgerRequest):
     """
     This request retrieves a list of currencies that an account can send or receive,
     based on its trust lines.
@@ -34,8 +33,5 @@ class AccountCurrencies(Request):
 
     :meta hide-value:
     """
-
-    ledger_hash: Optional[str] = None
-    ledger_index: Optional[Union[str, int]] = None
     method: RequestMethod = field(default=RequestMethod.ACCOUNT_CURRENCIES, init=False)
     strict: bool = False

--- a/xrpl/models/requests/account_info.py
+++ b/xrpl/models/requests/account_info.py
@@ -7,16 +7,15 @@ All information retrieved is relative to a particular version of the ledger.
 `See account_info <https://xrpl.org/account_info.html>`_
 """
 from dataclasses import dataclass, field
-from typing import Optional, Union
 
-from xrpl.models.requests.request import Request, RequestMethod
+from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
 from xrpl.models.required import REQUIRED
 from xrpl.models.utils import require_kwargs_on_init
 
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class AccountInfo(Request):
+class AccountInfo(Request, LookupByLedgerRequest):
     """
     This request retrieves information about an account, its activity, and its XRP
     balance.
@@ -33,8 +32,6 @@ class AccountInfo(Request):
     :meta hide-value:
     """
 
-    ledger_hash: Optional[str] = None
-    ledger_index: Optional[Union[str, int]] = None
     method: RequestMethod = field(default=RequestMethod.ACCOUNT_INFO, init=False)
     queue: bool = False
     signer_lists: bool = False

--- a/xrpl/models/requests/account_lines.py
+++ b/xrpl/models/requests/account_lines.py
@@ -6,16 +6,16 @@ particular version of the ledger.
 `See account_lines <https://xrpl.org/account_lines.html>`_
 """
 from dataclasses import dataclass, field
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
-from xrpl.models.requests.request import Request, RequestMethod
+from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
 from xrpl.models.required import REQUIRED
 from xrpl.models.utils import require_kwargs_on_init
 
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class AccountLines(Request):
+class AccountLines(Request, LookupByLedgerRequest):
     """
     This request returns information about an account's trust lines, including balances
     in all non-XRP currencies and assets. All information retrieved is relative to a
@@ -31,8 +31,6 @@ class AccountLines(Request):
     :meta hide-value:
     """
 
-    ledger_hash: Optional[str] = None
-    ledger_index: Optional[Union[str, int]] = None
     method: RequestMethod = field(default=RequestMethod.ACCOUNT_LINES, init=False)
     peer: Optional[str] = None
     limit: Optional[int] = None

--- a/xrpl/models/requests/account_nfts.py
+++ b/xrpl/models/requests/account_nfts.py
@@ -2,14 +2,14 @@
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
-from xrpl.models.requests.request import Request, RequestMethod
+from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
 from xrpl.models.required import REQUIRED
 from xrpl.models.utils import require_kwargs_on_init
 
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class AccountNFTs(Request):
+class AccountNFTs(Request, LookupByLedgerRequest):
     """
     This method retrieves all of the NFTs currently owned
     by the specified account.

--- a/xrpl/models/requests/account_objects.py
+++ b/xrpl/models/requests/account_objects.py
@@ -8,9 +8,9 @@ AccountLinesRequest instead.
 """
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
-from xrpl.models.requests.request import Request, RequestMethod
+from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
 from xrpl.models.required import REQUIRED
 from xrpl.models.utils import require_kwargs_on_init
 
@@ -31,7 +31,7 @@ class AccountObjectType(str, Enum):
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class AccountObjects(Request):
+class AccountObjects(Request, LookupByLedgerRequest):
     """
     This request returns the raw ledger format for all objects owned by an account.
 
@@ -48,8 +48,6 @@ class AccountObjects(Request):
     :meta hide-value:
     """
 
-    ledger_hash: Optional[str] = None
-    ledger_index: Optional[Union[str, int]] = None
     method: RequestMethod = field(default=RequestMethod.ACCOUNT_OBJECTS, init=False)
     type: Optional[AccountObjectType] = None
     deletion_blockers_only: bool = False

--- a/xrpl/models/requests/account_offers.py
+++ b/xrpl/models/requests/account_offers.py
@@ -5,16 +5,16 @@ outstanding as of a particular ledger version.
 `See account_offers <https://xrpl.org/account_offers.html>`_
 """
 from dataclasses import dataclass, field
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
-from xrpl.models.requests.request import Request, RequestMethod
+from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
 from xrpl.models.required import REQUIRED
 from xrpl.models.utils import require_kwargs_on_init
 
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class AccountOffers(Request):
+class AccountOffers(Request, LookupByLedgerRequest):
     """
     This request retrieves a list of offers made by a given account that are
     outstanding as of a particular ledger version.
@@ -29,8 +29,6 @@ class AccountOffers(Request):
     :meta hide-value:
     """
 
-    ledger_hash: Optional[str] = None
-    ledger_index: Optional[Union[str, int]] = None
     method: RequestMethod = field(default=RequestMethod.ACCOUNT_OFFERS, init=False)
     limit: Optional[int] = None
     # marker data shape is actually undefined in the spec, up to the

--- a/xrpl/models/requests/account_tx.py
+++ b/xrpl/models/requests/account_tx.py
@@ -5,16 +5,16 @@ specified account.
 `See account_tx <https://xrpl.org/account_tx.html>`_
 """
 from dataclasses import dataclass, field
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
-from xrpl.models.requests.request import Request, RequestMethod
+from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
 from xrpl.models.required import REQUIRED
 from xrpl.models.utils import require_kwargs_on_init
 
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class AccountTx(Request):
+class AccountTx(Request, LookupByLedgerRequest):
     """
     This request retrieves from the ledger a list of transactions that involved the
     specified account.
@@ -29,8 +29,6 @@ class AccountTx(Request):
     :meta hide-value:
     """
 
-    ledger_hash: Optional[str] = None
-    ledger_index: Optional[Union[str, int]] = None
     method: RequestMethod = field(default=RequestMethod.ACCOUNT_TX, init=False)
     ledger_index_min: Optional[int] = None
     ledger_index_max: Optional[int] = None

--- a/xrpl/models/requests/book_offers.py
+++ b/xrpl/models/requests/book_offers.py
@@ -3,17 +3,17 @@ The book_offers method retrieves a list of offers, also known
 as the order book, between two currencies.
 """
 from dataclasses import dataclass, field
-from typing import Optional, Union
+from typing import Optional
 
 from xrpl.models.currencies import Currency
-from xrpl.models.requests.request import Request, RequestMethod
+from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
 from xrpl.models.required import REQUIRED
 from xrpl.models.utils import require_kwargs_on_init
 
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class BookOffers(Request):
+class BookOffers(Request, LookupByLedgerRequest):
     """
     The book_offers method retrieves a list of offers, also known
     as the order book, between two currencies.
@@ -34,7 +34,5 @@ class BookOffers(Request):
     """
 
     method: RequestMethod = field(default=RequestMethod.BOOK_OFFERS, init=False)
-    ledger_hash: Optional[str] = None
-    ledger_index: Optional[Union[str, int]] = None
     limit: Optional[int] = None
     taker: Optional[str] = None

--- a/xrpl/models/requests/deposit_authorized.py
+++ b/xrpl/models/requests/deposit_authorized.py
@@ -5,16 +5,15 @@ Deposit Authorization for information on how to require
 authorization to deliver money to your account.
 """
 from dataclasses import dataclass, field
-from typing import Optional
 
-from xrpl.models.requests.request import Request, RequestMethod
+from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
 from xrpl.models.required import REQUIRED
 from xrpl.models.utils import require_kwargs_on_init
 
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class DepositAuthorized(Request):
+class DepositAuthorized(Request, LookupByLedgerRequest):
     """
     The deposit_authorized command indicates whether one account
     is authorized to send payments directly to another. See
@@ -37,5 +36,3 @@ class DepositAuthorized(Request):
     """
 
     method: RequestMethod = field(default=RequestMethod.DEPOSIT_AUTHORIZED, init=False)
-    ledger_hash: Optional[str] = None
-    ledger_index: Optional[str] = None

--- a/xrpl/models/requests/gateway_balances.py
+++ b/xrpl/models/requests/gateway_balances.py
@@ -7,14 +7,14 @@ excluding amounts held by operational addresses.
 from dataclasses import dataclass, field
 from typing import List, Optional, Union
 
-from xrpl.models.requests.request import Request, RequestMethod
+from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
 from xrpl.models.required import REQUIRED
 from xrpl.models.utils import require_kwargs_on_init
 
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class GatewayBalances(Request):
+class GatewayBalances(Request, LookupByLedgerRequest):
     """
     This request calculates the total balances issued by a given account, optionally
     excluding amounts held by operational addresses.
@@ -29,8 +29,6 @@ class GatewayBalances(Request):
     :meta hide-value:
     """
 
-    ledger_hash: Optional[str] = None
-    ledger_index: Optional[Union[str, int]] = None
     method: RequestMethod = field(default=RequestMethod.GATEWAY_BALANCES, init=False)
     strict: bool = False
     hotwallet: Optional[Union[str, List[str]]] = None

--- a/xrpl/models/requests/ledger.py
+++ b/xrpl/models/requests/ledger.py
@@ -3,24 +3,22 @@ Retrieve information about the public ledger.
 `See ledger <https://xrpl.org/ledger.html>`_
 """
 from dataclasses import dataclass, field
-from typing import Optional, Union
+from typing import Optional
 
 from xrpl.models.requests.ledger_entry import LedgerEntryType
-from xrpl.models.requests.request import Request, RequestMethod
+from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
 from xrpl.models.utils import require_kwargs_on_init
 
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class Ledger(Request):
+class Ledger(Request, LookupByLedgerRequest):
     """
     Retrieve information about the public ledger.
     `See ledger <https://xrpl.org/ledger.html>`_
     """
 
     method: RequestMethod = field(default=RequestMethod.LEDGER, init=False)
-    ledger_hash: Optional[str] = None
-    ledger_index: Optional[Union[str, int]] = None
     full: bool = False
     accounts: bool = False
     transactions: bool = False

--- a/xrpl/models/requests/ledger_data.py
+++ b/xrpl/models/requests/ledger_data.py
@@ -6,16 +6,16 @@ of a single ledger version.
 `See ledger data <https://xrpl.org/ledger_data.html>`_
 """
 from dataclasses import dataclass, field
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 from xrpl.models.requests.ledger_entry import LedgerEntryType
-from xrpl.models.requests.request import Request, RequestMethod
+from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
 from xrpl.models.utils import require_kwargs_on_init
 
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class LedgerData(Request):
+class LedgerData(Request, LookupByLedgerRequest):
     """
     The ledger_data method retrieves contents of
     the specified ledger. You can iterate through
@@ -25,8 +25,6 @@ class LedgerData(Request):
     """
 
     method: RequestMethod = field(default=RequestMethod.LEDGER_DATA, init=False)
-    ledger_hash: Optional[str] = None
-    ledger_index: Optional[Union[str, int]] = None
     binary: bool = False
     limit: Optional[int] = None
     # marker data shape is actually undefined in the spec, up to the

--- a/xrpl/models/requests/ledger_entry.py
+++ b/xrpl/models/requests/ledger_entry.py
@@ -12,7 +12,7 @@ from enum import Enum
 from typing import Dict, List, Optional, Union
 
 from xrpl.models.base_model import BaseModel
-from xrpl.models.requests.request import Request, RequestMethod
+from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
 from xrpl.models.required import REQUIRED
 from xrpl.models.utils import require_kwargs_on_init
 
@@ -174,7 +174,7 @@ class Ticket(BaseModel):
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class LedgerEntry(Request):
+class LedgerEntry(Request, LookupByLedgerRequest):
     """
     The ledger_entry method returns a single ledger
     object from the XRP Ledger in its raw format.
@@ -195,8 +195,8 @@ class LedgerEntry(Request):
     ripple_state: Optional[RippleState] = None
     ticket: Optional[Union[str, Ticket]] = None
     binary: bool = False
-    ledger_hash: Optional[str] = None
-    ledger_index: Optional[Union[str, int]] = None
+    nft_page: Optional[str] = None
+    """Must be the object ID of the NFToken page, as hexadecimal"""
 
     def _get_errors(self: LedgerEntry) -> Dict[str, str]:
         errors = super()._get_errors()

--- a/xrpl/models/requests/nft_buy_offers.py
+++ b/xrpl/models/requests/nft_buy_offers.py
@@ -4,14 +4,14 @@ for the specified NFToken.
 """
 from dataclasses import dataclass, field
 
-from xrpl.models.requests.request import Request, RequestMethod
+from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
 from xrpl.models.required import REQUIRED
 from xrpl.models.utils import require_kwargs_on_init
 
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class NFTBuyOffers(Request):
+class NFTBuyOffers(Request, LookupByLedgerRequest):
     """
     The `nft_buy_offers` method retrieves all of buy offers
     for the specified NFToken.

--- a/xrpl/models/requests/nft_history.py
+++ b/xrpl/models/requests/nft_history.py
@@ -3,16 +3,16 @@ The `nft_history` method retreives a list of transactions that involved the
 specified NFToken.
 """
 from dataclasses import dataclass, field
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
-from xrpl.models.requests.request import Request, RequestMethod
+from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
 from xrpl.models.required import REQUIRED
 from xrpl.models.utils import require_kwargs_on_init
 
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class NFTHistory(Request):
+class NFTHistory(Request, LookupByLedgerRequest):
     """
     The `nft_history` method retreives a list of transactions that involved the
     specified NFToken.
@@ -27,8 +27,6 @@ class NFTHistory(Request):
     :meta hide-value:
     """
 
-    ledger_hash: Optional[str] = None
-    ledger_index: Optional[Union[str, int]] = None
     ledger_index_min: Optional[int] = None
     ledger_index_max: Optional[int] = None
     binary: bool = False

--- a/xrpl/models/requests/nft_info.py
+++ b/xrpl/models/requests/nft_info.py
@@ -3,16 +3,15 @@ The `nft_info` method retrieves all the information about the
 NFToken
 """
 from dataclasses import dataclass, field
-from typing import Optional, Union
 
-from xrpl.models.requests.request import Request, RequestMethod
+from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
 from xrpl.models.required import REQUIRED
 from xrpl.models.utils import require_kwargs_on_init
 
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class NFTInfo(Request):
+class NFTInfo(Request, LookupByLedgerRequest):
     """
     The `nft_info` method retrieves all the information about the
     NFToken
@@ -26,6 +25,3 @@ class NFTInfo(Request):
 
     :meta hide-value:
     """
-
-    ledger_hash: Optional[str] = None
-    ledger_index: Optional[Union[str, int]] = None

--- a/xrpl/models/requests/nft_sell_offers.py
+++ b/xrpl/models/requests/nft_sell_offers.py
@@ -4,14 +4,14 @@ for the specified NFToken.
 """
 from dataclasses import dataclass, field
 
-from xrpl.models.requests.request import Request, RequestMethod
+from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
 from xrpl.models.required import REQUIRED
 from xrpl.models.utils import require_kwargs_on_init
 
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class NFTSellOffers(Request):
+class NFTSellOffers(Request, LookupByLedgerRequest):
     """
     The `nft_sell_offers` method retrieves all of sell offers
     for the specified NFToken.

--- a/xrpl/models/requests/no_ripple_check.py
+++ b/xrpl/models/requests/no_ripple_check.py
@@ -7,9 +7,9 @@ recommended settings.
 """
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Optional, Union
+from typing import Optional
 
-from xrpl.models.requests.request import Request, RequestMethod
+from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
 from xrpl.models.required import REQUIRED
 from xrpl.models.utils import require_kwargs_on_init
 
@@ -23,7 +23,7 @@ class NoRippleCheckRole(str, Enum):
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class NoRippleCheck(Request):
+class NoRippleCheck(Request, LookupByLedgerRequest):
     """
     This request provides a quick way to check the status of the Default Ripple field
     for an account and the No Ripple flag of its trust lines, compared with the
@@ -39,8 +39,6 @@ class NoRippleCheck(Request):
     :meta hide-value:
     """
 
-    ledger_hash: Optional[str] = None
-    ledger_index: Optional[Union[str, int]] = None
     method: RequestMethod = field(default=RequestMethod.NO_RIPPLE_CHECK, init=False)
     role: NoRippleCheckRole = REQUIRED  # type: ignore
     """

--- a/xrpl/models/requests/request.py
+++ b/xrpl/models/requests/request.py
@@ -83,7 +83,6 @@ class RequestMethod(str, Enum):
 R = TypeVar("R", bound="Request")
 
 
-@require_kwargs_on_init
 @dataclass(frozen=True)
 class Request(BaseModel):
     """
@@ -182,6 +181,8 @@ class Request(BaseModel):
         return {**super().to_dict(), "method": self.method.value}
 
 
+@require_kwargs_on_init
+@dataclass(frozen=True)
 class LookupByLedgerRequest:
     """Represents requests that need specifying an instance of the ledger"""
 

--- a/xrpl/models/requests/request.py
+++ b/xrpl/models/requests/request.py
@@ -180,3 +180,16 @@ class Request(BaseModel):
         # we need to override this because method is using ``field``
         # which will not include the value in the object's __dict__
         return {**super().to_dict(), "method": self.method.value}
+
+
+class LookupByLedgerRequest:
+    """Represents requests that need specifying an instance of the ledger"""
+
+    ledger_hash: Optional[str] = None
+    """
+    A 20-byte hex string for the ledger version to use.
+    """
+    ledger_index: Optional[Union[str, int]] = None
+    """
+    The ledger index of the ledger to use, or a shortcut string.
+    """

--- a/xrpl/models/requests/ripple_path_find.py
+++ b/xrpl/models/requests/ripple_path_find.py
@@ -12,18 +12,18 @@ combination of paths for making a payment, it is not guaranteed that
 the paths returned by this method are, in fact, the best paths.
 """
 from dataclasses import dataclass, field
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from xrpl.models.amounts import Amount
 from xrpl.models.currencies import Currency
-from xrpl.models.requests.request import Request, RequestMethod
+from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
 from xrpl.models.required import REQUIRED
 from xrpl.models.utils import require_kwargs_on_init
 
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class RipplePathFind(Request):
+class RipplePathFind(Request, LookupByLedgerRequest):
     """
     The ripple_path_find method is a simplified version of the
     path_find method that provides a single response with a payment
@@ -62,5 +62,3 @@ class RipplePathFind(Request):
     method: RequestMethod = field(default=RequestMethod.RIPPLE_PATH_FIND, init=False)
     send_max: Optional[Amount] = None
     source_currencies: Optional[List[Currency]] = None
-    ledger_hash: Optional[str] = None
-    ledger_index: Optional[Union[str, int]] = None

--- a/xrpl/models/requests/transaction_entry.py
+++ b/xrpl/models/requests/transaction_entry.py
@@ -9,16 +9,15 @@ specified transaction. We recommend using that method instead.)
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional, Union
 
-from xrpl.models.requests.request import Request, RequestMethod
+from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
 from xrpl.models.required import REQUIRED
 from xrpl.models.utils import require_kwargs_on_init
 
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class TransactionEntry(Request):
+class TransactionEntry(Request, LookupByLedgerRequest):
     """
     The transaction_entry method retrieves information on a single transaction from a
     specific ledger version. (The tx method, by contrast, searches all ledgers for the
@@ -28,8 +27,6 @@ class TransactionEntry(Request):
     """
 
     method: RequestMethod = field(default=RequestMethod.TRANSACTION_ENTRY, init=False)
-    ledger_hash: Optional[str] = None
-    ledger_index: Optional[Union[str, int]] = None
     tx_hash: str = REQUIRED  # type: ignore
     """
     This field is required.


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

- Add `ledger_hash` and `ledger_index` to `account_nfts`, `nft_buy_offers`, and `nft_sell_offers` requests.
- Create `LookupByLedgerRequest` to clean up `ledger_hash` and `ledger_index` which are optional on most request objects.
- Add `nft_page` to `ledger_entry` request.

Closes https://github.com/XRPLF/xrpl-py/issues/467

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->
Test passed.
