### PR TITLE
chore: fix sidechain networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exported `get_nftoken_id` and `parse_nftoken_id` at the `xrpl.utils` level
 - Fixed issue in `get_nftoken_id` where error is opaque when there are no `NFTokenPage`s
 
+### Changed
+- Removed sidechain-net1 Devnet faucet support as it has been decommissioned. Users should instead use the bridge between Devnet and sidechain-net2 for testing.
+
 ## [2.4.0] - 2023-09-27
 ### Added
 - Added new syntax for `SetFee` pseudo transaction sent after the [XRPFees](https://xrpl.org/known-amendments.html#xrpfees) amendment. (Backwards compatible)

--- a/snippets/bridge_transfer.py
+++ b/snippets/bridge_transfer.py
@@ -17,7 +17,7 @@ from xrpl.transaction import submit_and_wait
 from xrpl.utils import get_xchain_claim_id, xrp_to_drops
 from xrpl.wallet import Wallet, generate_faucet_wallet
 
-locking_client = JsonRpcClient("https://sidechain-net1.devnet.rippletest.net:51234")
+locking_client = JsonRpcClient("https://s.devnet.rippletest.net:51234")
 issuing_client = JsonRpcClient("https://sidechain-net2.devnet.rippletest.net:51234")
 
 locking_chain_door = "rMAXACCrp3Y8PpswXcg3bKggHX76V3F8M4"

--- a/snippets/bridge_transfer.py
+++ b/snippets/bridge_transfer.py
@@ -20,7 +20,7 @@ from xrpl.wallet import Wallet, generate_faucet_wallet
 locking_client = JsonRpcClient("https://s.devnet.rippletest.net:51234")
 issuing_client = JsonRpcClient("https://sidechain-net2.devnet.rippletest.net:51234")
 
-locking_chain_door = "rMAXACCrp3Y8PpswXcg3bKggHX76V3F8M4"
+locking_chain_door = "rNQQyL2bJqbtgP5zXHJyQXamtrKYpgsbzV"
 bridge_data = locking_client.request(
     AccountObjects(account=locking_chain_door, type=AccountObjectType.BRIDGE)
 ).result["account_objects"][0]

--- a/tests/integration/sugar/test_network_id.py
+++ b/tests/integration/sugar/test_network_id.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from xrpl.asyncio.transaction.main import _RESTRICTED_NETWORKS
-from xrpl.clients import JsonRpcClient, WebsocketClient
+from xrpl.clients import WebsocketClient
 from xrpl.models.transactions import AccountSet
 from xrpl.transaction import autofill
 from xrpl.wallet.wallet_generation import generate_faucet_wallet
@@ -24,17 +24,3 @@ class TestNetworkID(TestCase):
             tx_autofilled = autofill(tx, client)
             self.assertGreaterEqual(client.network_id, _RESTRICTED_NETWORKS)
             self.assertEqual(tx_autofilled.network_id, client.network_id)
-
-    # Autofill should ignore tx network_id for build version earlier than 1.11.0.
-    def test_networkid_ignore_early_version(self):
-        client = JsonRpcClient("https://sidechain-net1.devnet.rippletest.net:51234")
-        wallet = generate_faucet_wallet(client, debug=True)
-        # Override client build_version since 1.11.0 is not released yet.
-        client.build_version = "1.10.0"
-        tx = AccountSet(
-            account=wallet.classic_address,
-            fee=_FEE,
-            domain="www.example.com",
-        )
-        tx_autofilled = autofill(tx, client)
-        self.assertEqual(tx_autofilled.network_id, None)

--- a/tests/integration/sugar/test_wallet.py
+++ b/tests/integration/sugar/test_wallet.py
@@ -166,14 +166,6 @@ class TestWallet(IntegrationTestCase):
         ) as client:
             await generate_faucet_wallet_and_fund_again(self, client)
 
-    async def _parallel_test_generate_faucet_wallet_sidechain_devnet_async_websockets(
-        self,
-    ):
-        async with AsyncWebsocketClient(
-            "wss://sidechain-net1.devnet.rippletest.net:51233"
-        ) as client:
-            await generate_faucet_wallet_and_fund_again(self, client)
-
     async def _parallel_test_generate_faucet_wallet_hooks_v3_testnet_async_websockets(
         self,
     ):

--- a/xrpl/asyncio/wallet/wallet_generation.py
+++ b/xrpl/asyncio/wallet/wallet_generation.py
@@ -16,9 +16,6 @@ _AMM_DEV_FAUCET_URL: Final[str] = "https://ammfaucet.devnet.rippletest.net/accou
 _HOOKS_V3_TEST_FAUCET_URL: Final[
     str
 ] = "https://hooks-testnet-v3.xrpl-labs.com/accounts"
-_SIDECHAIN_DEVNET_FAUCET_URL: Final[
-    str
-] = "https://sidechain-faucet.devnet.rippletest.net/accounts"
 
 _TIMEOUT_SECONDS: Final[int] = 40
 
@@ -126,9 +123,7 @@ def get_faucet_url(url: str, faucet_host: Optional[str] = None) -> str:
         return _TEST_FAUCET_URL
     if "amm" in url:  # amm devnet
         return _AMM_DEV_FAUCET_URL
-    if "sidechain-net1" in url:  # sidechain devnet
-        return _SIDECHAIN_DEVNET_FAUCET_URL
-    elif "sidechain-net2" in url:  # sidechain issuing chain devnet
+    if "sidechain-net2" in url:  # sidechain issuing chain devnet
         raise XRPLFaucetException(
             "Cannot fund an account on an issuing chain. Accounts must be created via "
             "the bridge."


### PR DESCRIPTION
## High Level Overview of Change

This PR removes support for sidechain-net1 (in the faucet code and snippets) and switches from a decommissioned bridge to a new bridge in the snippet.

### Context of Change

The testing bridge was moved from sidechain-net1 to Devnet.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation Updates

### Did you update CHANGELOG.md?

- [x] Yes

## Test Plan

CI passes now.
