### PR TITLE
Add Metadata

### DIFF
--- a/docs/source/xrpl.models.ledger_objects.rst
+++ b/docs/source/xrpl.models.ledger_objects.rst
@@ -1,0 +1,157 @@
+xrpl.models.ledger\_objects package
+===================================
+
+Submodules
+----------
+
+xrpl.models.ledger\_objects.account\_root module
+------------------------------------------------
+
+.. automodule:: xrpl.models.ledger_objects.account_root
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.ledger\_objects.amendments module
+---------------------------------------------
+
+.. automodule:: xrpl.models.ledger_objects.amendments
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.ledger\_objects.check module
+----------------------------------------
+
+.. automodule:: xrpl.models.ledger_objects.check
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.ledger\_objects.deposit\_preauth module
+---------------------------------------------------
+
+.. automodule:: xrpl.models.ledger_objects.deposit_preauth
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.ledger\_objects.directory\_node module
+--------------------------------------------------
+
+.. automodule:: xrpl.models.ledger_objects.directory_node
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.ledger\_objects.escrow module
+-----------------------------------------
+
+.. automodule:: xrpl.models.ledger_objects.escrow
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.ledger\_objects.fee\_settings module
+------------------------------------------------
+
+.. automodule:: xrpl.models.ledger_objects.fee_settings
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.ledger\_objects.ledger\_entry\_type module
+------------------------------------------------------
+
+.. automodule:: xrpl.models.ledger_objects.ledger_entry_type
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.ledger\_objects.ledger\_hashes module
+-------------------------------------------------
+
+.. automodule:: xrpl.models.ledger_objects.ledger_hashes
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.ledger\_objects.ledger\_object module
+-------------------------------------------------
+
+.. automodule:: xrpl.models.ledger_objects.ledger_object
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.ledger\_objects.negative\_unl module
+------------------------------------------------
+
+.. automodule:: xrpl.models.ledger_objects.negative_unl
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.ledger\_objects.nftoken\_offer module
+-------------------------------------------------
+
+.. automodule:: xrpl.models.ledger_objects.nftoken_offer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.ledger\_objects.nftoken\_page module
+------------------------------------------------
+
+.. automodule:: xrpl.models.ledger_objects.nftoken_page
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.ledger\_objects.offer module
+----------------------------------------
+
+.. automodule:: xrpl.models.ledger_objects.offer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.ledger\_objects.pay\_channel module
+-----------------------------------------------
+
+.. automodule:: xrpl.models.ledger_objects.pay_channel
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.ledger\_objects.ripple\_state module
+------------------------------------------------
+
+.. automodule:: xrpl.models.ledger_objects.ripple_state
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.ledger\_objects.signer\_list module
+-----------------------------------------------
+
+.. automodule:: xrpl.models.ledger_objects.signer_list
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.ledger\_objects.ticket module
+-----------------------------------------
+
+.. automodule:: xrpl.models.ledger_objects.ticket
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: xrpl.models.ledger_objects
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/xrpl.models.metadata.rst
+++ b/docs/source/xrpl.models.metadata.rst
@@ -1,0 +1,133 @@
+xrpl.models.metadata package
+============================
+
+Submodules
+----------
+
+xrpl.models.metadata.account\_root module
+-----------------------------------------
+
+.. automodule:: xrpl.models.metadata.account_root
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.metadata.amendments module
+--------------------------------------
+
+.. automodule:: xrpl.models.metadata.amendments
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.metadata.check module
+---------------------------------
+
+.. automodule:: xrpl.models.metadata.check
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.metadata.deposit\_preauth module
+--------------------------------------------
+
+.. automodule:: xrpl.models.metadata.deposit_preauth
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.metadata.directory\_node module
+-------------------------------------------
+
+.. automodule:: xrpl.models.metadata.directory_node
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.metadata.ledger\_hashes module
+------------------------------------------
+
+.. automodule:: xrpl.models.metadata.ledger_hashes
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.metadata.metadata module
+------------------------------------
+
+.. automodule:: xrpl.models.metadata.metadata
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.metadata.negative\_unl module
+-----------------------------------------
+
+.. automodule:: xrpl.models.metadata.negative_unl
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.metadata.nftoken\_offer module
+------------------------------------------
+
+.. automodule:: xrpl.models.metadata.nftoken_offer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.metadata.nftoken\_page module
+-----------------------------------------
+
+.. automodule:: xrpl.models.metadata.nftoken_page
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.metadata.offer module
+---------------------------------
+
+.. automodule:: xrpl.models.metadata.offer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.metadata.pay\_channel module
+----------------------------------------
+
+.. automodule:: xrpl.models.metadata.pay_channel
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.metadata.ripple\_state module
+-----------------------------------------
+
+.. automodule:: xrpl.models.metadata.ripple_state
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.metadata.signer\_list module
+----------------------------------------
+
+.. automodule:: xrpl.models.metadata.signer_list
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+xrpl.models.metadata.ticket module
+----------------------------------
+
+.. automodule:: xrpl.models.metadata.ticket
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: xrpl.models.metadata
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/tests/unit/models/test_ledger_object.py
+++ b/tests/unit/models/test_ledger_object.py
@@ -14,6 +14,8 @@ from xrpl.models.ledger_objects import (  # NFTokenOffer,
     Majority,
     NegativeUNL,
     NFToken,
+    NFTokenOffer,
+    NFTokenOfferFlags,
     NFTokenPage,
     Offer,
     PayChannel,
@@ -167,8 +169,19 @@ negative_unl_json = {
     "index": "2E8A59AA9D3B5B186B0B9E0F62E6C02587CA74A4D778938E957B6357D364B244",
 }
 
-# TODO: Find example
-# nftoken_offer_json = {}
+nftoken_offer_json = {
+    "ledger_entry_type": "NFTokenOffer",
+    "index": "AEBABA4FAC212BF28E0F9A9C3788A47B085557EC5D1429E7A8266FB859C863B3",
+    "amount": "1000000",
+    "flags": 1,
+    "nftoken_id": "00081B5825A08C22787716FA031B432EBBC1B101BB54875F0002D2A400000000",
+    "owner": "rhRxL3MNvuKEjWjL7TBbZSDacb8PmzAd7m",
+    "previous_txn_id": "BFA9BE27383FA315651E26FDE1FA30815C5A5D0544EE10EC33D3E92532993"
+    "769",
+    "previous_txn_lgr_seq": 75443565,
+    "owner_node": "17",
+    "nftoken_offer_node": "0"
+}
 
 nftoken_page_json = {
     "ledger_entry_type": "NFTokenPage",
@@ -187,7 +200,7 @@ nftoken_page_json = {
             "7568377932366E6634646675796C71616266336F636C67747179353566627A6469",
         },
     ],
-    "index": "",  # TODO: Find out if there is unique index
+    "index": "",
 }
 
 offer_json = {
@@ -487,6 +500,24 @@ class TestFromTODict(TestCase):
         )
         self.assertEqual(actual, expected)
         self.assertEqual(negative_unl_json, expected.to_dict())
+
+    def test_nftoken_offer(self):
+        actual = NFTokenOffer.from_dict(nftoken_offer_json)
+        expected = NFTokenOffer(
+            index="AEBABA4FAC212BF28E0F9A9C3788A47B085557EC5D1429E7A8266FB859C863B3",
+            amount="1000000",
+            flags=1,
+            nftoken_id="00081B5825A08C22787716FA031B432EBBC1B101BB54875F0002D2A400000"
+            "000",
+            owner="rhRxL3MNvuKEjWjL7TBbZSDacb8PmzAd7m",
+            previous_txn_id="BFA9BE27383FA315651E26FDE1FA30815C5A5D0544EE10EC33D3E925"
+            "32993769",
+            previous_txn_lgr_seq=75443565,
+            owner_node="17",
+            nftoken_offer_node="0",
+        )
+        self.assertEqual(actual, expected)
+        self.assertEqual(nftoken_offer_json, expected.to_dict())
 
     def test_nftoken_page(self):
         actual = NFTokenPage.from_dict(nftoken_page_json)

