### PR TITLE
fix: update hooks testnet url

### DIFF
--- a/tests/integration/sugar/test_network_id.py
+++ b/tests/integration/sugar/test_network_id.py
@@ -58,7 +58,7 @@ class TestNetworkID(TestCase):
 
     # Autofill should override tx networkID for hooks-testnet.
     def test_networkid_override_hooks_testnet(self):
-        with WebsocketClient("wss://hooks-testnet-v3.xrpl-labs.com") as client:
+        with WebsocketClient("wss://xahau-test.net") as client:
             wallet = generate_faucet_wallet(client, debug=True)
             tx = AccountSet(
                 account=wallet.classic_address,

--- a/tests/integration/sugar/test_wallet.py
+++ b/tests/integration/sugar/test_wallet.py
@@ -174,14 +174,12 @@ class TestWallet(IntegrationTestCase):
         ) as client:
             await generate_faucet_wallet_and_fund_again(self, client)
 
-    async def _parallel_test_generate_faucet_wallet_hooks_v3_testnet_async_websockets(
+    async def _parallel_test_generate_faucet_wallet_hooks_testnet_async_websockets(
         self,
     ):
-        async with AsyncWebsocketClient(
-            "wss://hooks-testnet-v3.xrpl-labs.com"
-        ) as client:
+        async with AsyncWebsocketClient("wss://xahau-test.net") as client:
             global time_of_last_hooks_faucet_call
-            # Wait at least 10 seconds since last call to hooks v3 testnet faucet
+            # Wait at least 10 seconds since last call to hooks testnet faucet
             time_since_last_hooks_call = time.time() - time_of_last_hooks_faucet_call
             if time_since_last_hooks_call < 10:
                 time.sleep(11 - time_since_last_hooks_call)
@@ -199,13 +197,11 @@ class TestWallet(IntegrationTestCase):
             balance = int(result.result["account_data"]["Balance"])
             self.assertTrue(balance > 0)
 
-    # Named different from test_generate_faucet_wallet_hooks_v3_testnet_async_websockets
-    # so the test runs far from each other since hooks v3 testnet faucet
+    # Named different from test_generate_faucet_wallet_hooks_testnet_async_websockets
+    # so the test runs far from each other since hooks testnet faucet
     # requires 10 seconds between calls
-    async def test_fund_given_wallet_hooks_v3_testnet_async_websockets(self):
-        async with AsyncWebsocketClient(
-            "wss://hooks-testnet-v3.xrpl-labs.com"
-        ) as client:
+    async def test_fund_given_wallet_hooks_testnet_async_websockets(self):
+        async with AsyncWebsocketClient("wss://xahau-test.net") as client:
             global time_of_last_hooks_faucet_call
             wallet = Wallet.create()
             time_since_last_hooks_call = time.time() - time_of_last_hooks_faucet_call
@@ -220,7 +216,7 @@ class TestWallet(IntegrationTestCase):
             )
             balance = int(result.result["account_data"]["Balance"])
 
-            # Wait at least 10 seconds since last call to hooks v3 testnet faucet
+            # Wait at least 10 seconds since last call to hooks testnet faucet
             time_since_last_hooks_call = time.time() - time_of_last_hooks_faucet_call
             if time_since_last_hooks_call < 10:
                 time.sleep(11 - time_since_last_hooks_call)

--- a/tests/unit/asyn/wallet/test_wallet.py
+++ b/tests/unit/asyn/wallet/test_wallet.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from xrpl.asyncio.wallet.wallet_generation import (
     _AMM_DEV_FAUCET_URL,
     _DEV_FAUCET_URL,
-    _HOOKS_V3_TEST_FAUCET_URL,
+    _HOOKS_TEST_FAUCET_URL,
     _TEST_FAUCET_URL,
     get_faucet_url,
 )
@@ -50,10 +50,10 @@ class TestWallet(TestCase):
         self.assertEqual(get_faucet_url(json_client_url), expected_faucet)
         self.assertEqual(get_faucet_url(ws_client_url), expected_faucet)
 
-    def test_get_faucet_wallet_hooks_v3_test(self):
-        json_client_url = "https://hooks-testnet-v3.xrpl-labs.com"
-        ws_client_url = "wss://hooks-testnet-v3.xrpl-labs.com"
-        expected_faucet = _HOOKS_V3_TEST_FAUCET_URL
+    def test_get_faucet_wallet_hooks_test(self):
+        json_client_url = "https://xahau-test.net"
+        ws_client_url = "wss://xahau-test.net"
+        expected_faucet = _HOOKS_TEST_FAUCET_URL
 
         self.assertEqual(get_faucet_url(json_client_url), expected_faucet)
         self.assertEqual(get_faucet_url(ws_client_url), expected_faucet)

--- a/xrpl/asyncio/wallet/wallet_generation.py
+++ b/xrpl/asyncio/wallet/wallet_generation.py
@@ -13,9 +13,7 @@ from xrpl.wallet.main import Wallet
 _TEST_FAUCET_URL: Final[str] = "https://faucet.altnet.rippletest.net/accounts"
 _DEV_FAUCET_URL: Final[str] = "https://faucet.devnet.rippletest.net/accounts"
 _AMM_DEV_FAUCET_URL: Final[str] = "https://ammfaucet.devnet.rippletest.net/accounts"
-_HOOKS_V3_TEST_FAUCET_URL: Final[
-    str
-] = "https://hooks-testnet-v3.xrpl-labs.com/accounts"
+_HOOKS_TEST_FAUCET_URL: Final[str] = "https://xahau-test.net/accounts"
 _SIDECHAIN_DEVNET_FAUCET_URL: Final[
     str
 ] = "https://sidechain-faucet.devnet.rippletest.net/accounts"
@@ -120,8 +118,8 @@ def get_faucet_url(url: str, faucet_host: Optional[str] = None) -> str:
     """
     if faucet_host is not None:
         return f"https://{faucet_host}/accounts"
-    if "hooks-testnet-v3" in url:  # hooks v3 testnet
-        return _HOOKS_V3_TEST_FAUCET_URL
+    if "xahau-test" in url:  # hooks v3 testnet
+        return _HOOKS_TEST_FAUCET_URL
     if "altnet" in url or "testnet" in url:  # testnet
         return _TEST_FAUCET_URL
     if "amm" in url:  # amm devnet


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->
The hooks testnet url was changed a while ago but the previous one worked. That seems to have been disabled recently. New url is `https://xahau-test.net`

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update CHANGELOG.md?

- [ ] Yes
- [x] No, this change does not impact library users
