### PR TITLE
fix BidMin & BidMax types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Update request models related to AMM
 - Better error handling for when a `Wallet` is passed into an account or destination field
+- Fixed AMMBid fields (BidMin, BidMax) with correct type IssuedCurrencyAmount
 
 ## [2.3.0] - 2023-08-24
 ### Added

--- a/xrpl/models/transactions/amm_bid.py
+++ b/xrpl/models/transactions/amm_bid.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional
 
 from typing_extensions import Final
 
-from xrpl.models.amounts import Amount
+from xrpl.models.amounts.issued_currency_amount import IssuedCurrencyAmount
 from xrpl.models.auth_account import AuthAccount
 from xrpl.models.currencies import Currency
 from xrpl.models.required import REQUIRED
@@ -41,16 +41,16 @@ class AMMBid(Transaction):
     The definition for the other asset in the AMM's pool. This field is required.
     """
 
-    bid_min: Optional[Amount] = None
+    bid_min: Optional[IssuedCurrencyAmount] = None
     """
-    Pay at least this amount for the slot.
+    Pay at least this LPToken amount for the slot.
     Setting this value higher makes it harder for others to outbid you.
     If omitted, pay the minimum necessary to win the bid.
     """
 
-    bid_max: Optional[Amount] = None
+    bid_max: Optional[IssuedCurrencyAmount] = None
     """
-    Pay at most this amount for the slot.
+    Pay at most this LPToken amount for the slot.
     If the cost to win the bid is higher than this amount, the transaction fails.
     If omitted, pay as much as necessary to win the bid.
     """


### PR DESCRIPTION
## High Level Overview of Change

BidMin & BidMax types should be `IssuedCurrencyAmount` since they only accept LPToken amounts.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

### Did you update CHANGELOG.md?

- [x] Yes

## Test Plan

Current test already uses `IssuedCurrencyAmount`