--- a/tests/unit/models/test_ledger_object.py
+++ b/tests/unit/models/test_ledger_object.py
@@ -1,0 +1,634 @@
+from unittest import TestCase
+
+from xrpl.models import IssuedCurrencyAmount
+from xrpl.models.ledger_objects import (  # NFTokenOffer,
+    AccountRoot,
+    Amendments,
+    Check,
+    DepositPreauth,
+    DirectoryNode,
+    DisabledValidator,
+    Escrow,
+    FeeSettings,
+    LedgerHashes,
+    Majority,
+    NegativeUNL,
+    NFToken,
+    NFTokenPage,
+    Offer,
+    PayChannel,
+    RippleState,
+    SignerEntry,
+    SignerList,
+    Ticket,
+)
+
+account_root_json = {
+    "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+    "account_txn_id": "0D5FB50FA65C9FE1538FD7E398FFFE9D190"
+    "8DFA4576D8D7A020040686F93C77D",
+    "balance": "148446663",
+    "domain": "6D64756F31332E636F6D",
+    "email_hash": "98B4375E1D753E5B91627516F6D70977",
+    "flags": 8388608,
+    "ledger_entry_type": "AccountRoot",
+    "message_key": "0000000000000000000000070000000300",
+    "owner_count": 3,
+    "nftoken_minter": "rHello",
+    "previous_txn_id": "0D5FB50FA65C9FE1538FD7E398FFFE9D1908DFA4576D8D7A0200"
+    "40686F93C77D",
+    "previous_txn_lgr_seq": 14091160,
+    "sequence": 336,
+    "transfer_rate": 1004999999,
+    "index": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+}
+
+amendment_json = {
+    "majorities": [
+        {
+            "majority": {
+                "amendment": "1562511F573A19AE9BD103B5D6B9E01B3B46805AEC5D3C4805C902B51"
+                "4399146",
+                "close_time": 535589001,
+            }
+        }
+    ],
+    "amendments": [
+        "42426C4D4F1009EE67080A9B7965B44656D7714D104A72F9B4369F97ABF044EE",
+        "4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373",
+        "6781F8368C4771B83E8B821D88F580202BCB4228075297B19E4FDC5233F1EFDC",
+        "740352F2412A9909880C23A559FCECEDA3BE2126FED62FC7660D628A06927F11",
+    ],
+    "flags": 0,
+    "ledger_entry_type": "Amendments",
+    "index": "7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4",
+}
+
+check_json = {
+    "account": "rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo",
+    "destination": "rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy",
+    "destination_node": "0000000000000000",
+    "destination_tag": 1,
+    "expiration": 570113521,
+    "flags": 0,
+    "invoice_id": "46060241FABCF692D4D934BA2A6C4427CD4279083E38C77CBE642243E43BE291",
+    "ledger_entry_type": "Check",
+    "owner_node": "0000000000000000",
+    "previous_txn_id": "5463C6E08862A1FAE5EDAC12D70ADB16546A1F67"
+    "4930521295BC082494B62924",
+    "previous_txn_lgr_seq": 6,
+    "send_max": "100000000",
+    "sequence": 2,
+    "index": "49647F0D748DC3FE26BDACBC57F251AADEFFF391403EC9BF87C97F67E9977FB0",
+}
+
+deposit_preauth_json = {
+    "ledger_entry_type": "DepositPreauth",
+    "account": "rsUiUMpnrgxQp24dJYZDhmV4bE3aBtQyt8",
+    "authorize": "rEhxGqkqPPSxQ3P25J66ft5TwpzV14k2de",
+    "flags": 0,
+    "owner_node": "0000000000000000",
+    "previous_txn_id": "3E8964D5A86B3CD6B9ECB33310D4E073D64C865A5B866200"
+    "AD2B7E29F8326702",
+    "previous_txn_lgr_seq": 7,
+    "index": "4A255038CC3ADCC1A9C91509279B59908251728D0DAADB248FFE297D0F7E068C",
+}
+
+directory_node_json = {
+    "exchange_rate": "4F069BA8FF484000",
+    "flags": 0,
+    "indexes": ["AD7EAE148287EF12D213A251015F86E6D4BD34B3C4A0A1ED9A17198373F908AD"],
+    "ledger_entry_type": "DirectoryNode",
+    "root_index": "1BBEF97EDE88D40CEE2ADE6FEF121166AFE80D99EBADB01A4F069BA8FF484000",
+    "taker_gets_currency": "0000000000000000000000000000000000000000",
+    "taker_gets_issuer": "0000000000000000000000000000000000000000",
+    "taker_pays_currency": "0000000000000000000000004A50590000000000",
+    "taker_pays_issuer": "5BBC0F22F61D9224A110650CFE21CC0C4BE13098",
+    "index": "1BBEF97EDE88D40CEE2ADE6FEF121166AFE80D99EBADB01A4F069BA8FF484000",
+}
+
+escrow_json = {
+    "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+    "amount": "10000",
+    "cancel_after": 545440232,
+    "condition": "A0258020A82A88B2DF843A54F58772E4A3861866ECDB4157645DD9AE528C1D3AEEDAB"
+    "AB6810120",
+    "destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+    "destination_tag": 23480,
+    "finish_after": 545354132,
+    "flags": 0,
+    "ledger_entry_type": "Escrow",
+    "owner_node": "0000000000000000",
+    "destination_node": "0000000000000000",
+    "previous_txn_id": "C44F2EB84196B9AD820313DBEBA6316A15C9A2"
+    "D35787579ED172B87A30131DA7",
+    "previous_txn_lgr_seq": 28991004,
+    "source_tag": 11747,
+    "index": "DC5F3851D8A1AB622F957761E5963BC5BD439D5C24AC6AD7AC4523F0640244AC",
+}
+
+fee_settings_json = {
+    "base_fee": "000000000000000A",
+    "flags": 0,
+    "ledger_entry_type": "FeeSettings",
+    "reference_fee_units": 10,
+    "reserve_base": 20000000,
+    "reserve_increment": 5000000,
+    "index": "4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A95BF25E4AAB854A6A651",
+}
+
+ledger_hashes_json = {
+    "ledger_entry_type": "LedgerHashes",
+    "flags": 0,
+    "first_ledger_sequence": 2,
+    "last_ledger_sequence": 33872029,
+    "hashes": [
+        "D638208ADBD04CBB10DE7B645D3AB4BA31489379411A3A347151702B6401AA78",
+        "254D690864E418DDD9BCAC93F41B1F53B1AE693FC5FE667CE40205C322D1BE3B",
+        "A2B31D28905E2DEF926362822BC412B12ABF6942B73B72A32D46ED2ABB7ACCFA",
+        "AB4014846DF818A4B43D6B1686D0DE0644FE711577C5AB6F0B2A21CCEE280140",
+        "3383784E82A8BA45F4DD5EF4EE90A1B2D3B4571317DBAC37B859836ADDE644C1",
+    ],
+    "index": "B4979A36CDC7F3D3D5C31A4EAE2AC7D7209DDA877588B9AFC66799692AB0D66B",
+}
+
+negative_unl_json = {
+    "disabled_validators": [
+        {
+            "disabled_validator": {
+                "first_ledger_sequence": 1609728,
+                "public_key": "ED6629D456285AE3613B285F65BBFF168D695BA"
+                "3921F309949AFCD2CA7AFEC16FE",
+            }
+        }
+    ],
+    "flags": 0,
+    "ledger_entry_type": "NegativeUNL",
+    "index": "2E8A59AA9D3B5B186B0B9E0F62E6C02587CA74A4D778938E957B6357D364B244",
+}
+
+# TODO: Find example
+# nftoken_offer_json = {}
+
+nftoken_page_json = {
+    "ledger_entry_type": "NFTokenPage",
+    "previous_token_page": "598EDFD7CF73460FB8C695d6a9397E"
+    "907378C8A841F7204C793DCBEF5406",
+    "previous_token_next": "598EDFD7CF73460FB8C695d6a9397E90"
+    "73781BA3B78198904F659AAA252A",
+    "previous_txn_id": "95C8761B22894E328646F7A70035E9DFBECC9"
+    "0EDD83E43B7B973F626D21A0822",
+    "previous_txn_lgr_seq": 42891441,
+    "nftokens": [
+        {
+            "nftoken_id": "000B013A95F14B0044F78A264E41713"
+            "C64B5F89242540EE208C3098E00000D65",
+            "uri": "697066733A2F2F62616679626569676479727A74357366703775646D3768753736"
+            "7568377932366E6634646675796C71616266336F636C67747179353566627A6469",
+        },
+    ],
+    "index": "",  # TODO: Find out if there is unique index
+}
+
+offer_json = {
+    "account": "rBqb89MRQJnMPq8wTwEbtz4kvxrEDfcYvt",
+    "book_directory": "ACC27DE91DBA86FC509069EAF4BC511D7"
+    "3128B780F2E54BF5E07A369E2446000",
+    "book_node": "0000000000000000",
+    "flags": 131072,
+    "ledger_entry_type": "Offer",
+    "owner_node": "0000000000000000",
+    "previous_txn_id": "F0AB71E777B2DA54B86231E19B82554EF1"
+    "F8211F92ECA473121C655BFC5329BF",
+    "previous_txn_lgr_seq": 14524914,
+    "sequence": 866,
+    "taker_gets": {
+        "currency": "XAG",
+        "issuer": "r9Dr5xwkeLegBeXq6ujinjSBLQzQ1zQGjH",
+        "value": "37",
+    },
+    "taker_pays": "79550000000",
+    "index": "96F76F27D8A327FC48753167EC04A46AA0E382E6F57F32FD12274144D00F1797",
+}
+
+pay_channel_json = {
+    "account": "rBqb89MRQJnMPq8wTwEbtz4kvxrEDfcYvt",
+    "destination": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+    "amount": "4325800",
+    "balance": "2323423",
+    "public_key": "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A",
+    "settle_delay": 3600,
+    "expiration": 536027313,
+    "cancel_after": 536891313,
+    "source_tag": 0,
+    "destination_tag": 1002341,
+    "destination_node": "0000000000000000",
+    "flags": 0,
+    "ledger_entry_type": "PayChannel",
+    "owner_node": "0000000000000000",
+    "previous_txn_id": "F0AB71E777B2DA54B86231E19B82554E"
+    "F1F8211F92ECA473121C655BFC5329BF",
+    "previous_txn_lgr_seq": 14524914,
+    "index": "96F76F27D8A327FC48753167EC04A46AA0E382E6F57F32FD12274144D00F1797",
+}
+
+ripple_state_json = {
+    "balance": {
+        "currency": "USD",
+        "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+        "value": "-10",
+    },
+    "flags": 393216,
+    "high_limit": {
+        "currency": "USD",
+        "issuer": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+        "value": "110",
+    },
+    "high_node": "0000000000000000",
+    "ledger_entry_type": "RippleState",
+    "low_limit": {
+        "currency": "USD",
+        "issuer": "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW",
+        "value": "0",
+    },
+    "low_node": "0000000000000000",
+    "previous_txn_id": "E3FE6EA3D48F0C2B639448020EA4F03D"
+    "4F4F8FFDB243A852A0F59177921B4879",
+    "previous_txn_lgr_seq": 14090896,
+    "index": "9CA88CDEDFF9252B3DE183CE35B038F57282BC9503CDFA1923EF9A95DF0D6F7B",
+}
+
+signer_list_json = {
+    "flags": 0,
+    "ledger_entry_type": "SignerList",
+    "owner_node": "0000000000000000",
+    "previous_txn_id": "5904C0DC72C58A83AEFED2FFC5386356"
+    "AA83FCA6A88C89D00646E51E687CDBE4",
+    "previous_txn_lgr_seq": 16061435,
+    "signer_entries": [
+        {
+            "signer_entry": {
+                "account": "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW",
+                "signer_weight": 2,
+            }
+        },
+        {
+            "signer_entry": {
+                "account": "raKEEVSGnKSD9Zyvxu4z6Pqpm4ABH8FS6n",
+                "signer_weight": 1,
+            }
+        },
+        {
+            "signer_entry": {
+                "account": "rUpy3eEg8rqjqfUoLeBnZkscbKbFsKXC3v",
+                "signer_weight": 1,
+            }
+        },
+    ],
+    "signer_list_id": 0,
+    "signer_quorum": 3,
+    "index": "A9C28A28B85CD533217F5C0A0C7767666B093FA58A0F2D80026FCC4CD932DDC7",
+}
+
+ticket_json = {
+    "account": "rEhxGqkqPPSxQ3P25J66ft5TwpzV14k2de",
+    "flags": 0,
+    "ledger_entry_type": "Ticket",
+    "owner_node": "0000000000000000",
+    "previous_txn_id": "F19AD4577212D3BEACA0F75FE1BA1"
+    "644F2E854D46E8D62E9C95D18E9708CBFB1",
+    "previous_txn_lgr_seq": 4,
+    "ticket_sequence": 3,
+    "index": "",  # TODO: Find out if there is an unique index
+}
+
+
+class TestFromTODict(TestCase):
+    def test_account_root(self):
+        actual = AccountRoot.from_dict(account_root_json)
+        expected = AccountRoot(
+            index="13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+            account="rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            balance="148446663",
+            flags=8388608,
+            owner_count=3,
+            previous_txn_id="0D5FB50FA65C9FE1538FD7E398FFFE9D"
+            "1908DFA4576D8D7A020040686F93C77D",
+            previous_txn_lgr_seq=14091160,
+            sequence=336,
+            account_txn_id="0D5FB50FA65C9FE1538FD7E398FFFE9D1"
+            "908DFA4576D8D7A020040686F93C77D",
+            burned_nftokens=None,
+            domain="6D64756F31332E636F6D",
+            email_hash="98B4375E1D753E5B91627516F6D70977",
+            message_key="0000000000000000000000070000000300",
+            minted_nftokens=None,
+            nftoken_minter="rHello",
+            regular_key=None,
+            ticket_count=None,
+            ticket_size=None,
+            transfer_rate=1004999999,
+            wallet_locator=None,
+            wallet_size=None,
+        )
+        self.assertEqual(actual, expected)
+        self.assertEqual(account_root_json, expected.to_dict())
+
+    def test_amendments(self):
+        actual = Amendments.from_dict(amendment_json)
+        expected = Amendments(
+            index="7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4",
+            flags=0,
+            amendments=[
+                "42426C4D4F1009EE67080A9B7965B44656D7714D104A72F9B4369F97ABF044EE",
+                "4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373",
+                "6781F8368C4771B83E8B821D88F580202BCB4228075297B19E4FDC5233F1EFDC",
+                "740352F2412A9909880C23A559FCECEDA3BE2126FED62FC7660D628A06927F11",
+            ],
+            majorities=[
+                Majority(
+                    amendment="1562511F573A19AE9BD103B5D6B9E01B3B46805AEC5D3C"
+                    "4805C902B514399146",
+                    close_time=535589001,
+                )
+            ],
+        )
+        self.assertEqual(actual, expected)
+        self.assertEqual(amendment_json, expected.to_dict())
+
+    def test_check(self):
+        actual = Check.from_dict(check_json)
+        expected = Check(
+            index="49647F0D748DC3FE26BDACBC57F251AADEFFF391403EC9BF87C97F67E9977FB0",
+            account="rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo",
+            destination="rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy",
+            flags=0,
+            owner_node="0000000000000000",
+            previous_txn_id="5463C6E08862A1FAE5EDAC12D70ADB16546A"
+            "1F674930521295BC082494B62924",
+            previous_txn_lgr_seq=6,
+            send_max="100000000",
+            sequence=2,
+            destination_node="0000000000000000",
+            destination_tag=1,
+            expiration=570113521,
+            invoice_id="46060241FABCF692D4D934BA2A6C4427CD427"
+            "9083E38C77CBE642243E43BE291",
+            source_tag=None,
+        )
+        self.assertEqual(actual, expected)
+        self.assertEqual(check_json, expected.to_dict())
+
+    def test_deposit_preauth(self):
+        actual = DepositPreauth.from_dict(deposit_preauth_json)
+        expected = DepositPreauth(
+            index="4A255038CC3ADCC1A9C91509279B59908251728D0DAADB248FFE297D0F7E068C",
+            account="rsUiUMpnrgxQp24dJYZDhmV4bE3aBtQyt8",
+            authorize="rEhxGqkqPPSxQ3P25J66ft5TwpzV14k2de",
+            flags=0,
+            owner_node="0000000000000000",
+            previous_txn_id="3E8964D5A86B3CD6B9ECB33310D4E073D64C8"
+            "65A5B866200AD2B7E29F8326702",
+            previous_txn_lgr_seq=7,
+        )
+        self.assertEqual(actual, expected)
+        self.assertEqual(deposit_preauth_json, expected.to_dict())
+
+    def test_directory_node(self):
+        actual = DirectoryNode.from_dict(directory_node_json)
+        expected = DirectoryNode(
+            index="1BBEF97EDE88D40CEE2ADE6FEF121166AFE80D99EBADB01A4F069BA8FF484000",
+            flags=0,
+            root_index="1BBEF97EDE88D40CEE2ADE6FEF121166A"
+            "FE80D99EBADB01A4F069BA8FF484000",
+            indexes=[
+                "AD7EAE148287EF12D213A251015F86E6D4BD34B3C4A0A1ED9A17198373F908AD"
+            ],
+            index_next=None,
+            index_previous=None,
+            owner=None,
+            exchange_rate="4F069BA8FF484000",
+            taker_pays_currency="0000000000000000000000004A50590000000000",
+            taker_pays_issuer="5BBC0F22F61D9224A110650CFE21CC0C4BE13098",
+            taker_gets_currency="0000000000000000000000000000000000000000",
+            taker_gets_issuer="0000000000000000000000000000000000000000",
+        )
+        self.assertEqual(actual, expected)
+        self.assertEqual(directory_node_json, expected.to_dict())
+
+    def test_escrow(self):
+        actual = Escrow.from_dict(escrow_json)
+        expected = Escrow(
+            index="DC5F3851D8A1AB622F957761E5963BC5BD439D5C24AC6AD7AC4523F0640244AC",
+            account="rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            amount="10000",
+            destination="ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+            flags=0,
+            owner_node="0000000000000000",
+            previous_txn_id="C44F2EB84196B9AD820313DBEBA6316A15"
+            "C9A2D35787579ED172B87A30131DA7",
+            previous_txn_lgr_seq=28991004,
+            condition="A0258020A82A88B2DF843A54F58772E4A3861866EC"
+            "DB4157645DD9AE528C1D3AEEDABAB6810120",
+            cancel_after=545440232,
+            destination_node="0000000000000000",
+            destination_tag=23480,
+            finish_after=545354132,
+            source_tag=11747,
+        )
+        self.assertEqual(actual, expected)
+        self.assertEqual(escrow_json, expected.to_dict())
+
+    def test_fee_settings(self):
+        actual = FeeSettings.from_dict(fee_settings_json)
+        expected = FeeSettings(
+            index="4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A95BF25E4AAB854A6A651",
+            base_fee="000000000000000A",
+            flags=0,
+            reference_fee_units=10,
+            reserve_base=20000000,
+            reserve_increment=5000000,
+        )
+        self.assertEqual(actual, expected)
+        self.assertEqual(fee_settings_json, expected.to_dict())
+
+    def test_ledger_hashes(self):
+        actual = LedgerHashes.from_dict(ledger_hashes_json)
+        expected = LedgerHashes(
+            index="B4979A36CDC7F3D3D5C31A4EAE2AC7D7209DDA877588B9AFC66799692AB0D66B",
+            first_ledger_sequence=2,
+            last_ledger_sequence=33872029,
+            hashes=[
+                "D638208ADBD04CBB10DE7B645D3AB4BA31489379411A3A347151702B6401AA78",
+                "254D690864E418DDD9BCAC93F41B1F53B1AE693FC5FE667CE40205C322D1BE3B",
+                "A2B31D28905E2DEF926362822BC412B12ABF6942B73B72A32D46ED2ABB7ACCFA",
+                "AB4014846DF818A4B43D6B1686D0DE0644FE711577C5AB6F0B2A21CCEE280140",
+                "3383784E82A8BA45F4DD5EF4EE90A1B2D3B4571317DBAC37B859836ADDE644C1",
+            ],
+            flags=0,
+        )
+        self.assertEqual(actual, expected)
+        self.assertEqual(ledger_hashes_json, expected.to_dict())
+
+    def test_negative_unl(self):
+        actual = NegativeUNL.from_dict(negative_unl_json)
+        expected = NegativeUNL(
+            index="2E8A59AA9D3B5B186B0B9E0F62E6C02587CA74A4D778938E957B6357D364B244",
+            flags=0,
+            disabled_validators=[
+                DisabledValidator(
+                    first_ledger_sequence=1609728,
+                    public_key="ED6629D456285AE3613B285F65BBFF168D695BA"
+                    "3921F309949AFCD2CA7AFEC16FE",
+                )
+            ],
+            validator_to_disable=None,
+            validator_to_enable=None,
+        )
+        self.assertEqual(actual, expected)
+        self.assertEqual(negative_unl_json, expected.to_dict())
+
+    def test_nftoken_page(self):
+        actual = NFTokenPage.from_dict(nftoken_page_json)
+        expected = NFTokenPage(
+            index="",
+            previous_page_min=None,
+            next_page_min=None,
+            previous_token_page="598EDFD7CF73460FB8C695d6a9397E9"
+            "07378C8A841F7204C793DCBEF5406",
+            previous_token_next="598EDFD7CF73460FB8C695d6a9397E90"
+            "73781BA3B78198904F659AAA252A",
+            previous_txn_id="95C8761B22894E328646F7A70035E9DFBEC"
+            "C90EDD83E43B7B973F626D21A0822",
+            previous_txn_lgr_seq=42891441,
+            nftokens=[
+                NFToken(
+                    nftoken_id="000B013A95F14B0044F78A264E41713"
+                    "C64B5F89242540EE208C3098E00000D65",
+                    uri="697066733A2F2F62616679626569676479727A"
+                    "74357366703775646D37687537367568377932366E"
+                    "6634646675796C71616266336F636C67747179353566627A6469",
+                )
+            ],
+        )
+        self.assertEqual(actual, expected)
+        self.assertEqual(nftoken_page_json, expected.to_dict())
+
+    def test_offer(self):
+        actual = Offer.from_dict(offer_json)
+        expected = Offer(
+            index="96F76F27D8A327FC48753167EC04A46AA0E382E6F57F32FD12274144D00F1797",
+            account="rBqb89MRQJnMPq8wTwEbtz4kvxrEDfcYvt",
+            taker_gets=IssuedCurrencyAmount(
+                currency="XAG", issuer="r9Dr5xwkeLegBeXq6ujinjSBLQzQ1zQGjH", value="37"
+            ),
+            taker_pays="79550000000",
+            sequence=866,
+            flags=131072,
+            book_directory="ACC27DE91DBA86FC509069EAF4BC511D7"
+            "3128B780F2E54BF5E07A369E2446000",
+            book_node="0000000000000000",
+            owner_node="0000000000000000",
+            previous_txn_id="F0AB71E777B2DA54B86231E19B82554EF1F821"
+            "1F92ECA473121C655BFC5329BF",
+            previous_txn_lgr_seq=14524914,
+            expiration=None,
+        )
+        self.assertEqual(actual, expected)
+        self.assertEqual(offer_json, expected.to_dict())
+
+    def test_pay_channel(self):
+        actual = PayChannel.from_dict(pay_channel_json)
+        expected = PayChannel(
+            index="96F76F27D8A327FC48753167EC04A46AA0E382E6F57F32FD12274144D00F1797",
+            account="rBqb89MRQJnMPq8wTwEbtz4kvxrEDfcYvt",
+            amount="4325800",
+            balance="2323423",
+            destination="rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            flags=0,
+            owner_node="0000000000000000",
+            public_key="32D2471DB72B27E3310F355BB33E339BF26F83"
+            "92D5A93D3BC0FC3B566612DA0F0A",
+            previous_txn_id="F0AB71E777B2DA54B86231E19B82554EF1"
+            "F8211F92ECA473121C655BFC5329BF",
+            previous_txn_lgr_seq=14524914,
+            settle_delay=3600,
+            destination_node="0000000000000000",
+            destination_tag=1002341,
+            expiration=536027313,
+            cancel_after=536891313,
+            source_tag=0,
+        )
+        self.assertEqual(actual, expected)
+        self.assertEqual(pay_channel_json, expected.to_dict())
+
+    def test_ripple_state(self):
+        actual = RippleState.from_dict(ripple_state_json)
+        expected = RippleState(
+            index="9CA88CDEDFF9252B3DE183CE35B038F57282BC9503CDFA1923EF9A95DF0D6F7B",
+            balance=IssuedCurrencyAmount(
+                currency="USD", issuer="rrrrrrrrrrrrrrrrrrrrBZbvji", value="-10"
+            ),
+            flags=393216,
+            low_limit=IssuedCurrencyAmount(
+                currency="USD", issuer="rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW", value="0"
+            ),
+            high_limit=IssuedCurrencyAmount(
+                currency="USD", issuer="rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", value="110"
+            ),
+            previous_txn_id="E3FE6EA3D48F0C2B639448020EA4F03D4F4"
+            "F8FFDB243A852A0F59177921B4879",
+            previous_txn_lgr_seq=14090896,
+            high_node="0000000000000000",
+            low_node="0000000000000000",
+            high_quality_in=None,
+            high_quality_out=None,
+            low_quality_in=None,
+            low_quality_out=None,
+        )
+        self.assertEqual(actual, expected)
+        self.assertEqual(ripple_state_json, expected.to_dict())
+
+    def test_signer_list(self):
+        actual = SignerList.from_dict(signer_list_json)
+        expected = SignerList(
+            index="A9C28A28B85CD533217F5C0A0C7767666B093FA58A0F2D80026FCC4CD932DDC7",
+            flags=0,
+            owner_node="0000000000000000",
+            previous_txn_id="5904C0DC72C58A83AEFED2FFC5386356"
+            "AA83FCA6A88C89D00646E51E687CDBE4",
+            previous_txn_lgr_seq=16061435,
+            signer_entries=[
+                SignerEntry(
+                    account="rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW",
+                    signer_weight=2,
+                ),
+                SignerEntry(
+                    account="raKEEVSGnKSD9Zyvxu4z6Pqpm4ABH8FS6n",
+                    signer_weight=1,
+                ),
+                SignerEntry(
+                    account="rUpy3eEg8rqjqfUoLeBnZkscbKbFsKXC3v",
+                    signer_weight=1,
+                ),
+            ],
+            signer_list_id=0,
+            signer_quorum=3,
+        )
+        self.assertEqual(actual, expected)
+        self.assertEqual(signer_list_json, expected.to_dict())
+
+    def test_ticket(self):
+        actual = Ticket.from_dict(ticket_json)
+        expected = Ticket(
+            index="",
+            account="rEhxGqkqPPSxQ3P25J66ft5TwpzV14k2de",
+            flags=0,
+            owner_node="0000000000000000",
+            previous_txn_id="F19AD4577212D3BEACA0F75FE1BA1644F2E85"
+            "4D46E8D62E9C95D18E9708CBFB1",
+            previous_txn_lgr_seq=4,
+            ticket_sequence=3,
+        )
+        self.assertEqual(actual, expected)
+        self.assertEqual(ticket_json, expected.to_dict())

