### PR TITLE
docs: Update ReadTheDocs (rtd) configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,6 @@ build:
     python: "3.11"
 
 python:
-  version: 3.11
   install:
     - method: pip
       path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,19 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 python:
-  version: 3.7
+  version: 3.11
   install:
     - method: pip
       path: .
+
 sphinx:
   builder: html
   configuration: docs/conf.py

--- a/docs/source/snippets.rst
+++ b/docs/source/snippets.rst
@@ -14,7 +14,7 @@ Look Up a Transaction on the Ledger
 Send a Transaction and See if It Gets Validated
 -----------------------------------------------
 
-.. literalinclude:: ../../snippets/reliable_transaction_submission.py
+.. literalinclude:: ../../snippets/submit_payment.py
 
 Set a Regular Key
 -----------------------------------------------

--- a/docs/source/snippets.rst
+++ b/docs/source/snippets.rst
@@ -14,7 +14,7 @@ Look Up a Transaction on the Ledger
 Send a Transaction and See if It Gets Validated
 -----------------------------------------------
 
-.. literalinclude:: ../../snippets/submit_payment.py
+.. literalinclude:: ../../snippets/reliable_transaction_submission.py
 
 Set a Regular Key
 -----------------------------------------------


### PR DESCRIPTION
## High Level Overview of Change

ReadTheDocs has some breaking changes that need to be updated before September 15th.

### Context of Change

- Adds build > os (a new required field as of October 25th)
https://blog.readthedocs.com/use-build-os-config/

Also fixes a misnamed 

### Type of Change

- [X] Documentation Updates

### Did you update CHANGELOG.md?

- [X] No, this change does not impact library users

## Test Plan

Builds locally and by inspection follows the new rules.

<!--
## Future Tasks
For future tasks related to PR.
-->
