### PR TITLE
refactor: use single Oracle class for Price Oracles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Construction of Wallet throws an "Invalid Seed" error, if the secret is not decode-able.
 - Rectify the incorrect usage of a transaction flag name: Update `TF_NO_DIRECT_RIPPLE` to `TF_NO_RIPPLE_DIRECT`
 - Add the missing `AMMDeposit` Flag `TF_TWO_ASSET_IF_EMPTY`
-- Minor refactor changes for Price Oracles support.
 
 ## [2.5.0] - 2023-11-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Construction of Wallet throws an "Invalid Seed" error, if the secret is not decode-able.
 - Rectify the incorrect usage of a transaction flag name: Update `TF_NO_DIRECT_RIPPLE` to `TF_NO_RIPPLE_DIRECT`
 - Add the missing `AMMDeposit` Flag `TF_TWO_ASSET_IF_EMPTY`
+- Minor refactor changes for Price Oracles support.
 
 ## [2.5.0] - 2023-11-30
 

--- a/tests/unit/models/requests/test_get_aggregate_price.py
+++ b/tests/unit/models/requests/test_get_aggregate_price.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 from xrpl.models import XRPLModelException
 from xrpl.models.requests import GetAggregatePrice
-from xrpl.models.requests.get_aggregate_price import Oracle
+from xrpl.models.requests.get_aggregate_price import OracleEntry
 
 _ACCT_STR_1 = "rBwHKFS534tfG3mATXSycCnX8PAd3XJswj"
 _ORACLE_DOC_ID_1 = 1
@@ -27,8 +27,12 @@ class TestGetAggregatePrice(TestCase):
             GetAggregatePrice(
                 quote_asset="XRP",
                 oracles=[
-                    Oracle(account=_ACCT_STR_1, oracle_document_id=_ORACLE_DOC_ID_1),
-                    Oracle(account=_ACCT_STR_2, oracle_document_id=_ORACLE_DOC_ID_2),
+                    OracleEntry(
+                        account=_ACCT_STR_1, oracle_document_id=_ORACLE_DOC_ID_1
+                    ),
+                    OracleEntry(
+                        account=_ACCT_STR_2, oracle_document_id=_ORACLE_DOC_ID_2
+                    ),
                 ],
             )
 
@@ -37,8 +41,12 @@ class TestGetAggregatePrice(TestCase):
             GetAggregatePrice(
                 base_asset="USD",
                 oracles=[
-                    Oracle(account=_ACCT_STR_1, oracle_document_id=_ORACLE_DOC_ID_1),
-                    Oracle(account=_ACCT_STR_2, oracle_document_id=_ORACLE_DOC_ID_2),
+                    OracleEntry(
+                        account=_ACCT_STR_1, oracle_document_id=_ORACLE_DOC_ID_1
+                    ),
+                    OracleEntry(
+                        account=_ACCT_STR_2, oracle_document_id=_ORACLE_DOC_ID_2
+                    ),
                 ],
             )
 
@@ -48,8 +56,8 @@ class TestGetAggregatePrice(TestCase):
             base_asset="USD",
             quote_asset="XRP",
             oracles=[
-                Oracle(account=_ACCT_STR_1, oracle_document_id=_ORACLE_DOC_ID_1),
-                Oracle(account=_ACCT_STR_2, oracle_document_id=_ORACLE_DOC_ID_2),
+                OracleEntry(account=_ACCT_STR_1, oracle_document_id=_ORACLE_DOC_ID_1),
+                OracleEntry(account=_ACCT_STR_2, oracle_document_id=_ORACLE_DOC_ID_2),
             ],
         )
         self.assertTrue(request.is_valid())
@@ -59,8 +67,8 @@ class TestGetAggregatePrice(TestCase):
             base_asset="USD",
             quote_asset="XRP",
             oracles=[
-                Oracle(account=_ACCT_STR_1, oracle_document_id=_ORACLE_DOC_ID_1),
-                Oracle(account=_ACCT_STR_2, oracle_document_id=_ORACLE_DOC_ID_2),
+                OracleEntry(account=_ACCT_STR_1, oracle_document_id=_ORACLE_DOC_ID_1),
+                OracleEntry(account=_ACCT_STR_2, oracle_document_id=_ORACLE_DOC_ID_2),
             ],
             trim=20,
             time_threshold=10,