--- a/tests/unit/models/test_ledger_object.py
+++ b/tests/unit/models/test_ledger_object.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from xrpl.models import IssuedCurrencyAmount
-from xrpl.models.ledger_objects import (  # NFTokenOffer,
+from xrpl.models.ledger_objects import (
     AccountRoot,
     Amendments,
     Check,
@@ -15,7 +15,6 @@ from xrpl.models.ledger_objects import (  # NFTokenOffer,
     NegativeUNL,
     NFToken,
     NFTokenOffer,
-    NFTokenOfferFlags,
     NFTokenPage,
     Offer,
     PayChannel,
@@ -180,7 +179,7 @@ nftoken_offer_json = {
     "769",
     "previous_txn_lgr_seq": 75443565,
     "owner_node": "17",
-    "nftoken_offer_node": "0"
+    "nftoken_offer_node": "0",
 }
 
 nftoken_page_json = {

--- a/xrpl/models/ledger_objects/__init__.py
+++ b/xrpl/models/ledger_objects/__init__.py
@@ -1,0 +1,91 @@
+"""The models for Ledger Objects"""
+
+from xrpl.models.ledger_objects.account_root import (
+    AccountRoot,
+    AccountRootFlags,
+    MDAccountRootFields,
+)
+from xrpl.models.ledger_objects.amendments import (
+    Amendments,
+    Majority,
+    MDAmendmentsFields,
+)
+from xrpl.models.ledger_objects.check import Check, MDCheckFields
+from xrpl.models.ledger_objects.deposit_preauth import (
+    DepositPreauth,
+    MDDepositPreauthFields,
+)
+from xrpl.models.ledger_objects.directory_node import (
+    DirectoryNode,
+    MDDirectoryNodeFields,
+)
+from xrpl.models.ledger_objects.escrow import Escrow, MDEscrowFields
+from xrpl.models.ledger_objects.fee_settings import FeeSettings, MDFeeSettingsFields
+from xrpl.models.ledger_objects.ledger_entry_type import LedgerEntryType
+from xrpl.models.ledger_objects.ledger_hashes import LedgerHashes, MDLedgerHashesFields
+from xrpl.models.ledger_objects.negative_unl import (
+    DisabledValidator,
+    MDNegativeUNLFields,
+    NegativeUNL,
+)
+from xrpl.models.ledger_objects.nftoken_offer import (
+    MDNFTokenOfferFields,
+    NFToken,
+    NFTokenOffer,
+    NFTokenOfferFlags,
+)
+from xrpl.models.ledger_objects.nftoken_page import MDNFTokenPageFields, NFTokenPage
+from xrpl.models.ledger_objects.offer import MDOfferFields, Offer, OfferFlag
+from xrpl.models.ledger_objects.pay_channel import MDPayChannelFields, PayChannel
+from xrpl.models.ledger_objects.ripple_state import MDRippleStateFields, RippleState
+from xrpl.models.ledger_objects.signer_list import (
+    MDSignerListFields,
+    SignerEntry,
+    SignerList,
+    SignerListFlag,
+)
+from xrpl.models.ledger_objects.ticket import MDTicketFields, Ticket
+
+__all__ = [
+    "AccountRoot",
+    "MDAccountRootFields",
+    "AccountRootFlags",
+    "Amendments",
+    "MDAmendmentsFields",
+    "Check",
+    "MDCheckFields",
+    "DepositPreauth",
+    "MDDepositPreauthFields",
+    "DirectoryNode",
+    "MDDirectoryNodeFields",
+    "DisabledValidator",
+    "Escrow",
+    "MDEscrowFields",
+    "FeeSettings",
+    "MDFeeSettingsFields",
+    "LedgerEntryType",
+    "LedgerHashes",
+    "MDLedgerHashesFields",
+    "Majority",
+    "NegativeUNL",
+    "MDNegativeUNLFields",
+    "NFToken",
+    "NFTokenOffer",
+    "MDNFTokenOfferFields",
+    "NFTokenOfferFlags",
+    "NFTokenPage",
+    "MDNFTokenPageFields",
+    "Offer",
+    "MDOfferFields",
+    "OfferFlag",
+    "PayChannel",
+    "MDPayChannelFields",
+    "RippleState",
+    "MDRippleStateFields",
+    "SignerEntry",
+    "SignerList",
+    "MDSignerListFields",
+    "SignerListFlag",
+    "Ticket",
+    "MDTicketFields",
+]

--- a/xrpl/models/ledger_objects/__init__.py
+++ b/xrpl/models/ledger_objects/__init__.py
@@ -1,91 +1,55 @@
 """The models for Ledger Objects"""
 
-from xrpl.models.ledger_objects.account_root import (
-    AccountRoot,
-    AccountRootFlags,
-    MDAccountRootFields,
-)
-from xrpl.models.ledger_objects.amendments import (
-    Amendments,
-    Majority,
-    MDAmendmentsFields,
-)
-from xrpl.models.ledger_objects.check import Check, MDCheckFields
-from xrpl.models.ledger_objects.deposit_preauth import (
-    DepositPreauth,
-    MDDepositPreauthFields,
-)
-from xrpl.models.ledger_objects.directory_node import (
-    DirectoryNode,
-    MDDirectoryNodeFields,
-)
-from xrpl.models.ledger_objects.escrow import Escrow, MDEscrowFields
-from xrpl.models.ledger_objects.fee_settings import FeeSettings, MDFeeSettingsFields
+from xrpl.models.ledger_objects.account_root import AccountRoot, AccountRootFlags
+from xrpl.models.ledger_objects.amendments import Amendments, Majority
+from xrpl.models.ledger_objects.check import Check
+from xrpl.models.ledger_objects.deposit_preauth import DepositPreauth
+from xrpl.models.ledger_objects.directory_node import DirectoryNode
+from xrpl.models.ledger_objects.escrow import Escrow
+from xrpl.models.ledger_objects.fee_settings import FeeSettings
 from xrpl.models.ledger_objects.ledger_entry_type import LedgerEntryType
-from xrpl.models.ledger_objects.ledger_hashes import LedgerHashes, MDLedgerHashesFields
-from xrpl.models.ledger_objects.negative_unl import (
-    DisabledValidator,
-    MDNegativeUNLFields,
-    NegativeUNL,
-)
+from xrpl.models.ledger_objects.ledger_hashes import LedgerHashes
+from xrpl.models.ledger_objects.negative_unl import DisabledValidator, NegativeUNL
 from xrpl.models.ledger_objects.nftoken_offer import (
-    MDNFTokenOfferFields,
     NFToken,
     NFTokenOffer,
     NFTokenOfferFlags,
 )
-from xrpl.models.ledger_objects.nftoken_page import MDNFTokenPageFields, NFTokenPage
-from xrpl.models.ledger_objects.offer import MDOfferFields, Offer, OfferFlag
-from xrpl.models.ledger_objects.pay_channel import MDPayChannelFields, PayChannel
-from xrpl.models.ledger_objects.ripple_state import MDRippleStateFields, RippleState
+from xrpl.models.ledger_objects.nftoken_page import NFTokenPage
+from xrpl.models.ledger_objects.offer import Offer, OfferFlag
+from xrpl.models.ledger_objects.pay_channel import PayChannel
+from xrpl.models.ledger_objects.ripple_state import RippleState
 from xrpl.models.ledger_objects.signer_list import (
-    MDSignerListFields,
     SignerEntry,
     SignerList,
     SignerListFlag,
 )
-from xrpl.models.ledger_objects.ticket import MDTicketFields, Ticket
+from xrpl.models.ledger_objects.ticket import Ticket
 
 __all__ = [
     "AccountRoot",
-    "MDAccountRootFields",
     "AccountRootFlags",
     "Amendments",
-    "MDAmendmentsFields",
     "Check",
-    "MDCheckFields",
     "DepositPreauth",
-    "MDDepositPreauthFields",
     "DirectoryNode",
-    "MDDirectoryNodeFields",
     "DisabledValidator",
     "Escrow",
-    "MDEscrowFields",
     "FeeSettings",
-    "MDFeeSettingsFields",
     "LedgerEntryType",
     "LedgerHashes",
-    "MDLedgerHashesFields",
     "Majority",
     "NegativeUNL",
-    "MDNegativeUNLFields",
     "NFToken",
     "NFTokenOffer",
-    "MDNFTokenOfferFields",
     "NFTokenOfferFlags",
     "NFTokenPage",
-    "MDNFTokenPageFields",
     "Offer",
-    "MDOfferFields",
     "OfferFlag",
     "PayChannel",
-    "MDPayChannelFields",
     "RippleState",
-    "MDRippleStateFields",
     "SignerEntry",
     "SignerList",
-    "MDSignerListFields",
     "SignerListFlag",
     "Ticket",
-    "MDTicketFields",
 ]

--- a/xrpl/models/ledger_objects/account_root.py
+++ b/xrpl/models/ledger_objects/account_root.py
@@ -42,36 +42,6 @@ class AccountRoot(LedgerObject):
     )
 
 
-@require_kwargs_on_init
-@dataclass(frozen=True)
-class MDAccountRootFields(LedgerObject):
-    """
-    The model for the `AccountRoot` Ledger Object when
-    represented in a transaction's metadata.
-    """
-
-    account: Optional[str] = None
-    balance: Optional[str] = None
-    flags: Optional[Union[int, AccountRootFlags]] = None
-    owner_count: Optional[int] = None
-    previous_txn_id: Optional[str] = None
-    previous_txn_lgr_seq: Optional[int] = None
-    sequence: Optional[int] = None
-    account_txn_id: Optional[str] = None
-    burned_nftokens: Optional[int] = None
-    domain: Optional[str] = None
-    email_hash: Optional[str] = None
-    message_key: Optional[str] = None
-    minted_nftokens: Optional[int] = None
-    nftoken_minter: Optional[str] = None
-    regular_key: Optional[str] = None
-    ticket_count: Optional[int] = None
-    ticket_size: Optional[int] = None
-    transfer_rate: Optional[int] = None
-    wallet_locator: Optional[str] = None
-    wallet_size: Optional[int] = None
-
-
 class AccountRootFlags(Enum):
     """The flags for the `AccountRoot` Ledger Object"""
 

--- a/xrpl/models/ledger_objects/account_root.py
+++ b/xrpl/models/ledger_objects/account_root.py
@@ -1,0 +1,86 @@
+"""Models for the Ledger Object `AccountRoot`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional, Union
+
+from xrpl.models.ledger_objects.ledger_entry_type import LedgerEntryType
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.required import REQUIRED
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class AccountRoot(LedgerObject):
+    """The model for the `AccountRoot` Ledger Object"""
+
+    account: str = REQUIRED  # type: ignore
+    balance: str = REQUIRED  # type: ignore
+    flags: Union[int, AccountRootFlags] = REQUIRED  # type: ignore
+    owner_count: int = REQUIRED  # type: ignore
+    previous_txn_id: str = REQUIRED  # type: ignore
+    previous_txn_lgr_seq: int = REQUIRED  # type: ignore
+    sequence: int = REQUIRED  # type: ignore
+    account_txn_id: Optional[str] = None
+    burned_nftokens: Optional[int] = None
+    domain: Optional[str] = None
+    email_hash: Optional[str] = None
+    message_key: Optional[str] = None
+    minted_nftokens: Optional[int] = None
+    nftoken_minter: Optional[str] = None
+    regular_key: Optional[str] = None
+    ticket_count: Optional[int] = None
+    ticket_size: Optional[int] = None
+    transfer_rate: Optional[int] = None
+    wallet_locator: Optional[str] = None
+    wallet_size: Optional[int] = None
+    ledger_entry_type: LedgerEntryType = field(
+        default=LedgerEntryType.ACCOUNT_ROOT, init=False
+    )
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class MDAccountRootFields(LedgerObject):
+    """
+    The model for the `AccountRoot` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    account: Optional[str] = None
+    balance: Optional[str] = None
+    flags: Optional[Union[int, AccountRootFlags]] = None
+    owner_count: Optional[int] = None
+    previous_txn_id: Optional[str] = None
+    previous_txn_lgr_seq: Optional[int] = None
+    sequence: Optional[int] = None
+    account_txn_id: Optional[str] = None
+    burned_nftokens: Optional[int] = None
+    domain: Optional[str] = None
+    email_hash: Optional[str] = None
+    message_key: Optional[str] = None
+    minted_nftokens: Optional[int] = None
+    nftoken_minter: Optional[str] = None
+    regular_key: Optional[str] = None
+    ticket_count: Optional[int] = None
+    ticket_size: Optional[int] = None
+    transfer_rate: Optional[int] = None
+    wallet_locator: Optional[str] = None
+    wallet_size: Optional[int] = None
+
+
+class AccountRootFlags(Enum):
+    """The flags for the `AccountRoot` Ledger Object"""
+
+    LSF_DEFAULT_RIPPLE = 0x00800000
+    LSF_DEPOSIT_AUTH = 0x01000000
+    LSF_DISABLE_MASTER = 0x00100000
+    LSF_DISALLOW_XRP = 0x00080000
+    LSF_GLOBAL_FREEZE = 0x00400000
+    LSF_NO_FREEZE = 0x00200000
+    LSF_PASSWORD_SPENT = 0x00010000
+    LSF_REQUIRE_AUTH = 0x00040000
+    LSF_REQUIRE_DEST_TAG = 0x00020000

--- a/xrpl/models/ledger_objects/amendments.py
+++ b/xrpl/models/ledger_objects/amendments.py
@@ -1,0 +1,50 @@
+"""Models for the Ledger Object `Amendments`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from xrpl.models.ledger_objects.ledger_entry_type import LedgerEntryType
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.nested_model import NestedModel
+from xrpl.models.required import REQUIRED
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class Amendments(LedgerObject):
+    """The model for the `Amendments` Ledger Object"""
+
+    # always 0
+    flags: int = REQUIRED  # type: ignore
+    amendments: Optional[List[str]] = None
+    majorities: Optional[List[Majority]] = None
+    ledger_entry_type: LedgerEntryType = field(
+        default=LedgerEntryType.AMENDMENTS,
+        init=False,
+    )
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class MDAmendmentsFields(LedgerObject):
+    """
+    The model for the `Amendments` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    # always 0
+    flags: Optional[int] = None
+    amendments: Optional[List[str]] = None
+    majorities: Optional[List[Majority]] = None
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class Majority(NestedModel):
+    """A model for the `Majority` object"""
+
+    amendment: str = REQUIRED  # type: ignore
+    close_time: int = REQUIRED  # type: ignore

--- a/xrpl/models/ledger_objects/amendments.py
+++ b/xrpl/models/ledger_objects/amendments.py
@@ -29,20 +29,6 @@ class Amendments(LedgerObject):
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class MDAmendmentsFields(LedgerObject):
-    """
-    The model for the `Amendments` Ledger Object when
-    represented in a transaction's metadata.
-    """
-
-    # always 0
-    flags: Optional[int] = None
-    amendments: Optional[List[str]] = None
-    majorities: Optional[List[Majority]] = None
-
-
-@require_kwargs_on_init
-@dataclass(frozen=True)
 class Majority(NestedModel):
     """A model for the `Majority` object"""
 

--- a/xrpl/models/ledger_objects/check.py
+++ b/xrpl/models/ledger_objects/check.py
@@ -35,27 +35,3 @@ class Check(LedgerObject):
         default=LedgerEntryType.CHECK,
         init=False,
     )
-
-
-@require_kwargs_on_init
-@dataclass(frozen=True)
-class MDCheckFields(LedgerObject):
-    """
-    The model for the `Check` Ledger Object when
-    represented in a transaction's metadata.
-    """
-
-    account: Optional[str] = None
-    destination: Optional[str] = None
-    # always 0
-    flags: Optional[int] = None
-    owner_node: Optional[str] = None
-    previous_txn_id: Optional[str] = None
-    previous_txn_lgr_seq: Optional[int] = None
-    send_max: Optional[Union[str, IssuedCurrencyAmount]] = None
-    sequence: Optional[int] = None
-    destination_node: Optional[str] = None
-    destination_tag: Optional[int] = None
-    expiration: Optional[int] = None
-    invoice_id: Optional[str] = None
-    source_tag: Optional[int] = None

--- a/xrpl/models/ledger_objects/check.py
+++ b/xrpl/models/ledger_objects/check.py
@@ -1,0 +1,61 @@
+"""Models for the Ledger Object `Check`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional, Union
+
+from xrpl.models.amounts.issued_currency_amount import IssuedCurrencyAmount
+from xrpl.models.ledger_objects.ledger_entry_type import LedgerEntryType
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.required import REQUIRED
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class Check(LedgerObject):
+    """The model for the `Check` Ledger Object"""
+
+    account: str = REQUIRED  # type: ignore
+    destination: str = REQUIRED  # type: ignore
+    # always 0
+    flags: int = REQUIRED  # type: ignore
+    owner_node: str = REQUIRED  # type: ignore
+    previous_txn_id: str = REQUIRED  # type: ignore
+    previous_txn_lgr_seq: int = REQUIRED  # type: ignore
+    send_max: Union[str, IssuedCurrencyAmount] = REQUIRED  # type: ignore
+    sequence: int = REQUIRED  # type: ignore
+    destination_node: Optional[str] = None
+    destination_tag: Optional[int] = None
+    expiration: Optional[int] = None
+    invoice_id: Optional[str] = None
+    source_tag: Optional[int] = None
+    ledger_entry_type: LedgerEntryType = field(
+        default=LedgerEntryType.CHECK,
+        init=False,
+    )
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class MDCheckFields(LedgerObject):
+    """
+    The model for the `Check` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    account: Optional[str] = None
+    destination: Optional[str] = None
+    # always 0
+    flags: Optional[int] = None
+    owner_node: Optional[str] = None
+    previous_txn_id: Optional[str] = None
+    previous_txn_lgr_seq: Optional[int] = None
+    send_max: Optional[Union[str, IssuedCurrencyAmount]] = None
+    sequence: Optional[int] = None
+    destination_node: Optional[str] = None
+    destination_tag: Optional[int] = None
+    expiration: Optional[int] = None
+    invoice_id: Optional[str] = None
+    source_tag: Optional[int] = None

--- a/xrpl/models/ledger_objects/deposit_preauth.py
+++ b/xrpl/models/ledger_objects/deposit_preauth.py
@@ -1,0 +1,46 @@
+"""Models for the Ledger Object `DepositPreauth`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from xrpl.models.ledger_objects.ledger_entry_type import LedgerEntryType
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.required import REQUIRED
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class DepositPreauth(LedgerObject):
+    """The model for the `DepositPreauth` Ledger Object"""
+
+    account: str = REQUIRED  # type: ignore
+    authorize: str = REQUIRED  # type: ignore
+    # always 0
+    flags: int = REQUIRED  # type: ignore
+    owner_node: str = REQUIRED  # type: ignore
+    previous_txn_id: str = REQUIRED  # type: ignore
+    previous_txn_lgr_seq: int = REQUIRED  # type: ignore
+    ledger_entry_type: LedgerEntryType = field(
+        default=LedgerEntryType.DEPOSIT_PREAUTH,
+        init=False,
+    )
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class MDDepositPreauthFields(LedgerObject):
+    """
+    The model for the `DepositPreauth` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    account: Optional[str] = None
+    authorize: Optional[str] = None
+    # always 0
+    flags: Optional[int] = None
+    owner_node: Optional[str] = None
+    previous_txn_id: Optional[str] = None
+    previous_txn_lgr_seq: Optional[int] = None

--- a/xrpl/models/ledger_objects/deposit_preauth.py
+++ b/xrpl/models/ledger_objects/deposit_preauth.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional
 
 from xrpl.models.ledger_objects.ledger_entry_type import LedgerEntryType
 from xrpl.models.ledger_objects.ledger_object import LedgerObject
@@ -27,20 +26,3 @@ class DepositPreauth(LedgerObject):
         default=LedgerEntryType.DEPOSIT_PREAUTH,
         init=False,
     )
-
-
-@require_kwargs_on_init
-@dataclass(frozen=True)
-class MDDepositPreauthFields(LedgerObject):
-    """
-    The model for the `DepositPreauth` Ledger Object when
-    represented in a transaction's metadata.
-    """
-
-    account: Optional[str] = None
-    authorize: Optional[str] = None
-    # always 0
-    flags: Optional[int] = None
-    owner_node: Optional[str] = None
-    previous_txn_id: Optional[str] = None
-    previous_txn_lgr_seq: Optional[int] = None

--- a/xrpl/models/ledger_objects/directory_node.py
+++ b/xrpl/models/ledger_objects/directory_node.py
@@ -1,0 +1,56 @@
+"""Models for the Ledger Object `DirectoryNode`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from xrpl.models.ledger_objects.ledger_entry_type import LedgerEntryType
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.required import REQUIRED
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class DirectoryNode(LedgerObject):
+    """The model for the `DirectoryNode` Ledger Object"""
+
+    # always 0
+    flags: int = REQUIRED  # type: ignore
+    root_index: str = REQUIRED  # type: ignore
+    indexes: List[str] = REQUIRED  # type: ignore
+    index_next: Optional[int] = None
+    index_previous: Optional[int] = None
+    owner: Optional[str] = None
+    exchange_rate: Optional[str] = None
+    taker_pays_currency: Optional[str] = None
+    taker_pays_issuer: Optional[str] = None
+    taker_gets_currency: Optional[str] = None
+    taker_gets_issuer: Optional[str] = None
+    ledger_entry_type: LedgerEntryType = field(
+        default=LedgerEntryType.DIRECTORY_NODE,
+        init=False,
+    )
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class MDDirectoryNodeFields(LedgerObject):
+    """
+    The model for the `DirectoryNode` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    # always 0
+    flags: Optional[int] = None
+    root_index: Optional[str] = None
+    indexes: Optional[List[str]] = None
+    index_next: Optional[int] = None
+    index_previous: Optional[int] = None
+    owner: Optional[str] = None
+    exchange_rate: Optional[str] = None
+    taker_pays_currency: Optional[str] = None
+    taker_pays_issuer: Optional[str] = None
+    taker_gets_currency: Optional[str] = None
+    taker_gets_issuer: Optional[str] = None

--- a/xrpl/models/ledger_objects/directory_node.py
+++ b/xrpl/models/ledger_objects/directory_node.py
@@ -32,25 +32,3 @@ class DirectoryNode(LedgerObject):
         default=LedgerEntryType.DIRECTORY_NODE,
         init=False,
     )
