### PR TITLE
fix: fix network ID tests + refactor network ID logic

### DIFF
--- a/tests/integration/sugar/test_network_id.py
+++ b/tests/integration/sugar/test_network_id.py
@@ -14,18 +14,16 @@ class TestNetworkID(TestCase):
     # Autofill should override tx networkID for network with ID > 1024
     # and build_version from 1.11.0 or later.
     def test_networkid_override(self):
-        client = JsonRpcClient("https://sidechain-net1.devnet.rippletest.net:51234")
-        wallet = generate_faucet_wallet(client, debug=True)
-        # Override client build_version since 1.11.0 is not released yet.
-        client.build_version = "1.11.0"
-        tx = AccountSet(
-            account=wallet.classic_address,
-            fee=_FEE,
-            domain="www.example.com",
-        )
-        tx_autofilled = autofill(tx, client)
-        self.assertGreaterEqual(client.network_id, _RESTRICTED_NETWORKS)
-        self.assertEqual(tx_autofilled.network_id, client.network_id)
+        with WebsocketClient("wss://hooks-testnet-v3.xrpl-labs.com") as client:
+            wallet = generate_faucet_wallet(client, debug=True)
+            tx = AccountSet(
+                account=wallet.classic_address,
+                fee=_FEE,
+                domain="www.example.com",
+            )
+            tx_autofilled = autofill(tx, client)
+            self.assertGreaterEqual(client.network_id, _RESTRICTED_NETWORKS)
+            self.assertEqual(tx_autofilled.network_id, client.network_id)
 
     # Autofill should ignore tx network_id for build version earlier than 1.11.0.
     def test_networkid_ignore_early_version(self):
@@ -40,30 +38,3 @@ class TestNetworkID(TestCase):
         )
         tx_autofilled = autofill(tx, client)
         self.assertEqual(tx_autofilled.network_id, None)
-
-    # Autofill should ignore tx network_id for networks with ID <= 1024.
-    def test_networkid_ignore_restricted_networks(self):
-        client = JsonRpcClient("https://s.altnet.rippletest.net:51234")
-        wallet = generate_faucet_wallet(client, debug=True)
-        # Override client build_version since 1.11.0 is not released yet.
-        client.build_version = "1.11.0"
-        tx = AccountSet(
-            account=wallet.classic_address,
-            fee=_FEE,
-            domain="www.example.com",
-        )
-        tx_autofilled = autofill(tx, client)
-        self.assertLessEqual(client.network_id, _RESTRICTED_NETWORKS)
-        self.assertEqual(tx_autofilled.network_id, None)
-
-    # Autofill should override tx networkID for hooks-testnet.
-    def test_networkid_override_hooks_testnet(self):
-        with WebsocketClient("wss://hooks-testnet-v3.xrpl-labs.com") as client:
-            wallet = generate_faucet_wallet(client, debug=True)
-            tx = AccountSet(
-                account=wallet.classic_address,
-                fee=_FEE,
-                domain="www.example.com",
-            )
-            tx_autofilled = autofill(tx, client)
-            self.assertEqual(tx_autofilled.network_id, client.network_id)

--- a/xrpl/asyncio/transaction/main.py
+++ b/xrpl/asyncio/transaction/main.py
@@ -30,7 +30,6 @@ _LEDGER_OFFSET: Final[int] = 20
 # More context: https://github.com/XRPLF/rippled/pull/4370
 _RESTRICTED_NETWORKS = 1024
 _REQUIRED_NETWORKID_VERSION = "1.11.0"
-_HOOKS_TESTNET_ID = 21338
 # TODO: make this dynamic based on the current ledger fee
 _OWNER_RESERVE_FEE: Final[int] = int(xrp_to_drops(2))
 
@@ -285,12 +284,9 @@ def _tx_needs_networkID(client: Client) -> bool:
     if client.network_id and client.network_id > _RESTRICTED_NETWORKS:
         # TODO: remove the buildVersion logic when 1.11.0 is out and widely used.
         # Issue: https://github.com/XRPLF/xrpl-py/issues/595
-        if (
-            client.build_version
-            and _is_not_later_rippled_version(
-                _REQUIRED_NETWORKID_VERSION, client.build_version
-            )
-        ) or client.network_id == _HOOKS_TESTNET_ID:
+        if client.build_version and _is_not_later_rippled_version(
+            _REQUIRED_NETWORKID_VERSION, client.build_version
+        ):
             return True
     return False
 


### PR DESCRIPTION
## High Level Overview of Change

Title says it all.

### Context of Change

Tests are failing because the sidechain devnet no longer has a network ID greater than 1024.

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

### Did you update CHANGELOG.md?

- [ ] Yes
- [x] No, this change does not impact library users

## Test Plan

The network ID tests now work.