### PR TITLE
docs: Update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,6 +31,11 @@ Please check relevant options, delete irrelevant ones.
 - [ ] Documentation Updates
 - [ ] Release
 
+### Did you update CHANGELOG.md?
+
+- [ ] Yes
+- [ ] No, this change does not impact library users
+
 ## Test Plan
 
 <!--


### PR DESCRIPTION
## High Level Overview of Change

Updating the CHANGELOG is often forgotten by maintainers and external contributors, so we should add it to our PR template.

### Context of Change

This should make it easier to contribute to the repo since it's one less back and forth we'll need to message folks about, and make it easier to guarantee our changes are tracked for releases.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Documentation Updates

### Did you update CHANGELOG.md?

- [X] No, this change does not impact library users