-
-
-@require_kwargs_on_init
-@dataclass(frozen=True)
-class MDDirectoryNodeFields(LedgerObject):
-    """
-    The model for the `DirectoryNode` Ledger Object when
-    represented in a transaction's metadata.
-    """
-
-    # always 0
-    flags: Optional[int] = None
-    root_index: Optional[str] = None
-    indexes: Optional[List[str]] = None
-    index_next: Optional[int] = None
-    index_previous: Optional[int] = None
-    owner: Optional[str] = None
-    exchange_rate: Optional[str] = None
-    taker_pays_currency: Optional[str] = None
-    taker_pays_issuer: Optional[str] = None
-    taker_gets_currency: Optional[str] = None
-    taker_gets_issuer: Optional[str] = None

--- a/xrpl/models/ledger_objects/escrow.py
+++ b/xrpl/models/ledger_objects/escrow.py
@@ -1,0 +1,59 @@
+"""Models for the Ledger Object `Escrow`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from xrpl.models.ledger_objects.ledger_entry_type import LedgerEntryType
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.required import REQUIRED
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class Escrow(LedgerObject):
+    """The model for the `Escrow` Ledger Object"""
+
+    account: str = REQUIRED  # type: ignore
+    amount: str = REQUIRED  # type: ignore
+    destination: str = REQUIRED  # type: ignore
+    # always 0
+    flags: int = REQUIRED  # type: ignore
+    owner_node: str = REQUIRED  # type: ignore
+    previous_txn_id: str = REQUIRED  # type: ignore
+    previous_txn_lgr_seq: int = REQUIRED  # type: ignore
+    condition: Optional[str] = None
+    cancel_after: Optional[int] = None
+    destination_node: Optional[str] = None
+    destination_tag: Optional[int] = None
+    finish_after: Optional[int] = None
+    source_tag: Optional[int] = None
+    ledger_entry_type: LedgerEntryType = field(
+        default=LedgerEntryType.ESCROW, init=False
+    )
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class MDEscrowFields(LedgerObject):
+    """
+    The model for the `Escrow` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    account: Optional[str] = None
+    amount: Optional[str] = None
+    destination: Optional[str] = None
+    # always 0
+    flags: Optional[int] = None
+    owner_node: Optional[str] = None
+    previous_txn_id: Optional[str] = None
+    previous_txn_lgr_seq: Optional[int] = None
+    condition: Optional[str] = None
+    cancel_after: Optional[int] = None
+    destination_node: Optional[str] = None
+    destination_tag: Optional[int] = None
+    finish_after: Optional[int] = None
+    source_tag: Optional[int] = None

