### PR TITLE
ci: run type checking on earliest python version

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      PYTHON_VERSION: "3.11"
+      PYTHON_VERSION: "3.7"
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## High Level Overview of Change

Title says it all.

### Context of Change

I ran into an issue where types were fine on the latest version but had issues on the oldest version.

### Type of Change

- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

### Did you update CHANGELOG.md?

- [x] No, this change does not impact library users

## Test Plan

CI passes.