--- a/tests/unit/models/requests/test_get_aggregate_price.py
+++ b/tests/unit/models/requests/test_get_aggregate_price.py
@@ -27,12 +27,8 @@ class TestGetAggregatePrice(TestCase):
             GetAggregatePrice(
                 quote_asset="XRP",
                 oracles=[
-                    Oracle(
-                        account=_ACCT_STR_1, oracle_document_id=_ORACLE_DOC_ID_1
-                    ),
-                    Oracle(
-                        account=_ACCT_STR_2, oracle_document_id=_ORACLE_DOC_ID_2
-                    ),
+                    Oracle(account=_ACCT_STR_1, oracle_document_id=_ORACLE_DOC_ID_1),
+                    Oracle(account=_ACCT_STR_2, oracle_document_id=_ORACLE_DOC_ID_2),
                 ],
             )
 
@@ -41,12 +37,8 @@ class TestGetAggregatePrice(TestCase):
             GetAggregatePrice(
                 base_asset="USD",
                 oracles=[
-                    Oracle(
-                        account=_ACCT_STR_1, oracle_document_id=_ORACLE_DOC_ID_1
-                    ),
-                    Oracle(
-                        account=_ACCT_STR_2, oracle_document_id=_ORACLE_DOC_ID_2
-                    ),
+                    Oracle(account=_ACCT_STR_1, oracle_document_id=_ORACLE_DOC_ID_1),
+                    Oracle(account=_ACCT_STR_2, oracle_document_id=_ORACLE_DOC_ID_2),
                 ],
             )
 

--- a/tests/unit/models/requests/test_get_aggregate_price.py
+++ b/tests/unit/models/requests/test_get_aggregate_price.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 from xrpl.models import XRPLModelException
 from xrpl.models.requests import GetAggregatePrice
-from xrpl.models.requests.get_aggregate_price import OracleEntry
+from xrpl.models.requests.ledger_entry import Oracle
 
 _ACCT_STR_1 = "rBwHKFS534tfG3mATXSycCnX8PAd3XJswj"
 _ORACLE_DOC_ID_1 = 1