--- a/xrpl/models/ledger_objects/escrow.py
+++ b/xrpl/models/ledger_objects/escrow.py
@@ -33,27 +33,3 @@ class Escrow(LedgerObject):
     ledger_entry_type: LedgerEntryType = field(
         default=LedgerEntryType.ESCROW, init=False
     )
-
-
-@require_kwargs_on_init
-@dataclass(frozen=True)
-class MDEscrowFields(LedgerObject):
-    """
-    The model for the `Escrow` Ledger Object when
-    represented in a transaction's metadata.
-    """
-
-    account: Optional[str] = None
-    amount: Optional[str] = None
-    destination: Optional[str] = None
-    # always 0
-    flags: Optional[int] = None
-    owner_node: Optional[str] = None
-    previous_txn_id: Optional[str] = None
-    previous_txn_lgr_seq: Optional[int] = None
-    condition: Optional[str] = None
-    cancel_after: Optional[int] = None
-    destination_node: Optional[str] = None
-    destination_tag: Optional[int] = None
-    finish_after: Optional[int] = None
-    source_tag: Optional[int] = None

--- a/xrpl/models/ledger_objects/fee_settings.py
+++ b/xrpl/models/ledger_objects/fee_settings.py
@@ -1,0 +1,43 @@
+"""Models for the Ledger Object `FeeSettings`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from xrpl.models.ledger_objects.ledger_entry_type import LedgerEntryType
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.required import REQUIRED
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class FeeSettings(LedgerObject):
+    """The model for the `FeeSettings` Ledger Object"""
+
+    base_fee: str = REQUIRED  # type: ignore
+    # always 0
+    flags: int = REQUIRED  # type: ignore
+    reference_fee_units: int = REQUIRED  # type: ignore
+    reserve_base: int = REQUIRED  # type: ignore
+    reserve_increment: int = REQUIRED  # type: ignore
+    ledger_entry_type: LedgerEntryType = field(
+        default=LedgerEntryType.FEE_SETTINGS, init=False
+    )
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class MDFeeSettingsFields(LedgerObject):
+    """
+    The model for the `FeeSettings` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    base_fee: Optional[str] = None
+    # always 0
+    flags: Optional[int] = None
+    reference_fee_units: Optional[int] = None
+    reserve_base: Optional[int] = None
+    reserve_increment: Optional[int] = None

--- a/xrpl/models/ledger_objects/fee_settings.py
+++ b/xrpl/models/ledger_objects/fee_settings.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional
 
 from xrpl.models.ledger_objects.ledger_entry_type import LedgerEntryType
 from xrpl.models.ledger_objects.ledger_object import LedgerObject
@@ -25,19 +24,3 @@ class FeeSettings(LedgerObject):
     ledger_entry_type: LedgerEntryType = field(
         default=LedgerEntryType.FEE_SETTINGS, init=False
     )
-
-
-@require_kwargs_on_init
-@dataclass(frozen=True)
-class MDFeeSettingsFields(LedgerObject):
-    """
-    The model for the `FeeSettings` Ledger Object when
-    represented in a transaction's metadata.
-    """
-
-    base_fee: Optional[str] = None
-    # always 0
-    flags: Optional[int] = None
-    reference_fee_units: Optional[int] = None
-    reserve_base: Optional[int] = None
-    reserve_increment: Optional[int] = None

--- a/xrpl/models/ledger_objects/ledger_entry_type.py
+++ b/xrpl/models/ledger_objects/ledger_entry_type.py
@@ -1,0 +1,24 @@
+"""The different ledger entry types"""
+
+from enum import Enum
+
+
+class LedgerEntryType(str, Enum):
+    """The different ledger entry types"""
+
+    ACCOUNT_ROOT = "AccountRoot"
+    AMENDMENTS = "Amendments"
+    CHECK = "Check"
+    DEPOSIT_PREAUTH = "DepositPreauth"
+    DIRECTORY_NODE = "DirectoryNode"
+    ESCROW = "Escrow"
+    FEE_SETTINGS = "FeeSettings"
+    LEDGER_HASHES = "LedgerHashes"
+    NEGATIVE_UNL = "NegativeUNL"
+    NFTOKEN_OFFER = "NFTokenOffer"
+    NFTOKEN_PAGE = "NFTokenPage"
+    OFFER = "Offer"
+    PAY_CHANNEL = "PayChannel"
+    RIPPLE_STATE = "RippleState"
+    SIGNER_LIST = "SignerList"
+    TICKET = "Ticket"

--- a/xrpl/models/ledger_objects/ledger_hashes.py
+++ b/xrpl/models/ledger_objects/ledger_hashes.py
@@ -1,0 +1,42 @@
+"""Models for the Ledger Object `LedgerHashes`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from xrpl.models.ledger_objects.ledger_entry_type import LedgerEntryType
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.required import REQUIRED
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class LedgerHashes(LedgerObject):
+    """The model for the `LedgerHashes` Ledger Object"""
+
+    first_ledger_sequence: int = REQUIRED  # type: ignore
+    last_ledger_sequence: int = REQUIRED  # type: ignore
+    hashes: List[str] = REQUIRED  # type: ignore
+    # always 0
+    flags: int = REQUIRED  # type: ignore
+    ledger_entry_type: LedgerEntryType = field(
+        default=LedgerEntryType.LEDGER_HASHES,
+        init=False,
+    )
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class MDLedgerHashesFields(LedgerObject):
+    """
+    The model for the `LedgerHashes` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    first_ledger_sequence: Optional[int] = None
+    last_ledger_sequence: Optional[int] = None
+    hashes: Optional[List[str]] = None
+    # always 0
+    flags: Optional[int] = None

--- a/xrpl/models/ledger_objects/ledger_hashes.py
+++ b/xrpl/models/ledger_objects/ledger_hashes.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import List
 
 from xrpl.models.ledger_objects.ledger_entry_type import LedgerEntryType
 from xrpl.models.ledger_objects.ledger_object import LedgerObject
@@ -25,18 +25,3 @@ class LedgerHashes(LedgerObject):
         default=LedgerEntryType.LEDGER_HASHES,
         init=False,
     )
-
-
-@require_kwargs_on_init
-@dataclass(frozen=True)
-class MDLedgerHashesFields(LedgerObject):
-    """
-    The model for the `LedgerHashes` Ledger Object when
-    represented in a transaction's metadata.
-    """
-
-    first_ledger_sequence: Optional[int] = None
-    last_ledger_sequence: Optional[int] = None
-    hashes: Optional[List[str]] = None
-    # always 0
-    flags: Optional[int] = None

