### PR TITLE
fix: Fix `classic_address` aliasing issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [[Unreleased]]
 
+### Fixed
+- Replaced alias for `classic_address` with separate property to work around this mypy issue: 
+  https://github.com/python/mypy/issues/6700
+
 ## [2.0.0] - 2023-07-05
 ### Added:
 - Wallet support for regular key compatibility

--- a/xrpl/wallet/main.py
+++ b/xrpl/wallet/main.py
@@ -24,12 +24,16 @@ class Wallet:
         """  # noqa: DAR201
         return self._address
 
-    classic_address = address
-    """
-    `classic_address` is the same as `address`. It is called `classic_address` to
-    differentiate it from the x-address standard, which encodes the network,
-    destination tag, and XRPL address into a single value. It's also a base58 string.
-    """
+    # TODO: Just alias classic_address once mypy has resolved this issue:
+    #       https://github.com/python/mypy/issues/6700
+    @property
+    def classic_address(self: Wallet) -> str:
+        """
+        `classic_address` is the same as `address`. It is called `classic_address` to
+        differentiate it from the x-address standard, which encodes the network,
+        destination tag, and XRPL address into a single value. It's also a base58 string.
+        """  # noqa: DAR201
+        return self._address
 
     def __init__(
         self: Wallet,

--- a/xrpl/wallet/main.py
+++ b/xrpl/wallet/main.py
@@ -31,7 +31,8 @@ class Wallet:
         """
         `classic_address` is the same as `address`. It is called `classic_address` to
         differentiate it from the x-address standard, which encodes the network,
-        destination tag, and XRPL address into a single value. It's also a base58 string.
+        destination tag, and XRPL address into a single value.
+        It's also a base58 string.
         """  # noqa: DAR201
         return self._address
 


### PR DESCRIPTION
## High Level Overview of Change

Fix mypy complaining about `Wallet.classic_address` being a `Callable` when it is an aliased `str` property. (Open mypy issue: https://github.com/python/mypy/issues/6700)

### Context of Change

Currently aliasing a property is not properly typed by mypy. As a workaround you can switch to using `address` instead of `classic_address`, but this should resolve the issue until the mypy issue is fixed.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Bug fix (non-breaking change which fixes an issue)

## Test Plan

CI passes

<!--
## Future Tasks
For future tasks related to PR.
-->
