### PR TITLE
docs: Update theme to ReadTheDocs always (fixes regression)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,6 +157,14 @@ cd docs/_build/html/
 open index.html
 ```
 
+You can view docs builds for xrpl-py versions on the ReadTheDocs website here: https://readthedocs.org/projects/xrpl-py/builds/
+
+In order to test how a change in docs configuration looks like on ReadTheDocs before merging:
+1. Publish a branch with your docs configuration changes
+2. Active and hide the branch by scrolling down on this page: https://readthedocs.org/projects/xrpl-py/versions/
+3. View the page / build results here: https://readthedocs.org/projects/xrpl-py/builds/
+4. Once you're done testing, make the test branch inactive.
+
 ## Write integration tests
 
 1. If adding functionality to a new part of the library, create new file with a class that inherits `IntegrationTestCase` from `tests.integration.integration_test_case` to store all individual tests under (ex: `class TestWallet(IntegrationTestCase)`). Otherwise, add to an existing file.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,3 +56,6 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+
+# You can test your changes to this config by activating a branch on ReadTheDocs.
+# See CONTRIBUTING.md for more details.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,7 @@
 #
 import os
 import sys
+import sphinx_rtd_theme
 
 sys.path.insert(0, os.path.abspath("../"))
 
@@ -47,14 +48,9 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 #
 # html_theme = "alabaster"
 
-# on_rtd is whether we are on readthedocs.org
-on_rtd = os.environ.get("READTHEDOCS") == "True"
-
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme  # type: ignore
-
-    html_theme = "sphinx_rtd_theme"
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+# This overrides Sphinx's default theme of 'alabaster'
+html_theme = "sphinx_rtd_theme"
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # otherwise, readthedocs.org uses their theme by default, so no need to specify it
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,8 +52,6 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 html_theme = "sphinx_rtd_theme"
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
-# otherwise, readthedocs.org uses their theme by default, so no need to specify it
-
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".


### PR DESCRIPTION
## High Level Overview of Change

Since 2.2.0, the xrpl-py docs have been loading with a new theme. This brings it back to the previous ReadTheDocs theme.

### Context of Change

It seems that the default theme changed without warning (as far as we saw):

Autogenerated theme code from before 2.2.0:
https://readthedocs.org/projects/xrpl-py/builds/21212455/
<img width="744" alt="image" src="https://github.com/XRPLF/xrpl-py/assets/19694186/7b98f4cb-9197-4f42-ad90-71e6f5cc1b7d">

Autogenerated theme code from versions after/including 2.2.0:
https://readthedocs.org/projects/xrpl-py/builds/21889906/
<img width="744" alt="image" src="https://github.com/XRPLF/xrpl-py/assets/19694186/54241e05-4b23-44fa-a85c-0af4896cd206">

In general you can check builds and autogenerated theming by going to this build page: https://readthedocs.org/projects/xrpl-py/builds/

1. Click an individual build 
2. Click the "cat docs/conf.py" 
3. Scroll down past the "auto-generated below here" comment
4. Look for where the theme is defined

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Documentation Updates

### Did you update CHANGELOG.md?

- [X] No, this change does not impact library users

## Test Plan

Inspection and the docs build locally with the RTD theme ✅ 

~~The true efficacy will have to be determined after merging since this is a bug that only shows up in the production docs page, not in the local builds.~~

How it looks after the changes on ReadTheDocs:
<img width="1104" alt="image" src="https://github.com/XRPLF/xrpl-py/assets/19694186/1f60b687-3e45-4c61-99a4-e9ac16a13c42">


<!--
## Future Tasks
For future tasks related to PR.
-->