--- a/xrpl/models/ledger_objects/ledger_object.py
+++ b/xrpl/models/ledger_objects/ledger_object.py
@@ -1,0 +1,137 @@
+"""A model for Ledger Objects"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Type, TypeVar
+
+from xrpl.models.base_model import BaseModel
+from xrpl.models.exceptions import XRPLModelException
+from xrpl.models.ledger_objects.ledger_entry_type import LedgerEntryType
+
+# TODO: REMOVE if optional is needed
+# from xrpl.models.required import REQUIRED
+from xrpl.models.utils import require_kwargs_on_init
+
+L = TypeVar("L", bound="LedgerObject")
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class LedgerObject(BaseModel):
+    """The base model for a Ledger Object."""
+
+    # TODO: Try without optional
+    ledger_entry_type: Optional[LedgerEntryType] = None
+    index: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls: Type[L], value: Dict[str, Any]) -> L:
+        """Derive the model from a dict.
+
+        Args:
+            value: The dictionary to derive from.
+
+        Returns:
+            L: The Ledger Object.
+
+        Raises:
+            XRPLModelException: If there is no Ledger Object type is
+                provided or the type mismatches the constructor type.
+        """
+        if cls.__name__ == "LedgerObject":
+            if "ledger_entry_type" not in value:
+                raise XRPLModelException(
+                    "Ledger Object does not include ledger_entry_type."
+                )
+            correct_type = cls.get_ledger_object_type(value["ledger_entry_type"])
+            return correct_type.from_dict(value)  # type: ignore
+        elif cls.__name__ in ["FinalFields", "PreviousFields", "NewFields"]:
+            if "ledger_entry_type" not in value:
+                raise XRPLModelException(
+                    "Ledger Object does not include ledger_entry_type."
+                )
+            correct_type = cls.get_md_ledger_object_type(value["ledger_entry_type"])
+            del value["ledger_entry_type"]
+            return correct_type.from_dict(value)  # type: ignore
+        else:
+            if "ledger_entry_type" in value:
+                ledger_entry_type = value["ledger_entry_type"]
+                if (
+                    cls.get_ledger_object_type(ledger_entry_type).__name__
+                    != cls.__name__
+                    and cls.get_md_ledger_object_type(ledger_entry_type).__name__
+                    != cls.__name__
+                ):
+                    raise XRPLModelException(
+                        f"Using wrong constructor: using {cls.__name__} constructor "
+                        f"with ledger object type {value['ledger_entry_type']}."
+                    )
+                value = {**value}
+                del value["ledger_entry_type"]
+            return super(LedgerObject, cls).from_dict(value)
+
+    @classmethod
+    def get_ledger_object_type(
+        cls: Type[LedgerObject], ledger_object_type: str
+    ) -> Type[LedgerObject]:
+        """Get the correct model
+
+        Args:
+            ledger_object_type: The ledger object type willing to get.
+
+        Returns:
+            Type[AffectedNode]: The correct ledger object type.
+
+        Raises:
+            XRPLModelException: If the Ledger Object type does not exist.
+        """
+        import xrpl.models.ledger_objects as ledger_object_models
+
+        ledger_object_types: Dict[str, Type[LedgerObject]] = {
+            lgr_obj.value: getattr(ledger_object_models, lgr_obj)
+            for lgr_obj in ledger_object_models.ledger_entry_type.LedgerEntryType
+        }
+        if ledger_object_type in ledger_object_types:
+            return ledger_object_types[ledger_object_type]
+
+        raise XRPLModelException(
+            f"{ledger_object_type} is not a valid Ledger Object type."
+        )
+
+    @classmethod
+    def get_md_ledger_object_type(
+        cls: Type[LedgerObject], ledger_object_type: str
+    ) -> Type[LedgerObject]:
+        """
+        Get the correct model
+
+        Args:
+            ledger_object_type: The object type willing to get.
+
+        Returns:
+            Type[LedgerObject]: The correct ledger object type.
+
+        Raises:
+            XRPLModelException: If the Ledger Object type does not exist.
+        """
+        import xrpl.models.ledger_objects as ledger_object_models
+
+        ledger_object_types: Dict[str, Type[LedgerObject]] = {
+            lgr_obj.value: getattr(ledger_object_models, f"MD{lgr_obj}Fields")
+            for lgr_obj in ledger_object_models.ledger_entry_type.LedgerEntryType
+        }
+        if ledger_object_type in ledger_object_types:
+            return ledger_object_types[ledger_object_type]
+
+        raise XRPLModelException(
+            f"{ledger_object_type} is not a valid Ledger Object type."
+        )
+
+    def __getitem__(self: LedgerObject, field_name: str) -> Any:
+        """Enable to get the fields like from a `dict`"""
+        if field_name == self.__class__.__name__ or self.__class__.__name__ == "".join(
+            [word.capitalize() for word in field_name.split("_")]
+        ):
+            return self
+        return self.__getattribute__(field_name)

--- a/xrpl/models/ledger_objects/negative_unl.py
+++ b/xrpl/models/ledger_objects/negative_unl.py
@@ -28,20 +28,6 @@ class NegativeUNL(LedgerObject):
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class MDNegativeUNLFields(LedgerObject):
-    """
-    The model for the `NegativeUNL` Ledger Object when
-    represented in a transaction's metadata.
-    """
-
-    flags: Optional[int] = None
-    disabled_validators: Optional[List[DisabledValidator]] = None
-    validator_to_disable: Optional[str] = None
-    validator_to_enable: Optional[str] = None
-
-
-@require_kwargs_on_init
-@dataclass(frozen=True)
 class DisabledValidator(NestedModel):
     """A model for the `DisabledValidator` object"""
 

--- a/xrpl/models/ledger_objects/negative_unl.py
+++ b/xrpl/models/ledger_objects/negative_unl.py
@@ -1,0 +1,49 @@
+"""Models for the Ledger Object `NegativeUNL`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from xrpl.models.ledger_objects.ledger_entry_type import LedgerEntryType
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.nested_model import NestedModel
+from xrpl.models.required import REQUIRED
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class NegativeUNL(LedgerObject):
+    """The model for the `NegativeUNL` Ledger Object"""
+
+    flags: int = REQUIRED  # type: ignore
+    disabled_validators: Optional[List[DisabledValidator]] = None
+    validator_to_disable: Optional[str] = None
+    validator_to_enable: Optional[str] = None
+    ledger_entry_type: LedgerEntryType = field(
+        default=LedgerEntryType.NEGATIVE_UNL, init=False
+    )
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class MDNegativeUNLFields(LedgerObject):
+    """
+    The model for the `NegativeUNL` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    flags: Optional[int] = None
+    disabled_validators: Optional[List[DisabledValidator]] = None
+    validator_to_disable: Optional[str] = None
+    validator_to_enable: Optional[str] = None
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class DisabledValidator(NestedModel):
+    """A model for the `DisabledValidator` object"""
+
+    first_ledger_sequence: int = REQUIRED  # type: ignore
+    public_key: str = REQUIRED  # type: ignore

--- a/xrpl/models/ledger_objects/nftoken_offer.py
+++ b/xrpl/models/ledger_objects/nftoken_offer.py
@@ -1,0 +1,69 @@
+"""Models for the Ledger Object `NFTokenOffer`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional, Union
+
+from xrpl.models.base_model import BaseModel
+from xrpl.models.ledger_objects.ledger_entry_type import LedgerEntryType
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.required import REQUIRED
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class NFTokenOffer(LedgerObject):
+    """The model for the `NFTokenOffer` Ledger Object"""
+
+    amount: Union[str, NFToken] = REQUIRED  # type: ignore
+    flags: int = REQUIRED  # type: ignore
+    nftoken_id: str = REQUIRED  # type: ignore
+    owner: str = REQUIRED  # type: ignore
+    previous_txn_id: str = REQUIRED  # type: ignore
+    previous_txn_lgr_seq: int = REQUIRED  # type: ignore
+    destination: Optional[str] = None
+    expiration: Optional[int] = None
+    owner_node: Optional[str] = None
+    nftoken_offer_node: Optional[str] = None
+    ledger_entry_type: LedgerEntryType = field(
+        default=LedgerEntryType.NFTOKEN_OFFER,
+        init=False,
+    )
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class MDNFTokenOfferFields(LedgerObject):
+    """
+    The model for the `NFTokenOffer` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    amount: Optional[Union[str, NFToken]] = None
+    flags: Optional[int] = None
+    nftoken_id: Optional[str] = None
+    owner: Optional[str] = None
+    previous_txn_id: Optional[str] = None
+    previous_txn_lgr_seq: Optional[int] = None
+    destination: Optional[str] = None
+    expiration: Optional[int] = None
+    owner_node: Optional[str] = None
+    nftoken_offer_node: Optional[str] = None
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class NFToken(BaseModel):  #
+    """A model for the `NFToken` object"""
+
+    nftoken_id: str = REQUIRED  # type: ignore
+    uri: str = REQUIRED  # type: ignore
+
+
+class NFTokenOfferFlags(Enum):
+    """The flags for the `NFTokenOffer` Ledger Object"""
+
+    LSF_SELL_NFTOKEN = 0x00000001

--- a/xrpl/models/ledger_objects/nftoken_offer.py
+++ b/xrpl/models/ledger_objects/nftoken_offer.py
@@ -19,7 +19,7 @@ class NFTokenOffer(LedgerObject):
     """The model for the `NFTokenOffer` Ledger Object"""
 
     amount: Union[str, NFToken] = REQUIRED  # type: ignore
-    flags: int = REQUIRED  # type: ignore
+    flags: Union[int, NFTokenOfferFlags] = REQUIRED  # type: ignore
     nftoken_id: str = REQUIRED  # type: ignore
     owner: str = REQUIRED  # type: ignore
     previous_txn_id: str = REQUIRED  # type: ignore

--- a/xrpl/models/ledger_objects/nftoken_offer.py
+++ b/xrpl/models/ledger_objects/nftoken_offer.py
@@ -36,26 +36,6 @@ class NFTokenOffer(LedgerObject):
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class MDNFTokenOfferFields(LedgerObject):
-    """
-    The model for the `NFTokenOffer` Ledger Object when
-    represented in a transaction's metadata.
-    """
-
-    amount: Optional[Union[str, NFToken]] = None
-    flags: Optional[int] = None
-    nftoken_id: Optional[str] = None
-    owner: Optional[str] = None
-    previous_txn_id: Optional[str] = None
-    previous_txn_lgr_seq: Optional[int] = None
-    destination: Optional[str] = None
-    expiration: Optional[int] = None
-    owner_node: Optional[str] = None
-    nftoken_offer_node: Optional[str] = None
-
-
-@require_kwargs_on_init
-@dataclass(frozen=True)
 class NFToken(BaseModel):  #
     """A model for the `NFToken` object"""
 

--- a/xrpl/models/ledger_objects/nftoken_page.py
+++ b/xrpl/models/ledger_objects/nftoken_page.py
@@ -27,20 +27,3 @@ class NFTokenPage(LedgerObject):
         default=LedgerEntryType.NFTOKEN_PAGE,
         init=False,
     )
-
-
-@require_kwargs_on_init
-@dataclass(frozen=True)
-class MDNFTokenPageFields(LedgerObject):
-    """
-    The model for the `NFTokenPage` Ledger Object when
-    represented in a transaction's metadata.
-    """
-
-    previous_page_min: Optional[str] = None
-    next_page_min: Optional[str] = None
-    previous_token_page: Optional[str] = None
-    previous_token_next: Optional[str] = None
-    previous_txn_id: Optional[str] = None
-    previous_txn_lgr_seq: Optional[int] = None
-    nftokens: Optional[List[NFToken]] = None

--- a/xrpl/models/ledger_objects/nftoken_page.py
+++ b/xrpl/models/ledger_objects/nftoken_page.py
@@ -1,0 +1,46 @@
+"""Models for the Ledger Object `NFTokenPage`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from xrpl.models.ledger_objects.ledger_entry_type import LedgerEntryType
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.ledger_objects.nftoken_offer import NFToken
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class NFTokenPage(LedgerObject):
+    """The model for the `NFTokenPage` Ledger Object"""
+
+    previous_page_min: Optional[str] = None
+    next_page_min: Optional[str] = None
+    previous_token_page: Optional[str] = None
+    previous_token_next: Optional[str] = None
+    previous_txn_id: Optional[str] = None
+    previous_txn_lgr_seq: Optional[int] = None
+    nftokens: Optional[List[NFToken]] = None
+    ledger_entry_type: LedgerEntryType = field(
+        default=LedgerEntryType.NFTOKEN_PAGE,
+        init=False,
+    )
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class MDNFTokenPageFields(LedgerObject):
+    """
+    The model for the `NFTokenPage` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    previous_page_min: Optional[str] = None
+    next_page_min: Optional[str] = None
+    previous_token_page: Optional[str] = None
+    previous_token_next: Optional[str] = None
+    previous_txn_id: Optional[str] = None
+    previous_txn_lgr_seq: Optional[int] = None
+    nftokens: Optional[List[NFToken]] = None

--- a/xrpl/models/ledger_objects/offer.py
+++ b/xrpl/models/ledger_objects/offer.py
@@ -1,0 +1,63 @@
+"""Models for the Ledger Object `Offer`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional, Union
+
+from xrpl.models.amounts.issued_currency_amount import IssuedCurrencyAmount
+from xrpl.models.ledger_objects.ledger_entry_type import LedgerEntryType
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.required import REQUIRED
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class Offer(LedgerObject):
+    """The model for the `Offer` Ledger Object"""
+
+    account: str = REQUIRED  # type: ignore
+    taker_gets: Union[str, IssuedCurrencyAmount] = REQUIRED  # type: ignore
+    taker_pays: Union[str, IssuedCurrencyAmount] = REQUIRED  # type: ignore
+    sequence: int = REQUIRED  # type: ignore
+    flags: int = REQUIRED  # type: ignore
+    book_directory: str = REQUIRED  # type: ignore
+    book_node: str = REQUIRED  # type: ignore
+    owner_node: str = REQUIRED  # type: ignore
+    previous_txn_id: str = REQUIRED  # type: ignore
+    previous_txn_lgr_seq: int = REQUIRED  # type: ignore
+    expiration: Optional[int] = None
+    ledger_entry_type: LedgerEntryType = field(
+        default=LedgerEntryType.OFFER,
+        init=False,
+    )
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class MDOfferFields(LedgerObject):
+    """
+    The model for the `Offer` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    account: Optional[str] = None
+    taker_gets: Optional[Union[str, IssuedCurrencyAmount]] = None
+    taker_pays: Optional[Union[str, IssuedCurrencyAmount]] = None
+    sequence: Optional[int] = None
+    flags: Optional[int] = None
+    book_directory: Optional[str] = None
+    book_node: Optional[str] = None
+    owner_node: Optional[str] = None
+    previous_txn_id: Optional[str] = None
+    previous_txn_lgr_seq: Optional[int] = None
+    expiration: Optional[int] = None
+
+
+class OfferFlag(Enum):
+    """The flags for the `Offer` Ledger Object"""
+
+    LSF_PASSIVE = 0x00010000
+    LSF_SELL = 0x00020000

--- a/xrpl/models/ledger_objects/offer.py
+++ b/xrpl/models/ledger_objects/offer.py
@@ -35,27 +35,6 @@ class Offer(LedgerObject):
     )
 
 
-@require_kwargs_on_init
-@dataclass(frozen=True)
-class MDOfferFields(LedgerObject):
-    """
-    The model for the `Offer` Ledger Object when
-    represented in a transaction's metadata.
-    """
-
-    account: Optional[str] = None
-    taker_gets: Optional[Union[str, IssuedCurrencyAmount]] = None
-    taker_pays: Optional[Union[str, IssuedCurrencyAmount]] = None
-    sequence: Optional[int] = None
-    flags: Optional[int] = None
-    book_directory: Optional[str] = None
-    book_node: Optional[str] = None
-    owner_node: Optional[str] = None
-    previous_txn_id: Optional[str] = None
-    previous_txn_lgr_seq: Optional[int] = None
-    expiration: Optional[int] = None
-
-
 class OfferFlag(Enum):
     """The flags for the `Offer` Ledger Object"""
 

--- a/xrpl/models/ledger_objects/pay_channel.py
+++ b/xrpl/models/ledger_objects/pay_channel.py
@@ -1,0 +1,64 @@
+"""Models for the Ledger Object `PayChannel`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from xrpl.models.ledger_objects.ledger_entry_type import LedgerEntryType
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.required import REQUIRED
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class PayChannel(LedgerObject):
+    """The model for the `PayChannel` Ledger Object"""
+
+    account: str = REQUIRED  # type: ignore
+    amount: str = REQUIRED  # type: ignore
+    balance: str = REQUIRED  # type: ignore
+    destination: str = REQUIRED  # type: ignore
+    # always 0
+    flags: int = REQUIRED  # type: ignore
+    owner_node: str = REQUIRED  # type: ignore
+    public_key: str = REQUIRED  # type: ignore
+    previous_txn_id: str = REQUIRED  # type: ignore
+    previous_txn_lgr_seq: int = REQUIRED  # type: ignore
+    settle_delay: int = REQUIRED  # type: ignore
+    destination_node: Optional[str] = None
+    destination_tag: Optional[int] = None
+    expiration: Optional[int] = None
+    cancel_after: Optional[int] = None
+    source_tag: Optional[int] = None
+    ledger_entry_type: LedgerEntryType = field(
+        default=LedgerEntryType.PAY_CHANNEL,
+        init=False,
+    )
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class MDPayChannelFields(LedgerObject):
+    """
+    The model for the `PayChannel` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    account: Optional[str] = None
+    amount: Optional[str] = None
+    balance: Optional[str] = None
+    destination: Optional[str] = None
+    # always 0
+    flags: Optional[int] = None
+    owner_node: Optional[str] = None
+    public_key: Optional[str] = None
+    previous_txn_id: Optional[str] = None
+    previous_txn_lgr_seq: Optional[int] = None
+    settle_delay: Optional[int] = None
+    destination_node: Optional[str] = None
+    destination_tag: Optional[int] = None
+    expiration: Optional[int] = None
+    cancel_after: Optional[int] = None
+    source_tag: Optional[int] = None

--- a/xrpl/models/ledger_objects/pay_channel.py
+++ b/xrpl/models/ledger_objects/pay_channel.py
@@ -36,29 +36,3 @@ class PayChannel(LedgerObject):
         default=LedgerEntryType.PAY_CHANNEL,
         init=False,
     )
-
-
-@require_kwargs_on_init
-@dataclass(frozen=True)
-class MDPayChannelFields(LedgerObject):
-    """
-    The model for the `PayChannel` Ledger Object when
-    represented in a transaction's metadata.
-    """
-
-    account: Optional[str] = None
-    amount: Optional[str] = None
-    balance: Optional[str] = None
-    destination: Optional[str] = None
-    # always 0
-    flags: Optional[int] = None
-    owner_node: Optional[str] = None
-    public_key: Optional[str] = None
-    previous_txn_id: Optional[str] = None
-    previous_txn_lgr_seq: Optional[int] = None
-    settle_delay: Optional[int] = None
-    destination_node: Optional[str] = None
-    destination_tag: Optional[int] = None
-    expiration: Optional[int] = None
-    cancel_after: Optional[int] = None
-    source_tag: Optional[int] = None

--- a/xrpl/models/ledger_objects/ripple_state.py
+++ b/xrpl/models/ledger_objects/ripple_state.py
@@ -1,0 +1,71 @@
+"""Models for the Ledger Object `RippleState`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+from xrpl.models.amounts.issued_currency_amount import IssuedCurrencyAmount
+from xrpl.models.ledger_objects.ledger_entry_type import LedgerEntryType
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.required import REQUIRED
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class RippleState(LedgerObject):
+    """The model for the `RippleState` Ledger Object"""
+
+    balance: IssuedCurrencyAmount = REQUIRED  # type: ignore
+    flags: int = REQUIRED  # type: ignore
+    low_limit: IssuedCurrencyAmount = REQUIRED  # type: ignore
+    high_limit: IssuedCurrencyAmount = REQUIRED  # type: ignore
+    previous_txn_id: str = REQUIRED  # type: ignore
+    previous_txn_lgr_seq: int = REQUIRED  # type: ignore
+    high_node: Optional[str] = None
+    low_node: Optional[str] = None
+    high_quality_in: Optional[int] = None
+    high_quality_out: Optional[int] = None
+    low_quality_in: Optional[int] = None
+    low_quality_out: Optional[int] = None
+    ledger_entry_type: LedgerEntryType = field(
+        default=LedgerEntryType.RIPPLE_STATE,
+        init=False,
+    )
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class MDRippleStateFields(LedgerObject):
+    """
+    The model for the `RippleState` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    balance: Optional[IssuedCurrencyAmount] = None
+    flags: Optional[int] = None
+    low_limit: Optional[IssuedCurrencyAmount] = None
+    high_limit: Optional[IssuedCurrencyAmount] = None
+    previous_txn_id: Optional[str] = None
+    previous_txn_lgr_seq: Optional[int] = None
+    high_node: Optional[str] = None
+    low_node: Optional[str] = None
+    high_quality_in: Optional[int] = None
+    high_quality_out: Optional[int] = None
+    low_quality_in: Optional[int] = None
+    low_quality_out: Optional[int] = None
+
+
+class RippleStateFlag(Enum):
+    """The flags for the `RippleState` Ledger Object"""
+
+    LSF_LOW_RESERVE = 0x00010000
+    LSF_HIGH_RESERVE = 0x00020000
+    LSF_LOW_AUTH = 0x00040000
+    LSF_HIGH_AUTH = 0x00080000
+    LSF_LOW_NO_RIPPLE = 0x00100000
+    LSF_HIGH_NO_RIPPLE = 0x00200000
+    LSF_LOW_FREEZE = 0x00400000
+    LSF_HIGH_FREEZE = 0x00800000

--- a/xrpl/models/ledger_objects/ripple_state.py
+++ b/xrpl/models/ledger_objects/ripple_state.py
@@ -36,28 +36,6 @@ class RippleState(LedgerObject):
     )
 
 
-@require_kwargs_on_init
-@dataclass(frozen=True)
-class MDRippleStateFields(LedgerObject):
-    """
-    The model for the `RippleState` Ledger Object when
-    represented in a transaction's metadata.
-    """
-
-    balance: Optional[IssuedCurrencyAmount] = None
-    flags: Optional[int] = None
-    low_limit: Optional[IssuedCurrencyAmount] = None
-    high_limit: Optional[IssuedCurrencyAmount] = None
-    previous_txn_id: Optional[str] = None
-    previous_txn_lgr_seq: Optional[int] = None
-    high_node: Optional[str] = None
-    low_node: Optional[str] = None
-    high_quality_in: Optional[int] = None
-    high_quality_out: Optional[int] = None
-    low_quality_in: Optional[int] = None
-    low_quality_out: Optional[int] = None
-
-
 class RippleStateFlag(Enum):
     """The flags for the `RippleState` Ledger Object"""
 

--- a/xrpl/models/ledger_objects/signer_list.py
+++ b/xrpl/models/ledger_objects/signer_list.py
@@ -1,0 +1,54 @@
+"""Models for the Ledger Object `SignerList`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List, Optional
+
+from xrpl.models.ledger_objects.ledger_entry_type import LedgerEntryType
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.required import REQUIRED
+from xrpl.models.transactions.signer_list_set import SignerEntry
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class SignerList(LedgerObject):
+    """The model for the `SignerList` Ledger Object"""
+
+    flags: int = REQUIRED  # type: ignore
+    owner_node: str = REQUIRED  # type: ignore
+    previous_txn_id: str = REQUIRED  # type: ignore
+    previous_txn_lgr_seq: int = REQUIRED  # type: ignore
+    signer_entries: List[SignerEntry] = REQUIRED  # type: ignore
+    signer_list_id: int = REQUIRED  # type: ignore
+    signer_quorum: int = REQUIRED  # type: ignore
+    ledger_entry_type: LedgerEntryType = field(
+        default=LedgerEntryType.SIGNER_LIST,
+        init=False,
+    )
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class MDSignerListFields(LedgerObject):
+    """
+    The model for the `SignerList` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    flags: Optional[int] = None
+    owner_node: Optional[str] = None
+    previous_txn_id: Optional[str] = None
+    previous_txn_lgr_seq: Optional[int] = None
+    signer_entries: Optional[List[SignerEntry]] = None
+    signer_list_id: Optional[int] = None
+    signer_quorum: Optional[int] = None
+
+
+class SignerListFlag(Enum):
+    """The flags for the `SignerList` Ledger Object"""
+
+    LSF_ONE_OWNER_COUNT = 0x00010000

--- a/xrpl/models/ledger_objects/signer_list.py
+++ b/xrpl/models/ledger_objects/signer_list.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Optional
+from typing import List
 
 from xrpl.models.ledger_objects.ledger_entry_type import LedgerEntryType
 from xrpl.models.ledger_objects.ledger_object import LedgerObject
@@ -29,23 +29,6 @@ class SignerList(LedgerObject):
         default=LedgerEntryType.SIGNER_LIST,
         init=False,
     )
-
-
-@require_kwargs_on_init
-@dataclass(frozen=True)
-class MDSignerListFields(LedgerObject):
-    """
-    The model for the `SignerList` Ledger Object when
-    represented in a transaction's metadata.
-    """
-
-    flags: Optional[int] = None
-    owner_node: Optional[str] = None
-    previous_txn_id: Optional[str] = None
-    previous_txn_lgr_seq: Optional[int] = None
-    signer_entries: Optional[List[SignerEntry]] = None
-    signer_list_id: Optional[int] = None
-    signer_quorum: Optional[int] = None
 
 
 class SignerListFlag(Enum):

--- a/xrpl/models/ledger_objects/ticket.py
+++ b/xrpl/models/ledger_objects/ticket.py
@@ -1,0 +1,46 @@
+"""Models for the Ledger Object `Ticket`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from xrpl.models.ledger_objects.ledger_entry_type import LedgerEntryType
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.required import REQUIRED
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class Ticket(LedgerObject):
+    """The model for the `Ticket` Ledger Object"""
+
+    account: str = REQUIRED  # type: ignore
+    # always 0
+    flags: int = REQUIRED  # type: ignore
+    owner_node: str = REQUIRED  # type: ignore
+    previous_txn_id: str = REQUIRED  # type: ignore
+    previous_txn_lgr_seq: int = REQUIRED  # type: ignore
+    ticket_sequence: int = REQUIRED  # type: ignore
+    ledger_entry_type: LedgerEntryType = field(
+        default=LedgerEntryType.TICKET,
+        init=False,
+    )
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class MDTicketFields(LedgerObject):
+    """
+    The model for the `Ticket` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    account: Optional[str] = None
+    # always 0
+    flags: Optional[int] = None
+    owner_node: Optional[str] = None
+    previous_txn_id: Optional[str] = None
+    previous_txn_lgr_seq: Optional[int] = None
+    ticket_sequence: Optional[int] = None

--- a/xrpl/models/ledger_objects/ticket.py
+++ b/xrpl/models/ledger_objects/ticket.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional
 
 from xrpl.models.ledger_objects.ledger_entry_type import LedgerEntryType
 from xrpl.models.ledger_objects.ledger_object import LedgerObject
@@ -27,20 +26,3 @@ class Ticket(LedgerObject):
         default=LedgerEntryType.TICKET,
         init=False,
     )
-
-
-@require_kwargs_on_init
-@dataclass(frozen=True)
-class MDTicketFields(LedgerObject):
-    """
-    The model for the `Ticket` Ledger Object when
-    represented in a transaction's metadata.
-    """
-
-    account: Optional[str] = None
-    # always 0
-    flags: Optional[int] = None
-    owner_node: Optional[str] = None
-    previous_txn_id: Optional[str] = None
-    previous_txn_lgr_seq: Optional[int] = None
-    ticket_sequence: Optional[int] = None

--- a/xrpl/models/metadata/__init__.py
+++ b/xrpl/models/metadata/__init__.py
@@ -1,0 +1,34 @@
+"""Metadata models."""
+from xrpl.models.metadata.account_root import AccountRoot
+from xrpl.models.metadata.amendments import Amendments
+from xrpl.models.metadata.check import Check
+from xrpl.models.metadata.deposit_preauth import DepositPreauth
+from xrpl.models.metadata.directory_node import DirectoryNode
+from xrpl.models.metadata.ledger_hashes import LedgerHashes
+from xrpl.models.metadata.negative_unl import NegativeUNL
+from xrpl.models.metadata.nftoken_offer import NFTokenOffer
+from xrpl.models.metadata.nftoken_page import NFTokenPage
+from xrpl.models.metadata.offer import Offer
+from xrpl.models.metadata.pay_channel import PayChannel
+from xrpl.models.metadata.ripple_state import RippleState
+from xrpl.models.metadata.signer_list import SignerList
+from xrpl.models.metadata.ticket import Ticket
+
+__all__ = [
+    "AccountRoot",
+    "Amendments",
+    "Check",
+    "DepositPreauth",
+    "DirectoryNode",
+    "Escrow",
+    "FeeSettings",
+    "LedgerHashes",
+    "NegativeUNL",
+    "NFTokenOffer",
+    "NFTokenPage",
+    "Offer",
+    "PayChannel",
+    "RippleState",
+    "SignerList",
+    "Ticket",
+]

--- a/xrpl/models/metadata/account_root.py
+++ b/xrpl/models/metadata/account_root.py
@@ -1,0 +1,40 @@
+"""Models for the Metadata Object `AccountRoot`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Union
+
+from xrpl.models.ledger_objects import AccountRootFlags
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class AccountRoot(LedgerObject):
+    """
+    The model for the `AccountRoot` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    account: Optional[str] = None
+    balance: Optional[str] = None
+    flags: Optional[Union[int, AccountRootFlags]] = None
+    owner_count: Optional[int] = None
+    previous_txn_id: Optional[str] = None
+    previous_txn_lgr_seq: Optional[int] = None
+    sequence: Optional[int] = None
+    account_txn_id: Optional[str] = None
+    burned_nftokens: Optional[int] = None
+    domain: Optional[str] = None
+    email_hash: Optional[str] = None
+    message_key: Optional[str] = None
+    minted_nftokens: Optional[int] = None
+    nftoken_minter: Optional[str] = None
+    regular_key: Optional[str] = None
+    ticket_count: Optional[int] = None
+    ticket_size: Optional[int] = None
+    transfer_rate: Optional[int] = None
+    wallet_locator: Optional[str] = None
+    wallet_size: Optional[int] = None

--- a/xrpl/models/metadata/amendments.py
+++ b/xrpl/models/metadata/amendments.py
@@ -1,0 +1,24 @@
+"""Models for the Metadata Object `Amendments`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from xrpl.models.ledger_objects import Majority
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class Amendments(LedgerObject):
+    """
+    The model for the `Amendments` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    # always 0
+    flags: Optional[int] = None
+    amendments: Optional[List[str]] = None
+    majorities: Optional[List[Majority]] = None

--- a/xrpl/models/metadata/check.py
+++ b/xrpl/models/metadata/check.py
@@ -1,0 +1,34 @@
+"""Models for the Metadata Object `Check`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Union
+
+from xrpl.models.amounts.issued_currency_amount import IssuedCurrencyAmount
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class Check(LedgerObject):
+    """
+    The model for the `Check` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    account: Optional[str] = None
+    destination: Optional[str] = None
+    # always 0
+    flags: Optional[int] = None
+    owner_node: Optional[str] = None
+    previous_txn_id: Optional[str] = None
+    previous_txn_lgr_seq: Optional[int] = None
+    send_max: Optional[Union[str, IssuedCurrencyAmount]] = None
+    sequence: Optional[int] = None
+    destination_node: Optional[str] = None
+    destination_tag: Optional[int] = None
+    expiration: Optional[int] = None
+    invoice_id: Optional[str] = None
+    source_tag: Optional[int] = None

--- a/xrpl/models/metadata/deposit_preauth.py
+++ b/xrpl/models/metadata/deposit_preauth.py
@@ -1,0 +1,26 @@
+"""Models for the Metadata Object `DepositPreauth`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class DepositPreauth(LedgerObject):
+    """
+    The model for the `DepositPreauth` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    account: Optional[str] = None
+    authorize: Optional[str] = None
+    # always 0
+    flags: Optional[int] = None
+    owner_node: Optional[str] = None
+    previous_txn_id: Optional[str] = None
+    previous_txn_lgr_seq: Optional[int] = None

--- a/xrpl/models/metadata/directory_node.py
+++ b/xrpl/models/metadata/directory_node.py
@@ -1,0 +1,31 @@
+"""Models for the Metadata Object `DirectoryNode`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class DirectoryNode(LedgerObject):
+    """
+    The model for the `DirectoryNode` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    # always 0
+    flags: Optional[int] = None
+    root_index: Optional[str] = None
+    indexes: Optional[List[str]] = None
+    index_next: Optional[int] = None
+    index_previous: Optional[int] = None
+    owner: Optional[str] = None
+    exchange_rate: Optional[str] = None
+    taker_pays_currency: Optional[str] = None
+    taker_pays_issuer: Optional[str] = None
+    taker_gets_currency: Optional[str] = None
+    taker_gets_issuer: Optional[str] = None

--- a/xrpl/models/metadata/ledger_hashes.py
+++ b/xrpl/models/metadata/ledger_hashes.py
@@ -1,0 +1,24 @@
+"""Models for the Metadata Object `LedgerHashes`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class LedgerHashes(LedgerObject):
+    """
+    The model for the `LedgerHashes` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    first_ledger_sequence: Optional[int] = None
+    last_ledger_sequence: Optional[int] = None
+    hashes: Optional[List[str]] = None
+    # always 0
+    flags: Optional[int] = None

--- a/xrpl/models/metadata/metadata.py
+++ b/xrpl/models/metadata/metadata.py
@@ -1,0 +1,184 @@
+"""The models for a transaction's metadata"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Literal, Optional, Type, TypeVar, Union
+
+from xrpl.models.amounts import Amount
+from xrpl.models.base_model import BaseModel
+from xrpl.models.exceptions import XRPLModelException
+from xrpl.models.ledger_objects.ledger_object import LedgerEntryType, LedgerObject
+from xrpl.models.nested_model import NestedModel
+from xrpl.models.required import REQUIRED
+from xrpl.models.utils import require_kwargs_on_init
+
+N = TypeVar("N", bound="AffectedNode")
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class NewFields(LedgerObject):
+    """A model for a node's `NewFields`"""
+
+    pass
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class PreviousFields(LedgerObject):
+    """A model for a node's `PreviousFields`"""
+
+    pass
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class FinalFields(LedgerObject):
+    """A model for a node's `FinalFields`"""
+
+    pass
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class AffectedNode(NestedModel):
+    """A model a transaction's metadata's node."""
+
+    ledger_entry_type: LedgerEntryType = REQUIRED  # type: ignore
+    ledger_index: str = REQUIRED  # type: ignore
+
+    @classmethod
+    def from_dict(cls: Type[N], value: Dict[str, Any]) -> N:
+        """Derive the model from a dict.
+
+        Args:
+            value: The dictionary to derive from.
+
+        Returns:
+            N: The node type.
+
+        Raises:
+            XRPLModelException: If the provided node type does not exist.
+        """
+        affected_node_type = list(value.keys())[0]
+        if cls.__name__ == "AffectedNode":
+            if affected_node_type not in [
+                "created_node",
+                "modified_node",
+                "deleted_node",
+            ]:
+                raise XRPLModelException(f"{affected_node_type} is no node type.")
+            correct_type = cls.get_node_type(affected_node_type)
+            return correct_type.from_dict(value)  # type: ignore
+        else:
+            # TODO: Check for error
+            affected_node = value[affected_node_type]
+            ledger_entry_type = affected_node["ledger_entry_type"]
+
+            new_fields = affected_node.get("new_fields")
+            if new_fields is not None:
+                value[affected_node_type]["new_fields"][
+                    "ledger_entry_type"
+                ] = ledger_entry_type
+
+            previous_fields = affected_node.get("previous_fields")
+            if previous_fields is not None:
+                value[affected_node_type]["previous_fields"][
+                    "ledger_entry_type"
+                ] = ledger_entry_type
+
+            final_fields = affected_node.get("final_fields")
+            if final_fields is not None:
+                value[affected_node_type]["final_fields"][
+                    "ledger_entry_type"
+                ] = ledger_entry_type
+
+            return super(AffectedNode, cls).from_dict(value)
+
+    @classmethod
+    def get_node_type(cls: Type[AffectedNode], node_type: str) -> Type[AffectedNode]:
+        """Get the correct model
+
+        Args:
+            node_type: The node type willing to get.
+
+        Returns:
+            Type[AffectedNode]: The correct node type
+
+        Raises:
+            XRPLModelException: If the provided node type does not exist.
+        """
+        if node_type == "created_node":
+            return CreatedNode
+        elif node_type == "modified_node":
+            return ModifiedNode
+        elif node_type == "deleted_node":
+            return DeletedNode
+        else:
+            raise XRPLModelException(f"{node_type} is no node type.")
+
+    def __getitem__(self: AffectedNode, field_name: str) -> Any:
+        """Enable to get the fields like from a `dict`
+
+        Args:
+            field_name: The field's name to get the value from.
+
+        Returns:
+            Any: The value of the field.
+        """
+        if field_name == self.__class__.__name__ or self.__class__.__name__ == "".join(
+            [word.capitalize() for word in field_name.split("_")]
+        ):
+            return self
+        return self.__getattribute__(field_name)
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class CreatedNode(AffectedNode):
+    """A model for when a new node got created on the XRPL"""
+
+    new_fields: NewFields = REQUIRED  # type: ignore
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class ModifiedNode(AffectedNode):
+    """A model for when a node got modified in the XRPL"""
+
+    final_fields: FinalFields = REQUIRED  # type: ignore
+    previous_fields: Optional[PreviousFields] = None
+    previous_txn_id: Optional[str] = None
+    previous_txn_lgr_seq: Optional[int] = None
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class DeletedNode(AffectedNode):
+    """A model for when a node got deleted from the XRPL"""
+
+    final_fields: FinalFields = REQUIRED  # type: ignore
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class Metadata(BaseModel):
+    """A model for a transaction's metadata"""
+
+    affected_nodes: List[AffectedNode] = REQUIRED  # type: ignore
+    transaction_index: int = REQUIRED  # type: ignore
+    transaction_result: str = REQUIRED  # type: ignore
+    delivered_amount: Optional[Union[Amount, Literal["unavailable"]]] = None
+
+    def __getitem__(self: Metadata, field_name: str) -> Any:
+        """Enable to get the fields like from a `dict`
+
+        Args:
+            field_name: The field's name to get the value from.
+        """
+        if field_name == self.__class__.__name__ or self.__class__.__name__ == "".join(
+            [word.capitalize() for word in field_name.split("_")]
+        ):
+            return self
+        return self.__getattribute__(field_name)

