### PR TITLE
fix: remove unnecessary parameters from LedgerClosed request

### DIFF
--- a/xrpl/models/requests/ledger_closed.py
+++ b/xrpl/models/requests/ledger_closed.py
@@ -7,7 +7,6 @@ immutable yet.)
 from dataclasses import dataclass, field
 
 from xrpl.models.requests.request import Request, RequestMethod
-from xrpl.models.required import REQUIRED
 from xrpl.models.utils import require_kwargs_on_init
 
 
@@ -22,16 +21,3 @@ class LedgerClosed(Request):
     """
 
     method: RequestMethod = field(default=RequestMethod.LEDGER_CLOSED, init=False)
-    ledger_hash: str = REQUIRED  # type: ignore
-    """
-    This field is required.
-
-    :meta hide-value:
-    """
-
-    ledger_index: int = REQUIRED  # type: ignore
-    """
-    This field is required.
-
-    :meta hide-value:
-    """


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

This PR removes unnecessary parameters (ledger_hash and ledger_index) from the `LedgerClosed` model. (actually, ledger_hash and ledger_index field is for Response, not Request)

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

During a recent code review, it was discovered that the `LedgerClosed` model contained parameters that were not required in actual API (https://xrpl.org/ledger_closed.html)

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

CI Passes

<!--
## Future Tasks
For future tasks related to PR.
-->
