### PR TITLE
validate the contents of seed before creating a Wallet object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for `XChainModifyBridge` flag maps (fixing an issue with `NFTokenCreateOffer` flag names)
 - Fixed `XChainModifyBridge` validation to allow just clearing of `MinAccountCreateAmount`
 - Currency codes with special characters not being allowed by IssuedCurrency objects.
+- Construction of Wallet throws an "Invalid Seed" error, if the secret is not decode-able.
 
 ## [2.5.0] - 2023-11-30
 

--- a/tests/unit/asyn/wallet/test_main.py
+++ b/tests/unit/asyn/wallet/test_main.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from xrpl.constants import CryptoAlgorithm, XRPLException
+from xrpl.core.addresscodec.exceptions import XRPLAddressCodecException
 from xrpl.wallet.main import Wallet
 
 constants = {
@@ -138,6 +139,15 @@ class TestWalletMain(TestCase):
         )
 
         _test_wallet_values(self, wallet, "seed", "secp256k1")
+
+    def test_wallet_contructor_throws_on_empty_seed(self):
+        with self.assertRaises(XRPLAddressCodecException):
+            Wallet(
+                constants["regular_key_pair"]["secp256k1"]["public_key"],
+                constants["regular_key_pair"]["secp256k1"]["private_key"],
+                master_address=constants["regular_key_pair"]["master_address"],
+                seed="",
+            )
 
     def test_constructor_using_regular_key_pair(self):
         wallet = Wallet(

--- a/tests/unit/asyn/wallet/test_main.py
+++ b/tests/unit/asyn/wallet/test_main.py
@@ -140,13 +140,12 @@ class TestWalletMain(TestCase):
 
         _test_wallet_values(self, wallet, "seed", "secp256k1")
 
-    def test_wallet_contructor_throws_on_empty_seed(self):
+    def test_wallet_contructor_throws_with_invalid_seed(self):
         with self.assertRaises(XRPLAddressCodecException):
             Wallet(
                 constants["regular_key_pair"]["secp256k1"]["public_key"],
                 constants["regular_key_pair"]["secp256k1"]["private_key"],
-                master_address=constants["regular_key_pair"]["master_address"],
-                seed="",
+                seed="abc",
             )
 
     def test_constructor_using_regular_key_pair(self):


### PR DESCRIPTION
## High Level Overview of Change
Fixes https://github.com/XRPLF/xrpl-py/issues/503

It's ideal to validate a seed before creating a `Wallet` object. This is helpful in generating readable error messages for the users.

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update CHANGELOG.md?

- [ ] Yes
- [x] No, this change does not impact library users
Invalid seed input to `Wallet` will throw a different error. The current code throws a `ValueError`, this is hard to understand for users.

## Test Plan
I have added a unit test that validates the Exception thrown upon empty seed inputs into the `Wallet` class constructor.
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