--- a/xrpl/models/metadata/negative_unl.py
+++ b/xrpl/models/metadata/negative_unl.py
@@ -1,0 +1,24 @@
+"""Models for the Metadata Object `NegativeUNL`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from xrpl.models.ledger_objects import DisabledValidator
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class NegativeUNL(LedgerObject):
+    """
+    The model for the `NegativeUNL` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    flags: Optional[int] = None
+    disabled_validators: Optional[List[DisabledValidator]] = None
+    validator_to_disable: Optional[str] = None
+    validator_to_enable: Optional[str] = None

--- a/xrpl/models/metadata/nftoken_offer.py
+++ b/xrpl/models/metadata/nftoken_offer.py
@@ -1,0 +1,30 @@
+"""Models for the Metadata Object `NFTokenOffer`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Union
+
+from xrpl.models.ledger_objects import NFToken
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class NFTokenOffer(LedgerObject):
+    """
+    The model for the `NFTokenOffer` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    amount: Optional[Union[str, NFToken]] = None
+    flags: Optional[int] = None
+    nftoken_id: Optional[str] = None
+    owner: Optional[str] = None
+    previous_txn_id: Optional[str] = None
+    previous_txn_lgr_seq: Optional[int] = None
+    destination: Optional[str] = None
+    expiration: Optional[int] = None
+    owner_node: Optional[str] = None
+    nftoken_offer_node: Optional[str] = None

