### PR TITLE
docs: Remove TODO around build_version since we want the defensive coding

### DIFF
--- a/xrpl/asyncio/transaction/main.py
+++ b/xrpl/asyncio/transaction/main.py
@@ -283,8 +283,6 @@ def _tx_needs_networkID(client: Client) -> bool:
         bool: whether the transactions required network ID to be valid
     """
     if client.network_id and client.network_id > _RESTRICTED_NETWORKS:
-        # TODO: remove the buildVersion logic when 1.11.0 is out and widely used.
-        # Issue: https://github.com/XRPLF/xrpl-py/issues/595
         if (
             client.build_version
             and _is_not_later_rippled_version(


### PR DESCRIPTION
## High Level Overview of Change

Closes #595 

### Context of Change

We decided to keep the code in since it is more defensive and should be correct regardless of the network state.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Documentation Updates

### Did you update CHANGELOG.md?

- [ ] No, this change does not impact library users

## Test Plan

N/A

<!--
## Future Tasks
For future tasks related to PR.
-->
