### PR TITLE
add the missing AMMDeposit flag TF_TWO_ASSET_IF_EMPTY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Currency codes with special characters not being allowed by IssuedCurrency objects.
 - Construction of Wallet throws an "Invalid Seed" error, if the secret is not decode-able.
 - Rectify the incorrect usage of a transaction flag name: Update `TF_NO_DIRECT_RIPPLE` to `TF_NO_RIPPLE_DIRECT`
+- Add the missing `AMMDeposit` Flag `TF_TWO_ASSET_IF_EMPTY`
 
 ## [2.5.0] - 2023-11-30
 

--- a/xrpl/models/transactions/amm_deposit.py
+++ b/xrpl/models/transactions/amm_deposit.py
@@ -25,6 +25,7 @@ class AMMDepositFlag(int, Enum):
     TF_TWO_ASSET = 0x00100000
     TF_ONE_ASSET_LP_TOKEN = 0x00200000
     TF_LIMIT_LP_TOKEN = 0x00400000
+    TF_TWO_ASSET_IF_EMPTY = 0x00800000
 
 
 class AMMDepositFlagInterface(FlagInterface):
@@ -38,6 +39,7 @@ class AMMDepositFlagInterface(FlagInterface):
     TF_TWO_ASSET: bool
     TF_ONE_ASSET_LP_TOKEN: bool
     TF_LIMIT_LP_TOKEN: bool
+    TF_TWO_ASSET_IF_EMPTY: bool
 
 
 @require_kwargs_on_init


### PR DESCRIPTION
## High Level Overview of Change

Sister PR from https://github.com/XRPLF/xrpl.js/pull/2667
Fixes https://github.com/XRPLF/xrpl.js/issues/2666

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update CHANGELOG.md?

- [x] Yes
- [ ] No, this change does not impact library users

## Test Plan
I don't know enough about this particular flag to write tests. Please let me know if you have ideas
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