@@ -27,10 +27,10 @@ class TestGetAggregatePrice(TestCase):
             GetAggregatePrice(
                 quote_asset="XRP",
                 oracles=[
-                    OracleEntry(
+                    Oracle(
                         account=_ACCT_STR_1, oracle_document_id=_ORACLE_DOC_ID_1
                     ),
-                    OracleEntry(
+                    Oracle(
                         account=_ACCT_STR_2, oracle_document_id=_ORACLE_DOC_ID_2
                     ),
                 ],
@@ -41,10 +41,10 @@ class TestGetAggregatePrice(TestCase):
             GetAggregatePrice(
                 base_asset="USD",
                 oracles=[
-                    OracleEntry(
+                    Oracle(
                         account=_ACCT_STR_1, oracle_document_id=_ORACLE_DOC_ID_1
                     ),
-                    OracleEntry(
+                    Oracle(
                         account=_ACCT_STR_2, oracle_document_id=_ORACLE_DOC_ID_2
                     ),
                 ],
@@ -56,8 +56,8 @@ class TestGetAggregatePrice(TestCase):
             base_asset="USD",
             quote_asset="XRP",
             oracles=[
-                OracleEntry(account=_ACCT_STR_1, oracle_document_id=_ORACLE_DOC_ID_1),
-                OracleEntry(account=_ACCT_STR_2, oracle_document_id=_ORACLE_DOC_ID_2),
+                Oracle(account=_ACCT_STR_1, oracle_document_id=_ORACLE_DOC_ID_1),
+                Oracle(account=_ACCT_STR_2, oracle_document_id=_ORACLE_DOC_ID_2),
             ],
         )
         self.assertTrue(request.is_valid())
@@ -67,8 +67,8 @@ class TestGetAggregatePrice(TestCase):
             base_asset="USD",
             quote_asset="XRP",
             oracles=[
-                OracleEntry(account=_ACCT_STR_1, oracle_document_id=_ORACLE_DOC_ID_1),
-                OracleEntry(account=_ACCT_STR_2, oracle_document_id=_ORACLE_DOC_ID_2),
+                Oracle(account=_ACCT_STR_1, oracle_document_id=_ORACLE_DOC_ID_1),
+                Oracle(account=_ACCT_STR_2, oracle_document_id=_ORACLE_DOC_ID_2),
             ],
             trim=20,
             time_threshold=10,

--- a/xrpl/models/requests/get_aggregate_price.py
+++ b/xrpl/models/requests/get_aggregate_price.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
+from xrpl.models.requests.ledger_entry import Oracle
 from xrpl.models.requests.request import Request, RequestMethod
 from xrpl.models.required import REQUIRED
 from xrpl.models.utils import require_kwargs_on_init
@@ -29,7 +30,7 @@ class GetAggregatePrice(Request):
     quote_asset: str = REQUIRED  # type: ignore
     """The currency code of the asset to quote the price of the base asset"""
 
-    oracles: List[OracleEntry] = REQUIRED  # type: ignore
+    oracles: List[Oracle] = REQUIRED  # type: ignore
     """The oracle identifier"""
 
     trim: Optional[int] = None
@@ -47,15 +48,3 @@ class GetAggregatePrice(Request):
                 "GetAggregatePrice"
             ] = "Oracles array must contain at least one element"
         return errors
-
-
-@require_kwargs_on_init
-@dataclass(frozen=True)
-class OracleEntry:
-    """Represents one Oracle element. It is used in GetAggregatePrice request"""
-
-    oracle_document_id: int = REQUIRED  # type: ignore
-    """A unique identifier of the price oracle for the Account"""
-
-    account: str = REQUIRED  # type: ignore
-    """The XRPL account that controls the Oracle object"""

--- a/xrpl/models/requests/get_aggregate_price.py
+++ b/xrpl/models/requests/get_aggregate_price.py
@@ -53,7 +53,7 @@ class GetAggregatePrice(Request):
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class Oracle(TypedDict):
+class Oracle:
     """Represents one Oracle element. It is used in GetAggregatePrice request"""
 
     oracle_document_id: int = REQUIRED  # type: ignore

--- a/xrpl/models/requests/get_aggregate_price.py
+++ b/xrpl/models/requests/get_aggregate_price.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
-from typing_extensions import TypedDict
-
 from xrpl.models.requests.request import Request, RequestMethod
 from xrpl.models.required import REQUIRED
 from xrpl.models.utils import require_kwargs_on_init
@@ -31,7 +29,7 @@ class GetAggregatePrice(Request):
     quote_asset: str = REQUIRED  # type: ignore
     """The currency code of the asset to quote the price of the base asset"""
 
-    oracles: List[Oracle] = REQUIRED  # type: ignore
+    oracles: List[OracleEntry] = REQUIRED  # type: ignore
     """The oracle identifier"""
 
     trim: Optional[int] = None
@@ -53,7 +51,7 @@ class GetAggregatePrice(Request):
 
 @require_kwargs_on_init
 @dataclass(frozen=True)
-class Oracle:
+class OracleEntry:
     """Represents one Oracle element. It is used in GetAggregatePrice request"""
 
     oracle_document_id: int = REQUIRED  # type: ignore


### PR DESCRIPTION
## High Level Overview of Change

Use single Oracle class for Price Oracles support.

### Context of Change

- Use single `Oracle` class for `get_aggregate_price` and `ledger_entry` to resolve duplicate name conflict.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update CHANGELOG.md?

- [ ] Yes
- [x] No, this change does not impact library users

## Test Plan

Updated unit tests.