--- a/xrpl/models/metadata/nftoken_page.py
+++ b/xrpl/models/metadata/nftoken_page.py
@@ -1,0 +1,27 @@
+"""Models for the Metadata Object `NFTokenPage`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.ledger_objects.nftoken_offer import NFToken
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class NFTokenPage(LedgerObject):
+    """
+    The model for the `NFTokenPage` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    previous_page_min: Optional[str] = None
+    next_page_min: Optional[str] = None
+    previous_token_page: Optional[str] = None
+    previous_token_next: Optional[str] = None
+    previous_txn_id: Optional[str] = None
+    previous_txn_lgr_seq: Optional[int] = None
+    nftokens: Optional[List[NFToken]] = None

--- a/xrpl/models/metadata/offer.py
+++ b/xrpl/models/metadata/offer.py
@@ -1,0 +1,31 @@
+"""Models for the Metadata Object `Offer`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Union
+
+from xrpl.models.amounts.issued_currency_amount import IssuedCurrencyAmount
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class Offer(LedgerObject):
+    """
+    The model for the `Offer` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    account: Optional[str] = None
+    taker_gets: Optional[Union[str, IssuedCurrencyAmount]] = None
+    taker_pays: Optional[Union[str, IssuedCurrencyAmount]] = None
+    sequence: Optional[int] = None
+    flags: Optional[int] = None
+    book_directory: Optional[str] = None
+    book_node: Optional[str] = None
+    owner_node: Optional[str] = None
+    previous_txn_id: Optional[str] = None
+    previous_txn_lgr_seq: Optional[int] = None
+    expiration: Optional[int] = None

--- a/xrpl/models/metadata/pay_channel.py
+++ b/xrpl/models/metadata/pay_channel.py
@@ -1,0 +1,35 @@
+"""Models for the Metadata Object `PayChannel`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class PayChannel(LedgerObject):
+    """
+    The model for the `PayChannel` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    account: Optional[str] = None
+    amount: Optional[str] = None
+    balance: Optional[str] = None
+    destination: Optional[str] = None
+    # always 0
+    flags: Optional[int] = None
+    owner_node: Optional[str] = None
+    public_key: Optional[str] = None
+    previous_txn_id: Optional[str] = None
+    previous_txn_lgr_seq: Optional[int] = None
+    settle_delay: Optional[int] = None
+    destination_node: Optional[str] = None
+    destination_tag: Optional[int] = None
+    expiration: Optional[int] = None
+    cancel_after: Optional[int] = None
+    source_tag: Optional[int] = None

--- a/xrpl/models/metadata/ripple_state.py
+++ b/xrpl/models/metadata/ripple_state.py
@@ -1,0 +1,32 @@
+"""Models for the Metadata Object `RippleState`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from xrpl.models.amounts.issued_currency_amount import IssuedCurrencyAmount
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class RippleState(LedgerObject):
+    """
+    The model for the `RippleState` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    balance: Optional[IssuedCurrencyAmount] = None
+    flags: Optional[int] = None
+    low_limit: Optional[IssuedCurrencyAmount] = None
+    high_limit: Optional[IssuedCurrencyAmount] = None
+    previous_txn_id: Optional[str] = None
+    previous_txn_lgr_seq: Optional[int] = None
+    high_node: Optional[str] = None
+    low_node: Optional[str] = None
+    high_quality_in: Optional[int] = None
+    high_quality_out: Optional[int] = None
+    low_quality_in: Optional[int] = None
+    low_quality_out: Optional[int] = None

--- a/xrpl/models/metadata/signer_list.py
+++ b/xrpl/models/metadata/signer_list.py
@@ -1,0 +1,27 @@
+"""Models for the Metadata Object `SignerList`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.transactions.signer_list_set import SignerEntry
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class SignerList(LedgerObject):
+    """
+    The model for the `SignerList` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    flags: Optional[int] = None
+    owner_node: Optional[str] = None
+    previous_txn_id: Optional[str] = None
+    previous_txn_lgr_seq: Optional[int] = None
+    signer_entries: Optional[List[SignerEntry]] = None
+    signer_list_id: Optional[int] = None
+    signer_quorum: Optional[int] = None

--- a/xrpl/models/metadata/ticket.py
+++ b/xrpl/models/metadata/ticket.py
@@ -1,0 +1,26 @@
+"""Models for the Metadata Object `Ticket`"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from xrpl.models.ledger_objects.ledger_object import LedgerObject
+from xrpl.models.utils import require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True)
+class Ticket(LedgerObject):
+    """
+    The model for the `Ticket` Ledger Object when
+    represented in a transaction's metadata.
+    """
+
+    account: Optional[str] = None
+    # always 0
+    flags: Optional[int] = None
+    owner_node: Optional[str] = None
+    previous_txn_id: Optional[str] = None
+    previous_txn_lgr_seq: Optional[int] = None
+    ticket_sequence: Optional[int] = None


### PR DESCRIPTION
## High Level Overview of Change

**blocked by #663**

This PR adds (some) Metadata models:
- AccountRoot
- Amendment
- Check
- DepositPreauth
- DirectoryNode
- LedgerHashes
- LedgerObject
- NegativeUNL
- NFTokenOffer
- NFTokenPage
- Offer
- PayChannel
- RippleState
- SignerList
- Ticket

This seems like it isn't complete yet as all Metadata models are optional, `NewFields` is undefined, etc. But I think this might be a good starting point for someone (or me) to pick up in the future. I will close this PR for now.

### Context of Change

@JST5000 and I had a great chat this week. He told me one thing you might prioritize as a coming feature would be response models. I remembered I once had a PR adding Ledger Object and Metadata models and was told to split it up into two PRs, but somehow I forgot about it. This PR adds the Metadata objects. I could imagine there are some objects missing or are a bit deprecated but I still wanted to leave the progress made here for you to use.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### Did you update CHANGELOG.md?

- [x] No

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

None, it should have de-/serialization tests.