### PR TITLE
refactor: use `Self` instead of class name

### DIFF
--- a/tests/integration/clients/test_json_rpc_client.py
+++ b/tests/integration/clients/test_json_rpc_client.py
@@ -1,4 +1,5 @@
 """Test the json_rpc_client."""
+
 from __future__ import annotations
 
 from unittest import TestCase
@@ -10,7 +11,7 @@ from xrpl.models.requests import ServerInfo
 class TestJsonRpcClient(TestCase):
     """Test json_rpc_client."""
 
-    def test_json_rpc_client_valid_url(self: TestJsonRpcClient) -> None:
+    def test_json_rpc_client_valid_url(self) -> None:
         # Valid URL
         JSON_RPC_URL = "https://s.altnet.rippletest.net:51234"
         client = JsonRpcClient(JSON_RPC_URL)

--- a/tests/unit/utils/test_get_nftoken_id.py
+++ b/tests/unit/utils/test_get_nftoken_id.py
@@ -1,4 +1,5 @@
 """Test the get_nftoken_id util."""
+
 from __future__ import annotations
 
 import json
@@ -18,22 +19,22 @@ with open(path_to_json + "offer_cancelled.json", "r") as infile:
 class TestGetNFTokenID(TestCase):
     """Test get_nftoken_id."""
 
-    def test_decoding_a_valid_nftoken_id(self: TestGetNFTokenID):
+    def test_decoding_a_valid_nftoken_id(self):
         result = get_nftoken_id(nftokenmint_response1["meta"])
         expected_nftoken_id = (
             "00081388DC1AB4937C899037B2FDFC3CB20F6F64E73120BB5F8AA66A00000228"
         )
         self.assertEqual(result, expected_nftoken_id)
 
-    def test_a_different_valid_nftokenmint_metadata(self: TestGetNFTokenID):
+    def test_a_different_valid_nftokenmint_metadata(self):
         result = get_nftoken_id(nftokenmint_response2["meta"])
         expected_nftoken_id = (
             "0008125CBE4B401B2F62ED35CC67362165AA813CCA06316FFA766254000003EE"
         )
         self.assertEqual(result, expected_nftoken_id)
 
-    def test_error_with_wrong_tx_metadata(self: TestGetNFTokenID) -> None:
+    def test_error_with_wrong_tx_metadata(self) -> None:
         self.assertIsNone(get_nftoken_id(wrong_fixture["meta"]))
 
-    def test_error_when_given_raw_instead_of_meta(self: TestGetNFTokenID) -> None:
+    def test_error_when_given_raw_instead_of_meta(self) -> None:
         self.assertRaises(TypeError, lambda: get_nftoken_id(nftokenmint_response1))

--- a/tests/unit/utils/test_get_xchain_claim_id.py
+++ b/tests/unit/utils/test_get_xchain_claim_id.py
@@ -1,4 +1,5 @@
 """Test the get_xchain_claim_id util."""
+
 from __future__ import annotations
 
 import json
@@ -18,18 +19,18 @@ with open(path_to_json + "nftokenmint_response1.json", "r") as f:
 class TestGetXChainClaimID(TestCase):
     """Test get_xchain_claim_id."""
 
-    def test_decoding_a_valid_xchain_claim_id(self: TestGetXChainClaimID):
+    def test_decoding_a_valid_xchain_claim_id(self):
         result = get_xchain_claim_id(fixture["meta"])
         expected_xchain_claim_id = "b0"
         self.assertEqual(result, expected_xchain_claim_id)
 
-    def test_a_different_valid_xchain_claim_id(self: TestGetXChainClaimID):
+    def test_a_different_valid_xchain_claim_id(self):
         result = get_xchain_claim_id(fixture2["meta"])
         expected_xchain_claim_id = "ac"
         self.assertEqual(result, expected_xchain_claim_id)
 
-    def test_error_with_wrong_tx_metadata(self: TestGetXChainClaimID) -> None:
+    def test_error_with_wrong_tx_metadata(self) -> None:
         self.assertRaises(TypeError, lambda: get_xchain_claim_id(wrong_fixture["meta"]))
 
-    def test_error_with_raw_instead_of_meta(self: TestGetXChainClaimID) -> None:
+    def test_error_with_raw_instead_of_meta(self) -> None:
         self.assertRaises(TypeError, lambda: get_xchain_claim_id(fixture))

--- a/tests/unit/utils/test_parse_nftoken_id.py
+++ b/tests/unit/utils/test_parse_nftoken_id.py
@@ -1,4 +1,5 @@
 """Test the parse_nftoken_id util."""
+
 from __future__ import annotations
 
 from unittest import TestCase
@@ -10,7 +11,7 @@ from xrpl.utils import parse_nftoken_id
 class TestParseNFTokenID(TestCase):
     """Test parse_nftoken_id."""
 
-    def test_parse_nftoken_id_successful(self: TestParseNFTokenID) -> None:
+    def test_parse_nftoken_id_successful(self) -> None:
         nft_id = "000B0539C35B55AA096BA6D87A6E6C965A6534150DC56E5E12C5D09E0000000C"
         result = parse_nftoken_id(nft_id)
         expected = {
@@ -23,6 +24,6 @@ class TestParseNFTokenID(TestCase):
         }
         self.assertEqual(result, expected)
 
-    def test_parse_nftoken_id_raises(self: TestParseNFTokenID) -> None:
+    def test_parse_nftoken_id_raises(self) -> None:
         with self.assertRaises(XRPLException):
             parse_nftoken_id("ABCD")

--- a/tests/unit/utils/txn_parser/test_get_balance_changes.py
+++ b/tests/unit/utils/txn_parser/test_get_balance_changes.py
@@ -33,7 +33,7 @@ with open(path_to_json + "trustline_set_limit2.json", "r") as infile:
 
 
 class TestGetBalanceChanges(TestCase):
-    def test_payment_iou_destination_no_balance(self: TestGetBalanceChanges):
+    def test_payment_iou_destination_no_balance(self):
         actual = get_balance_changes(payment_iou_destination_no_balance["meta"])
         expected = [
             {
@@ -78,7 +78,7 @@ class TestGetBalanceChanges(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_payment_iou_multipath(self: TestGetBalanceChanges):
+    def test_payment_iou_multipath(self):
         actual = get_balance_changes(payment_iou_multipath["meta"])
         expected = [
             {
@@ -173,7 +173,7 @@ class TestGetBalanceChanges(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_payment_iou_redeem_then_issue(self: TestGetBalanceChanges):
+    def test_payment_iou_redeem_then_issue(self):
         actual = get_balance_changes(payment_iou_redeem_then_issue["meta"])
         expected = [
             {
@@ -200,7 +200,7 @@ class TestGetBalanceChanges(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_payment_iou_redeem(self: TestGetBalanceChanges):
+    def test_payment_iou_redeem(self):
         actual = get_balance_changes(payment_iou_redeem["meta"])
         expected = [
             {
@@ -230,7 +230,7 @@ class TestGetBalanceChanges(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_payment_iou_spend_full_balance(self: TestGetBalanceChanges):
+    def test_payment_iou_spend_full_balance(self):
         actual = get_balance_changes(payment_iou_spend_full_balance["meta"])
         expected = [
             {
@@ -275,7 +275,7 @@ class TestGetBalanceChanges(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_payment_iou(self: TestGetBalanceChanges):
+    def test_payment_iou(self):
         actual = get_balance_changes(payment_iou["meta"])
         expected = [
             {
@@ -320,7 +320,7 @@ class TestGetBalanceChanges(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_payment_xrp_create_account(self: TestGetBalanceChanges):
+    def test_payment_xrp_create_account(self):
         actual = get_balance_changes(payment_xrp_create_account["meta"])
         expected = [
             {
@@ -344,7 +344,7 @@ class TestGetBalanceChanges(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_trustline_create(self: TestGetBalanceChanges):
+    def test_trustline_create(self):
         actual = get_balance_changes(trustline_create["meta"])
         expected = [
             {
@@ -374,7 +374,7 @@ class TestGetBalanceChanges(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_trustline_delete(self: TestGetBalanceChanges):
+    def test_trustline_delete(self):
         actual = get_balance_changes(trustline_delete["meta"])
         expected = [
             {
@@ -419,7 +419,7 @@ class TestGetBalanceChanges(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_trustline_set_limit_zero(self: TestGetBalanceChanges):
+    def test_trustline_set_limit_zero(self):
         actual = get_balance_changes(trustline_set_limit_zero["meta"])
         expected = [
             {
@@ -434,7 +434,7 @@ class TestGetBalanceChanges(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_trustline_set_limit(self: TestGetBalanceChanges):
+    def test_trustline_set_limit(self):
         actual = get_balance_changes(trustline_set_limit["meta"])
         expected = [
             {
@@ -449,7 +449,7 @@ class TestGetBalanceChanges(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_trustline_set_limit2(self: TestGetBalanceChanges):
+    def test_trustline_set_limit2(self):
         actual = get_balance_changes(trustline_set_limit2["meta"])
         expected = [
             {

--- a/tests/unit/utils/txn_parser/test_get_final_balances.py
+++ b/tests/unit/utils/txn_parser/test_get_final_balances.py
@@ -33,7 +33,7 @@ with open(path_to_json + "trustline_set_limit2.json", "r") as infile:
 
 
 class TestGetFinalBalances(TestCase):
-    def test_payment_iou_destination_no_balance(self: TestGetFinalBalances):
+    def test_payment_iou_destination_no_balance(self):
         actual = get_final_balances(payment_iou_destination_no_balance["meta"])
         expected = [
             {
@@ -75,7 +75,7 @@ class TestGetFinalBalances(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_payment_iou_multipath(self: TestGetFinalBalances):
+    def test_payment_iou_multipath(self):
         actual = get_final_balances(payment_iou_multipath["meta"])
         expected = [
             {
@@ -135,7 +135,7 @@ class TestGetFinalBalances(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_payment_iou_redeem_then_issue(self: TestGetFinalBalances):
+    def test_payment_iou_redeem_then_issue(self):
         actual = get_final_balances(payment_iou_redeem_then_issue["meta"])
         expected = [
             {
@@ -162,7 +162,7 @@ class TestGetFinalBalances(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_payment_iou_redeem(self: TestGetFinalBalances):
+    def test_payment_iou_redeem(self):
         actual = get_final_balances(payment_iou_redeem["meta"])
         expected = [
             {
@@ -189,7 +189,7 @@ class TestGetFinalBalances(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_payment_iou_spend_full_balance(self: TestGetFinalBalances):
+    def test_payment_iou_spend_full_balance(self):
         actual = get_final_balances(payment_iou_spend_full_balance["meta"])
         expected = [
             {
@@ -219,7 +219,7 @@ class TestGetFinalBalances(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_payment_iou(self: TestGetFinalBalances):
+    def test_payment_iou(self):
         actual = get_final_balances(payment_iou["meta"])
         expected = [
             {
@@ -261,7 +261,7 @@ class TestGetFinalBalances(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_payment_xrp_create_account(self: TestGetFinalBalances):
+    def test_payment_xrp_create_account(self):
         actual = get_final_balances(payment_xrp_create_account["meta"])
         expected = [
             {
@@ -275,7 +275,7 @@ class TestGetFinalBalances(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_trustline_create(self: TestGetFinalBalances):
+    def test_trustline_create(self):
         actual = get_final_balances(trustline_create["meta"])
         expected = [
             {
@@ -302,7 +302,7 @@ class TestGetFinalBalances(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_trustline_delete(self: TestGetFinalBalances):
+    def test_trustline_delete(self):
         actual = get_final_balances(trustline_delete["meta"])
         expected = [
             {
@@ -332,7 +332,7 @@ class TestGetFinalBalances(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_trustline_set_limit_zero(self: TestGetFinalBalances):
+    def test_trustline_set_limit_zero(self):
         actual = get_final_balances(trustline_set_limit_zero["meta"])
         expected = [
             {
@@ -359,7 +359,7 @@ class TestGetFinalBalances(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_trustline_set_limit(self: TestGetFinalBalances):
+    def test_trustline_set_limit(self):
         actual = get_final_balances(trustline_set_limit["meta"])
         expected = [
             {
@@ -386,7 +386,7 @@ class TestGetFinalBalances(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_trustline_set_limit2(self: TestGetFinalBalances):
+    def test_trustline_set_limit2(self):
         actual = get_final_balances(trustline_set_limit2["meta"])
         expected = [
             {

--- a/tests/unit/utils/txn_parser/test_get_order_book_changes.py
+++ b/tests/unit/utils/txn_parser/test_get_order_book_changes.py
@@ -17,7 +17,7 @@ with open(path_to_json + "offer_with_expiration.json", "r") as infile:
 
 
 class TestGetOrderBookChanges(TestCase):
-    def test_offer_created(self: TestGetOrderBookChanges):
+    def test_offer_created(self):
         actual = get_order_book_changes(offer_created["meta"])
         expected = [
             {
@@ -41,7 +41,7 @@ class TestGetOrderBookChanges(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_offer_partially_filled_and_filled(self: TestGetOrderBookChanges):
+    def test_offer_partially_filled_and_filled(self):
         actual = get_order_book_changes(offer_partially_filled_and_filled["meta"])
         expected = [
             {
@@ -89,7 +89,7 @@ class TestGetOrderBookChanges(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_offer_cancelled(self: TestGetOrderBookChanges):
+    def test_offer_cancelled(self):
         actual = get_order_book_changes(offer_cancelled["meta"])
         expected = [
             {
@@ -112,7 +112,7 @@ class TestGetOrderBookChanges(TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    def test_offer_with_expiration(self: TestGetOrderBookChanges):
+    def test_offer_with_expiration(self):
         actual = get_order_book_changes(offer_with_expiration["meta"])
         expected = [
             {

--- a/xrpl/asyncio/clients/async_client.py
+++ b/xrpl/asyncio/clients/async_client.py
@@ -1,5 +1,8 @@
 """Interface for all async network clients to follow."""
+
 from __future__ import annotations
+
+from typing_extensions import Self
 
 from xrpl.asyncio.clients.client import Client
 from xrpl.models.requests.request import Request
@@ -13,7 +16,7 @@ class AsyncClient(Client):
     :meta private:
     """
 
-    async def request(self: AsyncClient, request: Request) -> Response:
+    async def request(self: Self, request: Request) -> Response:
         """
         Makes a request with this client and returns the response.
 

--- a/xrpl/asyncio/clients/async_websocket_client.py
+++ b/xrpl/asyncio/clients/async_websocket_client.py
@@ -1,9 +1,12 @@
 """A client for interacting with the rippled WebSocket API."""
+
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from types import TracebackType
 from typing import Any, Dict, Type
+
+from typing_extensions import Self
 
 from xrpl.asyncio.clients.async_client import AsyncClient
 from xrpl.asyncio.clients.client import REQUEST_TIMEOUT
@@ -206,17 +209,17 @@ class AsyncWebsocketClient(AsyncClient, WebsocketBase):
             asyncio.run(main())
     """
 
-    async def open(self: AsyncWebsocketClient) -> None:
+    async def open(self: Self) -> None:
         """Connects the client to the Web Socket API at the given URL."""
         if not self.is_open():
             await self._do_open()
 
-    async def close(self: AsyncWebsocketClient) -> None:
+    async def close(self: Self) -> None:
         """Closes the connection."""
         if self.is_open():
             await self._do_close()
 
-    async def __aenter__(self: AsyncWebsocketClient) -> AsyncWebsocketClient:
+    async def __aenter__(self: Self) -> AsyncWebsocketClient:
         """
         Enters an async context after opening itself.
 
@@ -227,7 +230,7 @@ class AsyncWebsocketClient(AsyncClient, WebsocketBase):
         return self
 
     async def __aexit__(
-        self: AsyncWebsocketClient,
+        self: Self,
         _exc_type: Type[BaseException],
         _exc_val: BaseException,
         _trace: TracebackType,
@@ -235,7 +238,7 @@ class AsyncWebsocketClient(AsyncClient, WebsocketBase):
         """Exits an async context after closing itself."""
         await self.close()
 
-    async def __aiter__(self: AsyncWebsocketClient) -> AsyncIterator[Dict[str, Any]]:
+    async def __aiter__(self: Self) -> AsyncIterator[Dict[str, Any]]:
         """
         Iterate on received messages.
 
@@ -245,7 +248,7 @@ class AsyncWebsocketClient(AsyncClient, WebsocketBase):
         while self.is_open():
             yield await self._do_pop_message()
 
-    async def send(self: AsyncWebsocketClient, request: Request) -> None:
+    async def send(self: Self, request: Request) -> None:
         """
         Submit the request represented by the request to the
         rippled node specified by this client's URL. Unlike ``request``,
@@ -264,7 +267,7 @@ class AsyncWebsocketClient(AsyncClient, WebsocketBase):
         await self._do_send(request)
 
     async def _request_impl(
-        self: WebsocketBase, request: Request, *, timeout: float = REQUEST_TIMEOUT
+        self: Self, request: Request, *, timeout: float = REQUEST_TIMEOUT
     ) -> Response:
         """
         ``_request_impl`` implementation for async websocket.

--- a/xrpl/asyncio/clients/async_websocket_client.py
+++ b/xrpl/asyncio/clients/async_websocket_client.py
@@ -219,7 +219,7 @@ class AsyncWebsocketClient(AsyncClient, WebsocketBase):
         if self.is_open():
             await self._do_close()
 
-    async def __aenter__(self: Self) -> AsyncWebsocketClient:
+    async def __aenter__(self: Self) -> Self:
         """
         Enters an async context after opening itself.
 

--- a/xrpl/asyncio/clients/client.py
+++ b/xrpl/asyncio/clients/client.py
@@ -1,10 +1,11 @@
 """Interface for all network clients to follow."""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import Optional
 
-from typing_extensions import Final
+from typing_extensions import Final, Self
 
 from xrpl.models.requests.request import Request
 from xrpl.models.response import Response
@@ -21,7 +22,7 @@ class Client(ABC):
     :meta private:
     """
 
-    def __init__(self: Client, url: str) -> None:
+    def __init__(self: Self, url: str) -> None:
         """
         Initializes a client.
 
@@ -34,7 +35,7 @@ class Client(ABC):
 
     @abstractmethod
     async def _request_impl(
-        self: Client, request: Request, *, timeout: float = REQUEST_TIMEOUT
+        self: Self, request: Request, *, timeout: float = REQUEST_TIMEOUT
     ) -> Response:
         """
         This is the actual driver for a given Client's request. It must be

--- a/xrpl/asyncio/clients/exceptions.py
+++ b/xrpl/asyncio/clients/exceptions.py
@@ -1,7 +1,10 @@
 """General XRPL Client Exceptions."""
+
 from __future__ import annotations
 
 from typing import Any, Dict
+
+from typing_extensions import Self
 
 from xrpl.constants import XRPLException
 
@@ -9,7 +12,7 @@ from xrpl.constants import XRPLException
 class XRPLRequestFailureException(XRPLException):
     """XRPL Request Exception, when the request fails."""
 
-    def __init__(self: XRPLRequestFailureException, result: Dict[str, Any]) -> None:
+    def __init__(self: Self, result: Dict[str, Any]) -> None:
         """
         Initializes a XRPLRequestFailureException.
 

--- a/xrpl/asyncio/clients/json_rpc_base.py
+++ b/xrpl/asyncio/clients/json_rpc_base.py
@@ -1,9 +1,11 @@
 """A common interface for JsonRpc requests."""
+
 from __future__ import annotations
 
 from json import JSONDecodeError
 
 from httpx import AsyncClient
+from typing_extensions import Self
 
 from xrpl.asyncio.clients.client import REQUEST_TIMEOUT, Client
 from xrpl.asyncio.clients.exceptions import XRPLRequestFailureException
@@ -20,7 +22,7 @@ class JsonRpcBase(Client):
     """
 
     async def _request_impl(
-        self: JsonRpcBase, request: Request, *, timeout: float = REQUEST_TIMEOUT
+        self: Self, request: Request, *, timeout: float = REQUEST_TIMEOUT
     ) -> Response:
         """
         Base ``_request_impl`` implementation for JSON RPC.

--- a/xrpl/asyncio/clients/websocket_base.py
+++ b/xrpl/asyncio/clients/websocket_base.py
@@ -1,4 +1,5 @@
 """A client for interacting with the rippled WebSocket API."""
+
 from __future__ import annotations
 
 import asyncio
@@ -6,7 +7,7 @@ import json
 from random import randrange
 from typing import TYPE_CHECKING, Any, Dict, Optional, cast
 
-from typing_extensions import Final
+from typing_extensions import Final, Self
 from websockets import client as websocket_client
 
 from xrpl.asyncio.clients.client import Client
@@ -55,7 +56,7 @@ class WebsocketBase(Client):
     :meta private:
     """
 
-    def __init__(self: WebsocketBase, url: str) -> None:
+    def __init__(self: Self, url: str) -> None:
         """
         Initializes a websocket client.
 
@@ -72,7 +73,7 @@ class WebsocketBase(Client):
         self._messages: Optional[_MESSAGES_TYPE] = None
         super().__init__(url)
 
-    def is_open(self: WebsocketBase) -> bool:
+    def is_open(self: Self) -> bool:
         """
         Returns whether the client is currently open.
 
@@ -86,7 +87,7 @@ class WebsocketBase(Client):
             and self._websocket.open
         )
 
-    async def _do_open(self: WebsocketBase) -> None:
+    async def _do_open(self: Self) -> None:
         """Connects the client to the Web Socket API at its URL."""
         # open the connection
         self._websocket = await websocket_client.connect(self.url)
@@ -97,7 +98,7 @@ class WebsocketBase(Client):
         # start the handler
         self._handler_task = asyncio.create_task(self._handler())
 
-    async def _do_close(self: WebsocketBase) -> None:
+    async def _do_close(self: Self) -> None:
         """Closes the connection."""
         # cancel the handler
         cast(_HANDLER_TYPE, self._handler_task).cancel()
@@ -117,7 +118,7 @@ class WebsocketBase(Client):
         # close the connection
         await cast(websocket_client.WebSocketClientProtocol, self._websocket).close()
 
-    async def _handler(self: WebsocketBase) -> None:
+    async def _handler(self: Self) -> None:
         """
         This is basically a middleware for the websocket library. For all received
         messages we check whether there is an outstanding future we need to resolve,
@@ -139,7 +140,7 @@ class WebsocketBase(Client):
             # enqueue the response for the message queue
             cast(_MESSAGES_TYPE, self._messages).put_nowait(response_dict)
 
-    def _set_up_future(self: WebsocketBase, request: Request) -> None:
+    def _set_up_future(self: Self, request: Request) -> None:
         """
         Only to be called from the public send and _request_impl functions.
         Given a request with an ID, ensure that that ID is backed by an open
@@ -164,7 +165,7 @@ class WebsocketBase(Client):
             )
         self._open_requests[request_str] = asyncio.get_running_loop().create_future()
 
-    async def _do_send_no_future(self: WebsocketBase, request: Request) -> None:
+    async def _do_send_no_future(self: Self, request: Request) -> None:
         """
         Base websocket send function
 
@@ -177,7 +178,7 @@ class WebsocketBase(Client):
             ),
         )
 
-    async def _do_send(self: WebsocketBase, request: Request) -> None:
+    async def _do_send(self: Self, request: Request) -> None:
         """
         Websocket send function that should be used by
         any inherited classes.
@@ -190,7 +191,7 @@ class WebsocketBase(Client):
         self._set_up_future(request)
         await self._do_send_no_future(request)
 
-    async def _do_pop_message(self: WebsocketBase) -> Dict[str, Any]:
+    async def _do_pop_message(self: Self) -> Dict[str, Any]:
         """
         Returns:
             The top message from the queue
@@ -200,7 +201,7 @@ class WebsocketBase(Client):
         return msg
 
     async def _do_request_impl(
-        self: WebsocketBase, request: Request, timeout: float
+        self: Self, request: Request, timeout: float
     ) -> Response:
         """
         Base ``_request_impl`` implementation for websockets.

--- a/xrpl/clients/sync_client.py
+++ b/xrpl/clients/sync_client.py
@@ -1,7 +1,10 @@
 """Interface for all sync network clients to follow."""
+
 from __future__ import annotations
 
 import asyncio
+
+from typing_extensions import Self
 
 from xrpl.asyncio.clients.client import Client
 from xrpl.models.requests.request import Request
@@ -15,7 +18,7 @@ class SyncClient(Client):
     :meta private:
     """
 
-    def request(self: SyncClient, request: Request) -> Response:
+    def request(self: Self, request: Request) -> Response:
         """
         Makes a request with this client and returns the response.
 

--- a/xrpl/clients/websocket_client.py
+++ b/xrpl/clients/websocket_client.py
@@ -1,4 +1,5 @@
 """A sync client for interacting with the rippled WebSocket API."""
+
 from __future__ import annotations
 
 import asyncio
@@ -6,6 +7,8 @@ from concurrent.futures import CancelledError, TimeoutError
 from threading import Thread
 from types import TracebackType
 from typing import Any, Dict, Iterator, Optional, Type, Union, cast
+
+from typing_extensions import Self
 
 from xrpl.asyncio.clients.client import REQUEST_TIMEOUT
 from xrpl.asyncio.clients.exceptions import XRPLWebsocketException
@@ -66,7 +69,7 @@ class WebsocketClient(SyncClient, WebsocketBase):
     """
 
     def __init__(
-        self: WebsocketClient, url: str, timeout: Optional[Union[int, float]] = None
+        self: Self, url: str, timeout: Optional[Union[int, float]] = None
     ) -> None:
         """
         Constructs a WebsocketClient.
@@ -82,7 +85,7 @@ class WebsocketClient(SyncClient, WebsocketBase):
         self._thread: Optional[Thread] = None
         super().__init__(url)
 
-    def is_open(self: WebsocketClient) -> bool:
+    def is_open(self: Self) -> bool:
         """
         Returns whether the client is currently open.
 
@@ -91,7 +94,7 @@ class WebsocketClient(SyncClient, WebsocketBase):
         """
         return self._loop is not None and self._thread is not None and super().is_open()
 
-    def open(self: WebsocketClient) -> None:
+    def open(self: Self) -> None:
         """Connects the client to the Web Socket API at the given URL."""
         if self.is_open():
             return
@@ -110,7 +113,7 @@ class WebsocketClient(SyncClient, WebsocketBase):
         # wait for it to finish
         asyncio.run_coroutine_threadsafe(self._do_open(), self._loop).result()
 
-    def close(self: WebsocketClient) -> None:
+    def close(self: Self) -> None:
         """Closes the connection."""
         if not self.is_open():
             return
@@ -135,7 +138,7 @@ class WebsocketClient(SyncClient, WebsocketBase):
         self._loop = None
         self._thread = None
 
-    def __enter__(self: WebsocketClient) -> WebsocketClient:
+    def __enter__(self: Self) -> WebsocketClient:
         """
         Enters a context after opening itself.
 
@@ -146,7 +149,7 @@ class WebsocketClient(SyncClient, WebsocketBase):
         return self
 
     def __exit__(
-        self: WebsocketClient,
+        self: Self,
         _exc_type: Type[BaseException],
         _exc_val: BaseException,
         _trace: TracebackType,
@@ -154,7 +157,7 @@ class WebsocketClient(SyncClient, WebsocketBase):
         """Exits a context after closing itself."""
         self.close()
 
-    def __iter__(self: WebsocketClient) -> Iterator[Dict[str, Any]]:
+    def __iter__(self: Self) -> Iterator[Dict[str, Any]]:
         """
         Iterate on received messages. This iterator will block until
         a message is received. If no message is received within
@@ -181,7 +184,7 @@ class WebsocketClient(SyncClient, WebsocketBase):
                 # stop listening but don't need to cancel it
                 break
 
-    def send(self: WebsocketClient, request: Request) -> None:
+    def send(self: Self, request: Request) -> None:
         """
         Submit the request represented by the request to the
         rippled node specified by this client's URL. Unlike ``request``,
@@ -202,7 +205,7 @@ class WebsocketClient(SyncClient, WebsocketBase):
         ).result()
 
     async def _request_impl(
-        self: WebsocketClient, request: Request, *, timeout: float = REQUEST_TIMEOUT
+        self: Self, request: Request, *, timeout: float = REQUEST_TIMEOUT
     ) -> Response:
         """
         ``_request_impl`` implementation for sync websockets that ensures the

--- a/xrpl/clients/websocket_client.py
+++ b/xrpl/clients/websocket_client.py
@@ -138,7 +138,7 @@ class WebsocketClient(SyncClient, WebsocketBase):
         self._loop = None
         self._thread = None
 
-    def __enter__(self: Self) -> WebsocketClient:
+    def __enter__(self: Self) -> Self:
         """
         Enters a context after opening itself.
 
@@ -163,7 +163,7 @@ class WebsocketClient(SyncClient, WebsocketBase):
         a message is received. If no message is received within
         `self.timeout` seconds then the iterator will exit. If
         `self.timeout` is `None` or `0` then the iterator will block
-        indefinetly for the next messsage.
+        indefinitely for the next message.
 
         Yields:
             The message at the top of the queue.

--- a/xrpl/core/binarycodec/binary_wrappers/binary_parser.py
+++ b/xrpl/core/binarycodec/binary_wrappers/binary_parser.py
@@ -1,9 +1,10 @@
 """Context manager and helpers for the deserialization of bytes into JSON."""
+
 from __future__ import annotations  # Requires Python 3.7+
 
 from typing import TYPE_CHECKING, Optional, Tuple, Type, cast
 
-from typing_extensions import Final
+from typing_extensions import Final, Self
 
 from xrpl.core.binarycodec.definitions import definitions
 from xrpl.core.binarycodec.definitions.field_header import FieldHeader
@@ -30,15 +31,15 @@ _MAX_DOUBLE_BYTE_VALUE: Final[int] = 65536
 class BinaryParser:
     """Deserializes from hex-encoded XRPL binary format to JSON fields and values."""
 
-    def __init__(self: BinaryParser, hex_bytes: str) -> None:
+    def __init__(self: Self, hex_bytes: str) -> None:
         """Construct a BinaryParser that will parse hex-encoded bytes."""
         self.bytes = bytes.fromhex(hex_bytes)
 
-    def __len__(self: BinaryParser) -> int:
+    def __len__(self: Self) -> int:
         """Return the number of bytes in this parser's buffer."""
         return len(self.bytes)
 
-    def peek(self: BinaryParser) -> Optional[bytes]:
+    def peek(self: Self) -> Optional[bytes]:
         """
         Peek the first byte of the BinaryParser.
 
@@ -49,7 +50,7 @@ class BinaryParser:
             return cast(bytes, self.bytes[0])
         return None
 
-    def skip(self: BinaryParser, n: int) -> None:
+    def skip(self: Self, n: int) -> None:
         """
         Consume the first n bytes of the BinaryParser.
 
@@ -65,7 +66,7 @@ class BinaryParser:
             )
         self.bytes = self.bytes[n:]
 
-    def read(self: BinaryParser, n: int) -> bytes:
+    def read(self: Self, n: int) -> bytes:
         """
         Consume and return the first n bytes of the BinaryParser.
 
@@ -79,7 +80,7 @@ class BinaryParser:
         self.skip(n)
         return first_n_bytes
 
-    def read_uint8(self: BinaryParser) -> int:
+    def read_uint8(self: Self) -> int:
         """
         Read 1 byte from parser and return as unsigned int.
 
@@ -88,7 +89,7 @@ class BinaryParser:
         """
         return int.from_bytes(self.read(1), byteorder="big", signed=False)
 
-    def read_uint16(self: BinaryParser) -> int:
+    def read_uint16(self: Self) -> int:
         """
         Read 2 bytes from parser and return as unsigned int.
 
@@ -97,7 +98,7 @@ class BinaryParser:
         """
         return int.from_bytes(self.read(2), byteorder="big", signed=False)
 
-    def read_uint32(self: BinaryParser) -> int:
+    def read_uint32(self: Self) -> int:
         """
         Read 4 bytes from parser and return as unsigned int.
 
@@ -106,7 +107,7 @@ class BinaryParser:
         """
         return int.from_bytes(self.read(4), byteorder="big", signed=False)
 
-    def is_end(self: BinaryParser, custom_end: Optional[int] = None) -> bool:
+    def is_end(self: Self, custom_end: Optional[int] = None) -> bool:
         """
         Returns whether the binary parser has finished parsing (e.g. there is nothing
         left in the buffer that needs to be processed).
@@ -121,7 +122,7 @@ class BinaryParser:
             custom_end is not None and len(self.bytes) <= custom_end
         )
 
-    def read_variable_length(self: BinaryParser) -> bytes:
+    def read_variable_length(self: Self) -> bytes:
         """
         Reads and returns variable length encoded bytes.
 
@@ -130,7 +131,7 @@ class BinaryParser:
         """
         return self.read(self._read_length_prefix())
 
-    def _read_length_prefix(self: BinaryParser) -> int:
+    def _read_length_prefix(self: Self) -> int:
         """
         Reads a variable length encoding prefix and returns the encoded length.
 
@@ -168,7 +169,7 @@ class BinaryParser:
             "Length prefix must contain between 1 and 3 bytes."
         )
 
-    def read_field_header(self: BinaryParser) -> FieldHeader:
+    def read_field_header(self: Self) -> FieldHeader:
         """
         Reads field ID from BinaryParser and returns as a FieldHeader object.
 
@@ -197,7 +198,7 @@ class BinaryParser:
                 )
         return FieldHeader(type_code, field_code)
 
-    def read_field(self: BinaryParser) -> FieldInstance:
+    def read_field(self: Self) -> FieldInstance:
         """
         Read the field ordinal at the head of the BinaryParser and return a
         FieldInstance object representing information about the field contained
@@ -210,9 +211,7 @@ class BinaryParser:
         field_name = definitions.get_field_name_from_header(field_header)
         return definitions.get_field_instance(field_name)
 
-    def read_type(
-        self: BinaryParser, field_type: Type[SerializedType]
-    ) -> SerializedType:
+    def read_type(self: Self, field_type: Type[SerializedType]) -> SerializedType:
         """
         Read next bytes from BinaryParser as the given type.
 
@@ -224,7 +223,7 @@ class BinaryParser:
         """
         return field_type.from_parser(self, None)
 
-    def read_field_value(self: BinaryParser, field: FieldInstance) -> SerializedType:
+    def read_field_value(self: Self, field: FieldInstance) -> SerializedType:
         """
         Read value of the type specified by field from the BinaryParser.
 
@@ -250,7 +249,7 @@ class BinaryParser:
         return value
 
     def read_field_and_value(
-        self: BinaryParser,
+        self: Self,
     ) -> Tuple[FieldInstance, SerializedType]:
         """
         Get the next field and value from the BinaryParser.

--- a/xrpl/core/binarycodec/binary_wrappers/binary_serializer.py
+++ b/xrpl/core/binarycodec/binary_wrappers/binary_serializer.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations  # Requires Python 3.7+
 
-from typing_extensions import Final
+from typing_extensions import Final, Self
 
 from xrpl.core.binarycodec.definitions.field_instance import FieldInstance
 from xrpl.core.binarycodec.types.serialized_type import SerializedType
@@ -54,11 +54,11 @@ def _encode_variable_length_prefix(length: int) -> bytes:
 class BinarySerializer:
     """Serializes JSON to XRPL binary format."""
 
-    def __init__(self: BinarySerializer) -> None:
+    def __init__(self: Self) -> None:
         """Construct a BinarySerializer."""
         self.bytesink = bytes()
 
-    def append(self: BinarySerializer, bytes_object: bytes) -> None:
+    def append(self: Self, bytes_object: bytes) -> None:
         """
         Write given bytes to this BinarySerializer's bytesink.
 
@@ -67,7 +67,7 @@ class BinarySerializer:
         """
         self.bytesink += bytes_object
 
-    def __bytes__(self: BinarySerializer) -> bytes:
+    def __bytes__(self: Self) -> bytes:
         """
         Get the bytes representation of a BinarySerializer.
 
@@ -77,7 +77,7 @@ class BinarySerializer:
         return self.bytesink
 
     def write_length_encoded(
-        self: BinarySerializer,
+        self: Self,
         value: SerializedType,
         encode_value: bool = True,
     ) -> None:
@@ -97,7 +97,7 @@ class BinarySerializer:
         self.bytesink += byte_object
 
     def write_field_and_value(
-        self: BinarySerializer,
+        self: Self,
         field: FieldInstance,
         value: SerializedType,
         is_unl_modify_workaround: bool = False,

--- a/xrpl/core/binarycodec/definitions/field_header.py
+++ b/xrpl/core/binarycodec/definitions/field_header.py
@@ -1,5 +1,8 @@
 """A container class for simultaneous storage of a field's type code and field code."""
+
 from __future__ import annotations  # Requires Python 3.7+
+
+from typing_extensions import Self
 
 
 class FieldHeader:
@@ -7,7 +10,7 @@ class FieldHeader:
     field code.
     """
 
-    def __init__(self: FieldHeader, type_code: int, field_code: int) -> None:
+    def __init__(self: Self, type_code: int, field_code: int) -> None:
         """
         Construct a FieldHeader.
         `See Field Order <https://xrpl.org/serialization.html#canonical-field-order>`_
@@ -18,17 +21,17 @@ class FieldHeader:
         self.type_code = type_code
         self.field_code = field_code
 
-    def __eq__(self: FieldHeader, other: object) -> bool:
+    def __eq__(self: Self, other: object) -> bool:
         """Two FieldHeaders are equal if both type code and field_code are the same."""
         if not isinstance(other, FieldHeader):
             return NotImplemented
         return self.type_code == other.type_code and self.field_code == other.field_code
 
-    def __hash__(self: FieldHeader) -> int:
+    def __hash__(self: Self) -> int:
         """Two equal FieldHeaders must have the same hash value."""
         return hash((self.type_code, self.field_code))
 
-    def __bytes__(self: FieldHeader) -> bytes:
+    def __bytes__(self: Self) -> bytes:
         """
         Get the bytes representation of a FieldHeader.
 
@@ -49,6 +52,6 @@ class FieldHeader:
 
         return bytes(header)
 
-    def __repr__(self: FieldHeader) -> str:
+    def __repr__(self: Self) -> str:
         """Print a string representation of a FieldHeader (for debugging)."""
         return f"FieldHeader({self.type_code}, {self.field_code})"

--- a/xrpl/core/binarycodec/definitions/field_info.py
+++ b/xrpl/core/binarycodec/definitions/field_info.py
@@ -1,5 +1,8 @@
 """Model object for field info from the "fields" section of definitions.json."""
+
 from __future__ import annotations  # Requires Python 3.7+
+
+from typing_extensions import Self
 
 
 class FieldInfo:
@@ -8,7 +11,7 @@ class FieldInfo:
     """
 
     def __init__(
-        self: FieldInfo,
+        self: Self,
         nth: int,
         is_variable_length_encoded: bool,
         is_serialized: bool,

--- a/xrpl/core/binarycodec/definitions/field_instance.py
+++ b/xrpl/core/binarycodec/definitions/field_instance.py
@@ -1,7 +1,10 @@
 """A collection of serialization information about a specific field type."""
+
 from __future__ import annotations  # Requires Python 3.7+
 
 from typing import TYPE_CHECKING, Dict, Type
+
+from typing_extensions import Self
 
 from xrpl.core.binarycodec.definitions.field_header import FieldHeader
 from xrpl.core.binarycodec.definitions.field_info import FieldInfo
@@ -36,7 +39,7 @@ class FieldInstance:
     """A collection of serialization information about a specific field type."""
 
     def __init__(
-        self: FieldInstance,
+        self: Self,
         field_info: FieldInfo,
         field_name: str,
         field_header: FieldHeader,

--- a/xrpl/core/binarycodec/types/account_id.py
+++ b/xrpl/core/binarycodec/types/account_id.py
@@ -1,12 +1,13 @@
 """Codec for serializing and deserializing AccountID fields.
 See `AccountID Fields <https://xrpl.org/serialization.html#accountid-fields>`_
 """
+
 from __future__ import annotations  # Requires Python 3.7+
 
 import re
 from typing import Optional, Pattern, Type
 
-from typing_extensions import Final
+from typing_extensions import Final, Self
 
 from xrpl.core.addresscodec import (
     decode_classic_address,
@@ -30,7 +31,7 @@ class AccountID(Hash160):
 
     LENGTH: Final[int] = 20  # bytes
 
-    def __init__(self: AccountID, buffer: Optional[bytes] = None) -> None:
+    def __init__(self: Self, buffer: Optional[bytes] = None) -> None:
         """
         Construct an AccountID from given bytes.
         If buffer is not provided, default to 20 zero bytes.
@@ -78,7 +79,7 @@ class AccountID(Hash160):
             f"or X-Address, received {value.__class__.__name__}."
         )
 
-    def to_json(self: AccountID) -> str:
+    def to_json(self: Self) -> str:
         """
         Return the value of this AccountID encoded as a base58 string.
 

--- a/xrpl/core/binarycodec/types/account_id.py
+++ b/xrpl/core/binarycodec/types/account_id.py
@@ -42,7 +42,7 @@ class AccountID(Hash160):
             super().__init__(bytes(self.LENGTH))
 
     @classmethod
-    def from_value(cls: Type[AccountID], value: str) -> AccountID:
+    def from_value(cls: Type[Self], value: str) -> Self:
         """
         Construct an AccountID from a hex string or a base58 r-Address.
 

--- a/xrpl/core/binarycodec/types/amount.py
+++ b/xrpl/core/binarycodec/types/amount.py
@@ -2,12 +2,13 @@
 Codec for serializing and deserializing Amount fields.
 See `Amount Fields <https://xrpl.org/serialization.html#amount-fields>`_
 """
+
 from __future__ import annotations
 
 from decimal import MAX_PREC, Context, Decimal, localcontext
 from typing import Any, Dict, Optional, Type, Union
 
-from typing_extensions import Final
+from typing_extensions import Final, Self
 
 from xrpl.constants import (
     IOU_DECIMAL_CONTEXT,
@@ -222,7 +223,7 @@ class Amount(SerializedType):
     See `Amount Fields <https://xrpl.org/serialization.html#amount-fields>`_
     """
 
-    def __init__(self: Amount, buffer: bytes) -> None:
+    def __init__(self: Self, buffer: bytes) -> None:
         """Construct an Amount from given bytes."""
         super().__init__(buffer)
 
@@ -277,7 +278,7 @@ class Amount(SerializedType):
             num_bytes = _NATIVE_AMOUNT_BYTE_LENGTH
         return cls(parser.read(num_bytes))
 
-    def to_json(self: Amount) -> Union[str, Dict[Any, Any]]:
+    def to_json(self: Self) -> Union[str, Dict[Any, Any]]:
         """Construct a JSON object representing this Amount.
 
         Returns:
@@ -314,7 +315,7 @@ class Amount(SerializedType):
             "issuer": issuer.to_json(),
         }
 
-    def is_native(self: Amount) -> bool:
+    def is_native(self: Self) -> bool:
         """Returns True if this amount is a native XRP amount.
 
         Returns:
@@ -323,7 +324,7 @@ class Amount(SerializedType):
         # 1st bit in 1st byte is set to 0 for native XRP
         return (self.buffer[0] & 0x80) == 0
 
-    def is_positive(self: Amount) -> bool:
+    def is_positive(self: Self) -> bool:
         """Returns True if 2nd bit in 1st byte is set to 1 (positive amount).
 
         Returns:

--- a/xrpl/core/binarycodec/types/amount.py
+++ b/xrpl/core/binarycodec/types/amount.py
@@ -228,7 +228,7 @@ class Amount(SerializedType):
         super().__init__(buffer)
 
     @classmethod
-    def from_value(cls: Type[Amount], value: Union[str, Dict[str, str]]) -> Amount:
+    def from_value(cls: Type[Self], value: Union[str, Dict[str, str]]) -> Self:
         """
         Construct an Amount from an issued currency amount or (for XRP),
         a string amount.
@@ -257,8 +257,8 @@ class Amount(SerializedType):
 
     @classmethod
     def from_parser(
-        cls: Type[Amount], parser: BinaryParser, length_hint: Optional[int] = None
-    ) -> Amount:
+        cls: Type[Self], parser: BinaryParser, length_hint: Optional[int] = None
+    ) -> Self:
         """Construct an Amount from an existing BinaryParser.
 
         Args:

--- a/xrpl/core/binarycodec/types/blob.py
+++ b/xrpl/core/binarycodec/types/blob.py
@@ -25,7 +25,7 @@ class Blob(SerializedType):
         super().__init__(buffer)
 
     @classmethod
-    def from_parser(cls: Type[Blob], parser: BinaryParser, length_hint: int) -> Blob:
+    def from_parser(cls: Type[Self], parser: BinaryParser, length_hint: int) -> Self:
         """
         Defines how to read a Blob from a BinaryParser.
 
@@ -39,7 +39,7 @@ class Blob(SerializedType):
         return cls(parser.read(length_hint))
 
     @classmethod
-    def from_value(cls: Type[Blob], value: str) -> Blob:
+    def from_value(cls: Type[Self], value: str) -> Self:
         """
         Create a Blob object from a hex-string.
 

--- a/xrpl/core/binarycodec/types/blob.py
+++ b/xrpl/core/binarycodec/types/blob.py
@@ -2,9 +2,12 @@
 Codec for serializing and deserializing blob fields.
 See `Blob Fields <https://xrpl.org/serialization.html#blob-fields>`_
 """
+
 from __future__ import annotations
 
 from typing import Type
+
+from typing_extensions import Self
 
 from xrpl.core.binarycodec.binary_wrappers.binary_parser import BinaryParser
 from xrpl.core.binarycodec.exceptions import XRPLBinaryCodecException
@@ -17,7 +20,7 @@ class Blob(SerializedType):
     See `Blob Fields <https://xrpl.org/serialization.html#blob-fields>`_
     """
 
-    def __init__(self: Blob, buffer: bytes) -> None:
+    def __init__(self: Self, buffer: bytes) -> None:
         """Construct a new Blob type from a ``bytes`` value."""
         super().__init__(buffer)
 

--- a/xrpl/core/binarycodec/types/currency.py
+++ b/xrpl/core/binarycodec/types/currency.py
@@ -1,9 +1,10 @@
 """Codec for currency property inside an XRPL issued currency amount json."""
+
 from __future__ import annotations  # Requires Python 3.7+
 
 from typing import Optional, Type
 
-from typing_extensions import Final
+from typing_extensions import Final, Self
 
 from xrpl.constants import HEX_CURRENCY_REGEX, ISO_CURRENCY_REGEX
 from xrpl.core.binarycodec.exceptions import XRPLBinaryCodecException
@@ -73,7 +74,7 @@ class Currency(Hash160):
     LENGTH: Final[int] = 20
     _iso: Optional[str] = None
 
-    def __init__(self: Currency, buffer: Optional[bytes] = None) -> None:
+    def __init__(self: Self, buffer: Optional[bytes] = None) -> None:
         """Construct a Currency."""
         if buffer is not None:
             super().__init__(buffer)
@@ -118,7 +119,7 @@ class Currency(Hash160):
             return cls(bytes.fromhex(value))
         raise XRPLBinaryCodecException("Unsupported Currency representation: {value}")
 
-    def to_json(self: Currency) -> str:
+    def to_json(self: Self) -> str:
         """
         Returns the JSON representation of a currency.
 

--- a/xrpl/core/binarycodec/types/currency.py
+++ b/xrpl/core/binarycodec/types/currency.py
@@ -94,7 +94,7 @@ class Currency(Hash160):
             self._iso = _iso_code_from_hex(code_bytes)
 
     @classmethod
-    def from_value(cls: Type[Currency], value: str) -> Currency:
+    def from_value(cls: Type[Self], value: str) -> Self:
         """
         Construct a Currency object from a string representation of a currency.
 
@@ -114,7 +114,7 @@ class Currency(Hash160):
             )
 
         if _is_iso_code(value):
-            return Currency(_iso_to_bytes(value))
+            return cls(_iso_to_bytes(value))
         if _is_hex(value):
             return cls(bytes.fromhex(value))
         raise XRPLBinaryCodecException("Unsupported Currency representation: {value}")

--- a/xrpl/core/binarycodec/types/hash.py
+++ b/xrpl/core/binarycodec/types/hash.py
@@ -1,10 +1,13 @@
 """Base class for XRPL Hash types.
 `See Hash Fields <https://xrpl.org/serialization.html#hash-fields>`_
 """
+
 from __future__ import annotations  # Requires Python 3.7+
 
 from abc import ABC, abstractmethod
 from typing import Optional, Type
+
+from typing_extensions import Self
 
 from xrpl.core.binarycodec.binary_wrappers.binary_parser import BinaryParser
 from xrpl.core.binarycodec.exceptions import XRPLBinaryCodecException
@@ -17,7 +20,7 @@ class Hash(SerializedType, ABC):
     `See Hash Fields <https://xrpl.org/serialization.html#hash-fields>`_
     """
 
-    def __init__(self: Hash, buffer: Optional[bytes]) -> None:
+    def __init__(self: Self, buffer: Optional[bytes]) -> None:
         """
         Construct a Hash.
 
@@ -33,7 +36,7 @@ class Hash(SerializedType, ABC):
             )
         super().__init__(buffer)
 
-    def __str__(self: Hash) -> str:
+    def __str__(self: Self) -> str:
         """Returns a hex-encoded string representation of the bytes buffer."""
         return self.to_hex()
 

--- a/xrpl/core/binarycodec/types/hash.py
+++ b/xrpl/core/binarycodec/types/hash.py
@@ -41,7 +41,7 @@ class Hash(SerializedType, ABC):
         return self.to_hex()
 
     @classmethod
-    def from_value(cls: Type[Hash], value: str) -> Hash:
+    def from_value(cls: Type[Self], value: str) -> Self:
         """
         Construct a Hash object from a hex string.
 
@@ -64,8 +64,8 @@ class Hash(SerializedType, ABC):
 
     @classmethod
     def from_parser(
-        cls: Type[Hash], parser: BinaryParser, length_hint: Optional[int] = None
-    ) -> Hash:
+        cls: Type[Self], parser: BinaryParser, length_hint: Optional[int] = None
+    ) -> Self:
         """
         Construct a Hash object from an existing BinaryParser.
 
@@ -81,5 +81,5 @@ class Hash(SerializedType, ABC):
 
     @classmethod
     @abstractmethod
-    def _get_length(cls: Type[Hash]) -> int:
+    def _get_length(cls: Type[Self]) -> int:
         pass

--- a/xrpl/core/binarycodec/types/hash128.py
+++ b/xrpl/core/binarycodec/types/hash128.py
@@ -3,9 +3,12 @@ Codec for serializing and deserializing a hash field with a width
 of 128 bits (16 bytes).
 `See Hash Fields <https://xrpl.org/serialization.html#hash-fields>`_
 """
+
 from __future__ import annotations
 
 from typing import Optional, Type
+
+from typing_extensions import Self
 
 from xrpl.core.binarycodec.exceptions import XRPLBinaryCodecException
 from xrpl.core.binarycodec.types.hash import Hash
@@ -18,7 +21,7 @@ class Hash128(Hash):
     `See Hash Fields <https://xrpl.org/serialization.html#hash-fields>`_
     """
 
-    def __init__(self: Hash128, buffer: Optional[bytes]) -> None:
+    def __init__(self: Self, buffer: Optional[bytes]) -> None:
         """
         Construct a Hash128.
 
@@ -38,7 +41,7 @@ class Hash128(Hash):
             )
         super().__init__(buffer)
 
-    def __str__(self: Hash128) -> str:
+    def __str__(self: Self) -> str:
         """Returns a hex-encoded string representation of the bytes buffer."""
         hex = self.to_hex()
         if hex == "0" * len(hex):

--- a/xrpl/core/binarycodec/types/hash128.py
+++ b/xrpl/core/binarycodec/types/hash128.py
@@ -49,5 +49,5 @@ class Hash128(Hash):
         return hex
 
     @classmethod
-    def _get_length(cls: Type[Hash128]) -> int:
+    def _get_length(cls: Type[Self]) -> int:
         return 16

--- a/xrpl/core/binarycodec/types/hash160.py
+++ b/xrpl/core/binarycodec/types/hash160.py
@@ -2,9 +2,12 @@
 of 160 bits (20 bytes).
 `See Hash Fields <https://xrpl.org/serialization.html#hash-fields>`_
 """
+
 from __future__ import annotations
 
 from typing import Type
+
+from typing_extensions import Self
 
 from xrpl.core.binarycodec.types.hash import Hash
 
@@ -17,5 +20,5 @@ class Hash160(Hash):
     """
 
     @classmethod
-    def _get_length(cls: Type[Hash160]) -> int:
+    def _get_length(cls: Type[Self]) -> int:
         return 20

--- a/xrpl/core/binarycodec/types/hash256.py
+++ b/xrpl/core/binarycodec/types/hash256.py
@@ -3,9 +3,12 @@ Codec for serializing and deserializing a hash field with a width
 of 256 bits (32 bytes).
 `See Hash Fields <https://xrpl.org/serialization.html#hash-fields>`_
 """
+
 from __future__ import annotations
 
 from typing import Type
+
+from typing_extensions import Self
 
 from xrpl.core.binarycodec.types.hash import Hash
 
@@ -18,5 +21,5 @@ class Hash256(Hash):
     """
 
     @classmethod
-    def _get_length(cls: Type[Hash256]) -> int:
+    def _get_length(cls: Type[Self]) -> int:
         return 32

--- a/xrpl/core/binarycodec/types/issue.py
+++ b/xrpl/core/binarycodec/types/issue.py
@@ -29,7 +29,7 @@ class Issue(SerializedType):
         super().__init__(buffer)
 
     @classmethod
-    def from_value(cls: Type[Issue], value: Dict[str, str]) -> Issue:
+    def from_value(cls: Type[Self], value: Dict[str, str]) -> Self:
         """
         Construct an Issue object from a string or dictionary representation
         of an issued currency.
@@ -59,10 +59,10 @@ class Issue(SerializedType):
 
     @classmethod
     def from_parser(
-        cls: Type[Issue],
+        cls: Type[Self],
         parser: BinaryParser,
         length_hint: Optional[int] = None,
-    ) -> Issue:
+    ) -> Self:
         """
         Construct an Issue object from an existing BinaryParser.
 

--- a/xrpl/core/binarycodec/types/issue.py
+++ b/xrpl/core/binarycodec/types/issue.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional, Type, Union
 
+from typing_extensions import Self
+
 from xrpl.core.binarycodec.binary_wrappers.binary_parser import BinaryParser
 from xrpl.core.binarycodec.exceptions import XRPLBinaryCodecException
 from xrpl.core.binarycodec.types.account_id import AccountID
@@ -16,7 +18,7 @@ from xrpl.models.currencies import IssuedCurrency as IssuedCurrencyModel
 class Issue(SerializedType):
     """Codec for serializing and deserializing issued currency fields."""
 
-    def __init__(self: Issue, buffer: bytes) -> None:
+    def __init__(self: Self, buffer: bytes) -> None:
         """
         Construct an Issue from given bytes.
 
@@ -78,7 +80,7 @@ class Issue(SerializedType):
         issuer = parser.read(20)  # the length in bytes of an account ID
         return cls(bytes(currency) + issuer)
 
-    def to_json(self: Issue) -> Union[str, Dict[Any, Any]]:
+    def to_json(self: Self) -> Union[str, Dict[Any, Any]]:
         """
         Returns the JSON representation of an issued currency.
 

--- a/xrpl/core/binarycodec/types/path_set.py
+++ b/xrpl/core/binarycodec/types/path_set.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Dict, List, Optional, Type, cast
 
-from typing_extensions import Final
+from typing_extensions import Final, Self
 
 from xrpl.core.binarycodec.binary_wrappers.binary_parser import BinaryParser
 from xrpl.core.binarycodec.exceptions import XRPLBinaryCodecException
@@ -102,7 +102,7 @@ class PathStep(SerializedType):
 
         return PathStep(bytes([data_type]) + buffer)
 
-    def to_json(self: PathStep) -> Dict[str, str]:
+    def to_json(self: Self) -> Dict[str, str]:
         """
         Returns the JSON representation of a PathStep.
 
@@ -126,7 +126,7 @@ class PathStep(SerializedType):
         return json
 
     @property
-    def type(self: PathStep) -> int:
+    def type(self: Self) -> int:
         """Get a number representing the type of this PathStep.
 
         Returns:
@@ -189,7 +189,7 @@ class Path(SerializedType):
                 break
         return Path(b"".join(buffer))
 
-    def to_json(self: Path) -> List[Dict[str, str]]:
+    def to_json(self: Self) -> List[Dict[str, str]]:
         """
         Returns the JSON representation of a Path.
 
@@ -266,7 +266,7 @@ class PathSet(SerializedType):
                 break
         return PathSet(b"".join(buffer))
 
-    def to_json(self: PathSet) -> List[List[Dict[str, str]]]:
+    def to_json(self: Self) -> List[List[Dict[str, str]]]:
         """
         Returns the JSON representation of a PathSet.
 

--- a/xrpl/core/binarycodec/types/path_set.py
+++ b/xrpl/core/binarycodec/types/path_set.py
@@ -38,7 +38,7 @@ class PathStep(SerializedType):
     """Serialize and deserialize a single step in a Path."""
 
     @classmethod
-    def from_value(cls: Type[PathStep], value: Dict[str, str]) -> PathStep:
+    def from_value(cls: Type[Self], value: Dict[str, str]) -> Self:
         """
         Construct a PathStep object from a dictionary.
 
@@ -72,12 +72,12 @@ class PathStep(SerializedType):
             buffer += bytes(issuer)
             data_type |= _TYPE_ISSUER
 
-        return PathStep(bytes([data_type]) + buffer)
+        return cls(bytes([data_type]) + buffer)
 
     @classmethod
     def from_parser(
-        cls: Type[PathStep], parser: BinaryParser, _length_hint: Optional[None] = None
-    ) -> PathStep:
+        cls: Type[Self], parser: BinaryParser, _length_hint: Optional[None] = None
+    ) -> Self:
         """
         Construct a PathStep object from an existing BinaryParser.
 
@@ -100,7 +100,7 @@ class PathStep(SerializedType):
             issuer = parser.read(AccountID.LENGTH)
             buffer += issuer
 
-        return PathStep(bytes([data_type]) + buffer)
+        return cls(bytes([data_type]) + buffer)
 
     def to_json(self: Self) -> Dict[str, str]:
         """
@@ -140,7 +140,7 @@ class Path(SerializedType):
     """Class for serializing/deserializing Paths."""
 
     @classmethod
-    def from_value(cls: Type[Path], value: List[Dict[str, str]]) -> Path:
+    def from_value(cls: Type[Self], value: List[Dict[str, str]]) -> Self:
         """
         Construct a Path from an array of dictionaries describing PathSteps.
 
@@ -163,12 +163,12 @@ class Path(SerializedType):
         for PathStep_dict in value:
             pathstep = PathStep.from_value(PathStep_dict)
             buffer += bytes(pathstep)
-        return Path(buffer)
+        return cls(buffer)
 
     @classmethod
     def from_parser(
-        cls: Type[Path], parser: BinaryParser, _length_hint: Optional[None] = None
-    ) -> Path:
+        cls: Type[Self], parser: BinaryParser, _length_hint: Optional[None] = None
+    ) -> Self:
         """
         Construct a Path object from an existing BinaryParser.
 
@@ -187,7 +187,7 @@ class Path(SerializedType):
                 bytes, _PATH_SEPARATOR_BYTE
             ):
                 break
-        return Path(b"".join(buffer))
+        return cls(b"".join(buffer))
 
     def to_json(self: Self) -> List[Dict[str, str]]:
         """
@@ -212,7 +212,7 @@ class PathSet(SerializedType):
     """
 
     @classmethod
-    def from_value(cls: Type[PathSet], value: List[List[Dict[str, str]]]) -> PathSet:
+    def from_value(cls: Type[Self], value: List[List[Dict[str, str]]]) -> Self:
         """
         Construct a PathSet from a List of Lists representing paths.
 
@@ -239,14 +239,14 @@ class PathSet(SerializedType):
                 buffer.append(bytes([_PATH_SEPARATOR_BYTE]))
 
             buffer[-1] = bytes([_PATHSET_END_BYTE])
-            return PathSet(b"".join(buffer))
+            return cls(b"".join(buffer))
 
         raise XRPLBinaryCodecException("Cannot construct PathSet from given value")
 
     @classmethod
     def from_parser(
-        cls: Type[PathSet], parser: BinaryParser, _length_hint: Optional[None] = None
-    ) -> PathSet:
+        cls: Type[Self], parser: BinaryParser, _length_hint: Optional[None] = None
+    ) -> Self:
         """
         Construct a PathSet object from an existing BinaryParser.
 
@@ -264,7 +264,7 @@ class PathSet(SerializedType):
 
             if buffer[-1][0] == _PATHSET_END_BYTE:
                 break
-        return PathSet(b"".join(buffer))
+        return cls(b"".join(buffer))
 
     def to_json(self: Self) -> List[List[Dict[str, str]]]:
         """

--- a/xrpl/core/binarycodec/types/serialized_type.py
+++ b/xrpl/core/binarycodec/types/serialized_type.py
@@ -22,18 +22,16 @@ class SerializedType(ABC):
     @classmethod
     @abstractmethod
     def from_parser(  # noqa: D102
-        cls: Type[SerializedType],
+        cls: Type[Self],
         parser: BinaryParser,
         # length_hint is Any so that subclasses can choose whether or not to require it.
         length_hint: Any,
-    ) -> SerializedType:
+    ) -> Self:
         pass
 
     @classmethod
     @abstractmethod
-    def from_value(  # noqa: D102
-        cls: Type[SerializedType], value: Any
-    ) -> SerializedType:
+    def from_value(cls: Type[Self], value: Any) -> Self:  # noqa: D102
         pass
 
     def to_byte_sink(self: Self, bytesink: bytearray) -> None:

--- a/xrpl/core/binarycodec/types/serialized_type.py
+++ b/xrpl/core/binarycodec/types/serialized_type.py
@@ -1,8 +1,11 @@
 """The base class for all binary codec field types."""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Type
+
+from typing_extensions import Self
 
 if TYPE_CHECKING:
     # To prevent a circular dependency.
@@ -12,7 +15,7 @@ if TYPE_CHECKING:
 class SerializedType(ABC):
     """The base class for all binary codec field types."""
 
-    def __init__(self: SerializedType, buffer: bytes = bytes()) -> None:
+    def __init__(self: Self, buffer: bytes = bytes()) -> None:
         """Construct a new SerializedType."""
         self.buffer = buffer
 
@@ -33,7 +36,7 @@ class SerializedType(ABC):
     ) -> SerializedType:
         pass
 
-    def to_byte_sink(self: SerializedType, bytesink: bytearray) -> None:
+    def to_byte_sink(self: Self, bytesink: bytearray) -> None:
         """
         Write the bytes representation of a SerializedType to a bytearray.
 
@@ -44,7 +47,7 @@ class SerializedType(ABC):
         """
         bytesink.extend(self.buffer)
 
-    def __bytes__(self: SerializedType) -> bytes:
+    def __bytes__(self: Self) -> bytes:
         """
         Get the bytes representation of a SerializedType.
 
@@ -53,7 +56,7 @@ class SerializedType(ABC):
         """
         return self.buffer
 
-    def to_json(self: SerializedType) -> Any:
+    def to_json(self: Self) -> Any:
         """
         Returns the JSON representation of a SerializedType.
 
@@ -64,7 +67,7 @@ class SerializedType(ABC):
         """
         return self.to_hex()
 
-    def __str__(self: SerializedType) -> str:
+    def __str__(self: Self) -> str:
         """
         Returns the hex string representation of self.buffer.
 
@@ -73,7 +76,7 @@ class SerializedType(ABC):
         """
         return self.to_hex()
 
-    def to_hex(self: SerializedType) -> str:
+    def to_hex(self: Self) -> str:
         """
         Get the hex representation of a SerializedType's bytes.
 
@@ -82,6 +85,6 @@ class SerializedType(ABC):
         """
         return self.buffer.hex().upper()
 
-    def __len__(self: SerializedType) -> int:
+    def __len__(self: Self) -> int:
         """Get the length of a SerializedType's bytes."""
         return len(self.buffer)

--- a/xrpl/core/binarycodec/types/st_array.py
+++ b/xrpl/core/binarycodec/types/st_array.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any, List, Optional, Type
 
-from typing_extensions import Final
+from typing_extensions import Final, Self
 
 from xrpl.core.binarycodec.binary_wrappers.binary_parser import BinaryParser
 from xrpl.core.binarycodec.exceptions import XRPLBinaryCodecException
@@ -85,7 +85,7 @@ class STArray(SerializedType):
         bytestring += _ARRAY_END_MARKER
         return STArray(bytestring)
 
-    def to_json(self: STArray) -> List[Any]:
+    def to_json(self: Self) -> List[Any]:
         """
         Returns the JSON representation of a STArray.
 

--- a/xrpl/core/binarycodec/types/st_array.py
+++ b/xrpl/core/binarycodec/types/st_array.py
@@ -26,10 +26,10 @@ class STArray(SerializedType):
 
     @classmethod
     def from_parser(
-        cls: Type[STArray],
+        cls: Type[Self],
         parser: BinaryParser,
         _length_hint: Optional[None] = None,
-    ) -> STArray:
+    ) -> Self:
         """
         Construct a STArray from a BinaryParser.
 
@@ -50,10 +50,10 @@ class STArray(SerializedType):
             bytestring += _OBJECT_END_MARKER
 
         bytestring += _ARRAY_END_MARKER
-        return STArray(bytestring)
+        return cls(bytestring)
 
     @classmethod
-    def from_value(cls: Type[STArray], value: List[Any]) -> STArray:
+    def from_value(cls: Type[Self], value: List[Any]) -> Self:
         """
         Create a STArray object from a dictionary.
 
@@ -83,7 +83,7 @@ class STArray(SerializedType):
             transaction = STObject.from_value(obj)
             bytestring += bytes(transaction)
         bytestring += _ARRAY_END_MARKER
-        return STArray(bytestring)
+        return cls(bytestring)
 
     def to_json(self: Self) -> List[Any]:
         """

--- a/xrpl/core/binarycodec/types/st_object.py
+++ b/xrpl/core/binarycodec/types/st_object.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Type, Union
 
-from typing_extensions import Final
+from typing_extensions import Final, Self
 
 from xrpl.core.addresscodec import is_valid_xaddress, xaddress_to_classic_address
 from xrpl.core.binarycodec.binary_wrappers.binary_parser import BinaryParser
@@ -217,7 +217,7 @@ class STObject(SerializedType):
 
         return STObject(bytes(serializer))
 
-    def to_json(self: STObject) -> Dict[str, Any]:
+    def to_json(self: Self) -> Dict[str, Any]:
         """
         Returns the JSON representation of a STObject.
 

--- a/xrpl/core/binarycodec/types/st_object.py
+++ b/xrpl/core/binarycodec/types/st_object.py
@@ -86,10 +86,10 @@ class STObject(SerializedType):
 
     @classmethod
     def from_parser(
-        cls: Type[STObject],
+        cls: Type[Self],
         parser: BinaryParser,
         _length_hint: Optional[None] = None,
-    ) -> STObject:
+    ) -> Self:
         """
         Construct a STObject from a BinaryParser.
 
@@ -115,12 +115,12 @@ class STObject(SerializedType):
             if field.type == _ST_OBJECT:
                 serializer.append(_OBJECT_END_MARKER_BYTE)
 
-        return STObject(bytes(serializer))
+        return cls(bytes(serializer))
 
     @classmethod
     def from_value(
-        cls: Type[STObject], value: Dict[str, Any], only_signing: bool = False
-    ) -> STObject:
+        cls: Type[Self], value: Dict[str, Any], only_signing: bool = False
+    ) -> Self:
         """
         Create a STObject object from a dictionary.
 
@@ -215,7 +215,7 @@ class STObject(SerializedType):
             if field.type == _ST_OBJECT:
                 serializer.append(_OBJECT_END_MARKER_BYTE)
 
-        return STObject(bytes(serializer))
+        return cls(bytes(serializer))
 
     def to_json(self: Self) -> Dict[str, Any]:
         """

--- a/xrpl/core/binarycodec/types/uint.py
+++ b/xrpl/core/binarycodec/types/uint.py
@@ -1,9 +1,12 @@
 """Base class for serializing and deserializing unsigned integers.
 See `UInt Fields <https://xrpl.org/serialization.html#uint-fields>`_
 """
+
 from __future__ import annotations
 
 from typing import Union
+
+from typing_extensions import Self
 
 from xrpl.core.binarycodec.exceptions import XRPLBinaryCodecException
 from xrpl.core.binarycodec.types.serialized_type import SerializedType
@@ -14,12 +17,12 @@ class UInt(SerializedType):
     See `UInt Fields <https://xrpl.org/serialization.html#uint-fields>`_
     """
 
-    def __init__(self: UInt, buffer: bytes) -> None:
+    def __init__(self: Self, buffer: bytes) -> None:
         """Construct a new UInt type from a ``bytes`` value."""
         self.buffer = buffer
 
     @property
-    def value(self: UInt) -> int:
+    def value(self: Self) -> int:
         """
         Get the value of the UInt represented by `self.buffer`.
 
@@ -28,7 +31,7 @@ class UInt(SerializedType):
         """
         return int.from_bytes(self.buffer, byteorder="big", signed=False)
 
-    def __eq__(self: UInt, other: object) -> bool:
+    def __eq__(self: Self, other: object) -> bool:
         """Determine whether two UInt objects are equal."""
         if isinstance(other, int):
             return self.value == other
@@ -36,7 +39,7 @@ class UInt(SerializedType):
             return self.value == other.value
         raise XRPLBinaryCodecException(f"Cannot compare UInt and {type(other)}")
 
-    def __ne__(self: UInt, other: object) -> bool:
+    def __ne__(self: Self, other: object) -> bool:
         """Determine whether two UInt objects are unequal."""
         if isinstance(other, int):
             return self.value != other
@@ -44,7 +47,7 @@ class UInt(SerializedType):
             return self.value != other.value
         raise XRPLBinaryCodecException(f"Cannot compare UInt and {type(other)}")
 
-    def __lt__(self: UInt, other: object) -> bool:
+    def __lt__(self: Self, other: object) -> bool:
         """Determine whether one UInt object is less than another."""
         if isinstance(other, int):
             return self.value < other
@@ -52,7 +55,7 @@ class UInt(SerializedType):
             return self.value < other.value
         raise XRPLBinaryCodecException(f"Cannot compare UInt and {type(other)}")
 
-    def __le__(self: UInt, other: object) -> bool:
+    def __le__(self: Self, other: object) -> bool:
         """Determine whether one UInt object is less than or equal to another."""
         if isinstance(other, int):
             return self.value <= other
@@ -60,7 +63,7 @@ class UInt(SerializedType):
             return self.value <= other.value
         raise XRPLBinaryCodecException(f"Cannot compare UInt and {type(other)}")
 
-    def __gt__(self: UInt, other: object) -> bool:
+    def __gt__(self: Self, other: object) -> bool:
         """Determine whether one UInt object is greater than another."""
         if isinstance(other, int):
             return self.value > other
@@ -68,7 +71,7 @@ class UInt(SerializedType):
             return self.value > other.value
         raise XRPLBinaryCodecException(f"Cannot compare UInt and {type(other)}")
 
-    def __ge__(self: UInt, other: object) -> bool:
+    def __ge__(self: Self, other: object) -> bool:
         """Determine whether one UInt object is greater than or equal to another."""
         if isinstance(other, int):
             return self.value >= other
@@ -76,7 +79,7 @@ class UInt(SerializedType):
             return self.value >= other.value
         raise XRPLBinaryCodecException(f"Cannot compare UInt and {type(other)}")
 
-    def to_json(self: UInt) -> Union[str, int]:
+    def to_json(self: Self) -> Union[str, int]:
         """
         Convert a UInt object to JSON.
 

--- a/xrpl/core/binarycodec/types/uint16.py
+++ b/xrpl/core/binarycodec/types/uint16.py
@@ -26,8 +26,8 @@ class UInt16(UInt):
 
     @classmethod
     def from_parser(
-        cls: Type[UInt16], parser: BinaryParser, _length_hint: Optional[int] = None
-    ) -> UInt16:
+        cls: Type[Self], parser: BinaryParser, _length_hint: Optional[int] = None
+    ) -> Self:
         """
         Construct a new UInt16 type from a BinaryParser.
 
@@ -40,7 +40,7 @@ class UInt16(UInt):
         return cls(parser.read(_WIDTH))
 
     @classmethod
-    def from_value(cls: Type[UInt16], value: int) -> UInt16:
+    def from_value(cls: Type[Self], value: int) -> Self:
         """
         Construct a new UInt16 type from a number.
 

--- a/xrpl/core/binarycodec/types/uint16.py
+++ b/xrpl/core/binarycodec/types/uint16.py
@@ -1,11 +1,12 @@
 """Class for serializing and deserializing a 16-bit UInt.
 See `UInt Fields <https://xrpl.org/serialization.html#uint-fields>`_
 """
+
 from __future__ import annotations
 
 from typing import Optional, Type
 
-from typing_extensions import Final
+from typing_extensions import Final, Self
 
 from xrpl.core.binarycodec.binary_wrappers.binary_parser import BinaryParser
 from xrpl.core.binarycodec.exceptions import XRPLBinaryCodecException
@@ -19,7 +20,7 @@ class UInt16(UInt):
     See `UInt Fields <https://xrpl.org/serialization.html#uint-fields>`_
     """
 
-    def __init__(self: UInt16, buffer: bytes = bytes(_WIDTH)) -> None:
+    def __init__(self: Self, buffer: bytes = bytes(_WIDTH)) -> None:
         """Construct a new UInt16 type from a ``bytes`` value."""
         super().__init__(buffer)
 

--- a/xrpl/core/binarycodec/types/uint32.py
+++ b/xrpl/core/binarycodec/types/uint32.py
@@ -1,11 +1,12 @@
 """Class for serializing and deserializing a 32-bit UInt.
 See `UInt Fields <https://xrpl.org/serialization.html#uint-fields>`_
 """
+
 from __future__ import annotations
 
 from typing import Optional, Type, Union
 
-from typing_extensions import Final
+from typing_extensions import Final, Self
 
 from xrpl.core.binarycodec.binary_wrappers.binary_parser import BinaryParser
 from xrpl.core.binarycodec.exceptions import XRPLBinaryCodecException
@@ -20,7 +21,7 @@ class UInt32(UInt):
     See `UInt Fields <https://xrpl.org/serialization.html#uint-fields>`_
     """
 
-    def __init__(self: UInt32, buffer: bytes = bytes(_WIDTH)) -> None:
+    def __init__(self: Self, buffer: bytes = bytes(_WIDTH)) -> None:
         """Construct a new UInt32 type from a ``bytes`` value."""
         super().__init__(buffer)
 

--- a/xrpl/core/binarycodec/types/uint32.py
+++ b/xrpl/core/binarycodec/types/uint32.py
@@ -27,8 +27,8 @@ class UInt32(UInt):
 
     @classmethod
     def from_parser(
-        cls: Type[UInt32], parser: BinaryParser, _length_hint: Optional[int] = None
-    ) -> UInt32:
+        cls: Type[Self], parser: BinaryParser, _length_hint: Optional[int] = None
+    ) -> Self:
         """
         Construct a new UInt32 type from a BinaryParser.
 
@@ -41,7 +41,7 @@ class UInt32(UInt):
         return cls(parser.read(_WIDTH))
 
     @classmethod
-    def from_value(cls: Type[UInt32], value: Union[str, int]) -> UInt32:
+    def from_value(cls: Type[Self], value: Union[str, int]) -> Self:
         """
         Construct a new UInt32 type from a number.
 

--- a/xrpl/core/binarycodec/types/uint64.py
+++ b/xrpl/core/binarycodec/types/uint64.py
@@ -2,12 +2,13 @@
 Class for serializing and deserializing a 64-bit UInt.
 See `UInt Fields <https://xrpl.org/serialization.html#uint-fields>`_
 """
+
 from __future__ import annotations
 
 import re
 from typing import Optional, Pattern, Type, Union
 
-from typing_extensions import Final
+from typing_extensions import Final, Self
 
 from xrpl.core.binarycodec.binary_wrappers.binary_parser import BinaryParser
 from xrpl.core.binarycodec.exceptions import XRPLBinaryCodecException
@@ -24,7 +25,7 @@ class UInt64(UInt):
     See `UInt Fields <https://xrpl.org/serialization.html#uint-fields>`_
     """
 
-    def __init__(self: UInt64, buffer: bytes = bytes(_WIDTH)) -> None:
+    def __init__(self: Self, buffer: bytes = bytes(_WIDTH)) -> None:
         """Construct a new UInt64 type from a ``bytes`` value."""
         super().__init__(buffer)
 
@@ -80,7 +81,7 @@ class UInt64(UInt):
             "Cannot construct UInt64 from given value {value}"
         )
 
-    def to_json(self: UInt64) -> str:
+    def to_json(self: Self) -> str:
         """
         Convert a UInt64 object to JSON (hex).
 

--- a/xrpl/core/binarycodec/types/uint64.py
+++ b/xrpl/core/binarycodec/types/uint64.py
@@ -31,8 +31,8 @@ class UInt64(UInt):
 
     @classmethod
     def from_parser(
-        cls: Type[UInt64], parser: BinaryParser, _length_hint: Optional[int] = None
-    ) -> UInt64:
+        cls: Type[Self], parser: BinaryParser, _length_hint: Optional[int] = None
+    ) -> Self:
         """
         Construct a new UInt64 type from a BinaryParser.
 
@@ -45,7 +45,7 @@ class UInt64(UInt):
         return cls(parser.read(_WIDTH))
 
     @classmethod
-    def from_value(cls: Type[UInt64], value: Union[str, int]) -> UInt64:
+    def from_value(cls: Type[Self], value: Union[str, int]) -> Self:
         """
         Construct a new UInt64 type from a number.
 

--- a/xrpl/core/binarycodec/types/uint8.py
+++ b/xrpl/core/binarycodec/types/uint8.py
@@ -28,8 +28,8 @@ class UInt8(UInt):
 
     @classmethod
     def from_parser(
-        cls: Type[UInt8], parser: BinaryParser, _length_hint: Optional[int] = None
-    ) -> UInt8:
+        cls: Type[Self], parser: BinaryParser, _length_hint: Optional[int] = None
+    ) -> Self:
         """
         Construct a new UInt8 type from a BinaryParser.
 
@@ -42,7 +42,7 @@ class UInt8(UInt):
         return cls(parser.read(_WIDTH))
 
     @classmethod
-    def from_value(cls: Type[UInt8], value: int) -> UInt8:
+    def from_value(cls: Type[Self], value: int) -> Self:
         """
         Construct a new UInt8 type from a number.
 

--- a/xrpl/core/binarycodec/types/uint8.py
+++ b/xrpl/core/binarycodec/types/uint8.py
@@ -2,11 +2,12 @@
 Class for serializing and deserializing an 8-bit UInt.
 See `UInt Fields <https://xrpl.org/serialization.html#uint-fields>`_
 """
+
 from __future__ import annotations
 
 from typing import Optional, Type
 
-from typing_extensions import Final
+from typing_extensions import Final, Self
 
 from xrpl.core.binarycodec.binary_wrappers.binary_parser import BinaryParser
 from xrpl.core.binarycodec.exceptions import XRPLBinaryCodecException
@@ -21,7 +22,7 @@ class UInt8(UInt):
     See `UInt Fields <https://xrpl.org/serialization.html#uint-fields>`_
     """
 
-    def __init__(self: UInt8, buffer: bytes = bytes(_WIDTH)) -> None:
+    def __init__(self: Self, buffer: bytes = bytes(_WIDTH)) -> None:
         """Construct a new UInt8 type from a ``bytes`` value."""
         super().__init__(buffer)
 

--- a/xrpl/core/binarycodec/types/vector256.py
+++ b/xrpl/core/binarycodec/types/vector256.py
@@ -22,7 +22,7 @@ class Vector256(SerializedType):
         super().__init__(buffer)
 
     @classmethod
-    def from_value(cls: Type[Vector256], value: List[str]) -> Vector256:
+    def from_value(cls: Type[Self], value: List[str]) -> Self:
         """Construct a Vector256 from a list of strings.
 
         Args:
@@ -47,8 +47,8 @@ class Vector256(SerializedType):
 
     @classmethod
     def from_parser(
-        cls: Type[Vector256], parser: BinaryParser, length_hint: Optional[int] = None
-    ) -> SerializedType:
+        cls: Type[Self], parser: BinaryParser, length_hint: Optional[int] = None
+    ) -> Self:
         """Construct a Vector256 from a BinaryParser.
 
         Args:

--- a/xrpl/core/binarycodec/types/vector256.py
+++ b/xrpl/core/binarycodec/types/vector256.py
@@ -1,9 +1,10 @@
 """Codec for serializing and deserializing vectors of Hash256."""
+
 from __future__ import annotations
 
 from typing import List, Optional, Type
 
-from typing_extensions import Final
+from typing_extensions import Final, Self
 
 from xrpl.core.binarycodec import XRPLBinaryCodecException
 from xrpl.core.binarycodec.binary_wrappers.binary_parser import BinaryParser
@@ -16,7 +17,7 @@ _HASH_LENGTH_BYTES: Final[int] = 32
 class Vector256(SerializedType):
     """Codec for serializing and deserializing vectors of Hash256."""
 
-    def __init__(self: Vector256, buffer: bytes) -> None:
+    def __init__(self: Self, buffer: bytes) -> None:
         """Construct a Vector256."""
         super().__init__(buffer)
 
@@ -64,7 +65,7 @@ class Vector256(SerializedType):
             byte_list.append(bytes(Hash256.from_parser(parser)))
         return cls(b"".join(byte_list))
 
-    def to_json(self: Vector256) -> List[str]:
+    def to_json(self: Self) -> List[str]:
         """Return a list of hashes encoded as hex strings.
 
         Returns:

--- a/xrpl/core/binarycodec/types/xchain_bridge.py
+++ b/xrpl/core/binarycodec/types/xchain_bridge.py
@@ -30,9 +30,7 @@ class XChainBridge(SerializedType):
         super().__init__(buffer)
 
     @classmethod
-    def from_value(
-        cls: Type[XChainBridge], value: Union[str, Dict[str, str]]
-    ) -> XChainBridge:
+    def from_value(cls: Type[Self], value: Union[str, Dict[str, str]]) -> Self:
         """
         Construct a XChainBridge object from a dictionary representation of a bridge.
 
@@ -61,8 +59,8 @@ class XChainBridge(SerializedType):
 
     @classmethod
     def from_parser(
-        cls: Type[XChainBridge], parser: BinaryParser, length_hint: Optional[int] = None
-    ) -> XChainBridge:
+        cls: Type[Self], parser: BinaryParser, length_hint: Optional[int] = None
+    ) -> Self:
         """
         Construct a XChainBridge object from an existing BinaryParser.
 

--- a/xrpl/core/binarycodec/types/xchain_bridge.py
+++ b/xrpl/core/binarycodec/types/xchain_bridge.py
@@ -1,7 +1,10 @@
 """Codec for serializing and deserializing bridge fields."""
+
 from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
+
+from typing_extensions import Self
 
 from xrpl.core.binarycodec.binary_wrappers.binary_parser import BinaryParser
 from xrpl.core.binarycodec.exceptions import XRPLBinaryCodecException
@@ -22,7 +25,7 @@ _TYPE_KEYS = {type[0] for type in _TYPE_ORDER}
 class XChainBridge(SerializedType):
     """Codec for serializing and deserializing bridge fields."""
 
-    def __init__(self: XChainBridge, buffer: bytes) -> None:
+    def __init__(self: Self, buffer: bytes) -> None:
         """Construct a XChainBridge from given bytes."""
         super().__init__(buffer)
 
@@ -82,7 +85,7 @@ class XChainBridge(SerializedType):
 
         return cls(buffer)
 
-    def to_json(self: XChainBridge) -> Union[str, Dict[Any, Any]]:
+    def to_json(self: Self) -> Union[str, Dict[Any, Any]]:
         """
         Returns the JSON representation of a bridge.
 

--- a/xrpl/core/keypairs/crypto_implementation.py
+++ b/xrpl/core/keypairs/crypto_implementation.py
@@ -2,12 +2,14 @@
 Abstract base class for cryptographic algorithms in the XRP Ledger. The classes
 for all cryptographic algorithms are derived from this interface.
 """
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import Tuple, Type
 
 from ecpy.keys import ECPrivateKey  # type: ignore
+from typing_extensions import Self
 
 
 class CryptoImplementation(ABC):
@@ -19,7 +21,7 @@ class CryptoImplementation(ABC):
     @classmethod
     @abstractmethod
     def derive_keypair(  # noqa: D102
-        cls: Type[CryptoImplementation],
+        cls: Type[Self],
         decoded_seed: bytes,
         is_validator: bool,
     ) -> Tuple[str, str]:
@@ -28,7 +30,7 @@ class CryptoImplementation(ABC):
     @classmethod
     @abstractmethod
     def sign(  # noqa: D102
-        cls: Type[CryptoImplementation],
+        cls: Type[Self],
         message: bytes,
         private_key: str,
     ) -> bytes:
@@ -37,7 +39,7 @@ class CryptoImplementation(ABC):
     @classmethod
     @abstractmethod
     def is_valid_message(  # noqa: D102
-        cls: Type[CryptoImplementation],
+        cls: Type[Self],
         message: bytes,
         signature: bytes,
         public_key: str,
@@ -45,5 +47,5 @@ class CryptoImplementation(ABC):
         pass
 
     @classmethod
-    def _private_key_to_str(cls: Type[CryptoImplementation], key: ECPrivateKey) -> str:
+    def _private_key_to_str(cls: Type[Self], key: ECPrivateKey) -> str:
         return format(key.d, "x")

--- a/xrpl/core/keypairs/ed25519.py
+++ b/xrpl/core/keypairs/ed25519.py
@@ -1,4 +1,5 @@
 """Ed25519 elliptic curve cryptography interface."""
+
 from __future__ import annotations
 
 from hashlib import sha512
@@ -7,7 +8,7 @@ from typing import Tuple, Type, cast
 from ecpy.curves import Curve  # type: ignore
 from ecpy.eddsa import EDDSA  # type: ignore
 from ecpy.keys import ECPrivateKey, ECPublicKey  # type: ignore
-from typing_extensions import Final
+from typing_extensions import Final, Self
 
 from xrpl.core.keypairs.crypto_implementation import CryptoImplementation
 from xrpl.core.keypairs.exceptions import XRPLKeypairsException
@@ -23,7 +24,7 @@ class ED25519(CryptoImplementation):
 
     @classmethod
     def derive_keypair(
-        cls: Type[ED25519], decoded_seed: bytes, is_validator: bool
+        cls: Type[Self], decoded_seed: bytes, is_validator: bool
     ) -> Tuple[str, str]:
         """
         Derives a key pair in Ed25519 format for use with the XRP Ledger from a
@@ -54,7 +55,7 @@ class ED25519(CryptoImplementation):
         )
 
     @classmethod
-    def sign(cls: Type[ED25519], message: bytes, private_key: str) -> bytes:
+    def sign(cls: Type[Self], message: bytes, private_key: str) -> bytes:
         """
         Signs a message using a given Ed25519 private key.
 
@@ -71,7 +72,7 @@ class ED25519(CryptoImplementation):
 
     @classmethod
     def is_valid_message(
-        cls: Type[ED25519], message: bytes, signature: bytes, public_key: str
+        cls: Type[Self], message: bytes, signature: bytes, public_key: str
     ) -> bool:
         """
         Verifies the signature on a given message.
@@ -91,11 +92,11 @@ class ED25519(CryptoImplementation):
         return cast(bool, _SIGNER.verify(message, signature, wrapped_public))
 
     @classmethod
-    def _public_key_to_str(cls: Type[ED25519], key: ECPublicKey) -> str:
+    def _public_key_to_str(cls: Type[Self], key: ECPublicKey) -> str:
         return cast(str, _CURVE.encode_point(key.W).hex())
 
     @classmethod
-    def _format_key(cls: Type[ED25519], keystr: str) -> str:
+    def _format_key(cls: Type[Self], keystr: str) -> str:
         if len(keystr) < 64:
             keystr = keystr.zfill(64)
         return (PREFIX + keystr).upper()

--- a/xrpl/core/keypairs/secp256k1.py
+++ b/xrpl/core/keypairs/secp256k1.py
@@ -1,4 +1,5 @@
 """secp256k1 elliptic curve cryptography interface."""
+
 # The process for using SECP256k1 is complex and more involved than ED25519.
 #
 # See https://xrpl.org/cryptographic-keys.html#secp256k1-key-derivation
@@ -11,7 +12,7 @@ from typing import Callable, Tuple, Type, cast
 from ecpy.curves import Curve  # type: ignore
 from ecpy.ecdsa import ECDSA  # type: ignore
 from ecpy.keys import ECPrivateKey, ECPublicKey  # type: ignore
-from typing_extensions import Final, Literal
+from typing_extensions import Final, Literal, Self
 
 from xrpl.core.keypairs.crypto_implementation import CryptoImplementation
 from xrpl.core.keypairs.exceptions import XRPLKeypairsException
@@ -46,7 +47,7 @@ class SECP256K1(CryptoImplementation):
 
     @classmethod
     def derive_keypair(
-        cls: Type[SECP256K1], decoded_seed: bytes, is_validator: bool
+        cls: Type[Self], decoded_seed: bytes, is_validator: bool
     ) -> Tuple[str, str]:
         """
         Derive the public and private secp256k1 keys from a given seed value.
@@ -76,7 +77,7 @@ class SECP256K1(CryptoImplementation):
         return cls._format_keys(final_public, final_private)
 
     @classmethod
-    def sign(cls: Type[SECP256K1], message: bytes, private_key: str) -> bytes:
+    def sign(cls: Type[Self], message: bytes, private_key: str) -> bytes:
         """
         Signs a message using a given secp256k1 private key.
 
@@ -100,7 +101,7 @@ class SECP256K1(CryptoImplementation):
 
     @classmethod
     def is_valid_message(
-        cls: Type[SECP256K1], message: bytes, signature: bytes, public_key: str
+        cls: Type[Self], message: bytes, signature: bytes, public_key: str
     ) -> bool:
         """
         Verifies the signature on a given message.
@@ -123,7 +124,7 @@ class SECP256K1(CryptoImplementation):
 
     @classmethod
     def _format_keys(
-        cls: Type[SECP256K1], public: ECPublicKey, private: ECPrivateKey
+        cls: Type[Self], public: ECPublicKey, private: ECPrivateKey
     ) -> Tuple[str, str]:
         return (
             cls._format_key(cls._public_key_to_str(public)),
@@ -131,20 +132,20 @@ class SECP256K1(CryptoImplementation):
         )
 
     @classmethod
-    def _format_key(cls: Type[SECP256K1], keystr: str) -> str:
+    def _format_key(cls: Type[Self], keystr: str) -> str:
         return keystr.rjust(_KEY_LENGTH, _PADDING_PREFIX).upper()
 
     @classmethod
-    def _public_key_to_bytes(cls: Type[SECP256K1], key: ECPublicKey) -> bytes:
+    def _public_key_to_bytes(cls: Type[Self], key: ECPublicKey) -> bytes:
         return bytes(_CURVE.encode_point(key.W, compressed=True))
 
     @classmethod
-    def _public_key_to_str(cls: Type[SECP256K1], key: ECPublicKey) -> str:
+    def _public_key_to_str(cls: Type[Self], key: ECPublicKey) -> str:
         return cls._public_key_to_bytes(key).hex()
 
     @classmethod
     def _do_derive_part(
-        cls: Type[SECP256K1], bytes_input: bytes, phase: Literal["root", "mid"]
+        cls: Type[Self], bytes_input: bytes, phase: Literal["root", "mid"]
     ) -> Tuple[ECPublicKey, ECPrivateKey]:
         """
         Given bytes_input determine public/private keypair for a given phase of
@@ -165,7 +166,7 @@ class SECP256K1(CryptoImplementation):
 
     @classmethod
     def _derive_final_pair(
-        cls: Type[SECP256K1],
+        cls: Type[Self],
         root_public: ECPublicKey,
         root_private: ECPrivateKey,
         mid_public: ECPublicKey,
@@ -178,7 +179,7 @@ class SECP256K1(CryptoImplementation):
 
     @classmethod
     def _get_secret(
-        cls: Type[SECP256K1], candidate_merger: Callable[[bytes], bytes]
+        cls: Type[Self], candidate_merger: Callable[[bytes], bytes]
     ) -> bytes:
         """
         Given a function `candidate_merger` that knows how
@@ -202,6 +203,6 @@ class SECP256K1(CryptoImplementation):
         )
 
     @classmethod
-    def _is_secret_valid(cls: Type[SECP256K1], secret: bytes) -> bool:
+    def _is_secret_valid(cls: Type[Self], secret: bytes) -> bool:
         numerical_secret = int.from_bytes(secret, "big")
         return numerical_secret in range(1, _GROUP_ORDER)

--- a/xrpl/models/amounts/issued_currency_amount.py
+++ b/xrpl/models/amounts/issued_currency_amount.py
@@ -3,10 +3,13 @@ Specifies an amount in an issued currency.
 
 See https://xrpl.org/currency-formats.html#issued-currency-amounts.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Dict, Union
+
+from typing_extensions import Self
 
 from xrpl.models.currencies import IssuedCurrency
 from xrpl.models.required import REQUIRED
@@ -29,7 +32,7 @@ class IssuedCurrencyAmount(IssuedCurrency):
     :meta hide-value:
     """
 
-    def to_currency(self: IssuedCurrencyAmount) -> IssuedCurrency:
+    def to_currency(self: Self) -> IssuedCurrency:
         """
         Build an IssuedCurrency from this IssuedCurrencyAmount.
 
@@ -38,7 +41,7 @@ class IssuedCurrencyAmount(IssuedCurrency):
         """
         return IssuedCurrency(issuer=self.issuer, currency=self.currency)
 
-    def to_dict(self: IssuedCurrencyAmount) -> Dict[str, str]:
+    def to_dict(self: Self) -> Dict[str, str]:
         """
         Returns the dictionary representation of an IssuedCurrencyAmount.
 

--- a/xrpl/models/base_model.py
+++ b/xrpl/models/base_model.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, fields
 from enum import Enum
 from typing import Any, Dict, List, Pattern, Type, TypeVar, Union, cast, get_type_hints
 
-from typing_extensions import Final, Literal, get_args, get_origin
+from typing_extensions import Final, Literal, Self, get_args, get_origin
 
 from xrpl.models.exceptions import XRPLModelException
 from xrpl.models.required import REQUIRED
@@ -242,11 +242,11 @@ class BaseModel(ABC):
 
         return cls.from_dict(formatted_dict)
 
-    def __post_init__(self: BaseModel) -> None:
+    def __post_init__(self: Self) -> None:
         """Called by dataclasses immediately after __init__."""
         self.validate()
 
-    def validate(self: BaseModel) -> None:
+    def validate(self: Self) -> None:
         """
         Raises if this object is invalid.
 
@@ -257,7 +257,7 @@ class BaseModel(ABC):
         if len(errors) > 0:
             raise XRPLModelException(str(errors))
 
-    def is_valid(self: BaseModel) -> bool:
+    def is_valid(self: Self) -> bool:
         """
         Returns whether this BaseModel is valid.
 
@@ -266,7 +266,7 @@ class BaseModel(ABC):
         """
         return len(self._get_errors()) == 0
 
-    def _get_errors(self: BaseModel) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         """
         Extended in subclasses to define custom validation logic.
 
@@ -279,7 +279,7 @@ class BaseModel(ABC):
             if value is REQUIRED
         }
 
-    def to_dict(self: BaseModel) -> Dict[str, Any]:
+    def to_dict(self: Self) -> Dict[str, Any]:
         """
         Returns the dictionary representation of a BaseModel.
 
@@ -296,7 +296,7 @@ class BaseModel(ABC):
             if getattr(self, key) is not None
         }
 
-    def _to_dict_elem(self: BaseModel, elem: Any) -> Any:
+    def _to_dict_elem(self: Self, elem: Any) -> Any:
         if isinstance(elem, BaseModel):
             return elem.to_dict()
         if isinstance(elem, Enum):
@@ -309,11 +309,11 @@ class BaseModel(ABC):
             ]
         return elem
 
-    def __eq__(self: BaseModel, other: object) -> bool:
+    def __eq__(self: Self, other: object) -> bool:
         """Compares a BaseModel to another object to determine if they are equal."""
         return isinstance(other, BaseModel) and self.to_dict() == other.to_dict()
 
-    def __repr__(self: BaseModel) -> str:
+    def __repr__(self: Self) -> str:
         """Returns a string representation of a BaseModel object"""
         repr_items = [f"{key}={repr(value)}" for key, value in self.to_dict().items()]
         return f"{type(self).__name__}({repr_items})"

--- a/xrpl/models/base_model.py
+++ b/xrpl/models/base_model.py
@@ -7,7 +7,7 @@ import re
 from abc import ABC
 from dataclasses import dataclass, fields
 from enum import Enum
-from typing import Any, Dict, List, Pattern, Type, TypeVar, Union, cast, get_type_hints
+from typing import Any, Dict, List, Pattern, Type, Union, cast, get_type_hints
 
 from typing_extensions import Final, Literal, Self, get_args, get_origin
 
@@ -45,8 +45,6 @@ ABBREVIATIONS: Final[Dict[str, str]] = {
     "xchain": "XChain",
 }
 
-BM = TypeVar("BM", bound="BaseModel")  # any type inherited from BaseModel
-
 
 def _key_to_json(field: str) -> str:
     """
@@ -78,7 +76,7 @@ class BaseModel(ABC):
     """The base class for all model types."""
 
     @classmethod
-    def is_dict_of_model(cls: Type[BM], dictionary: Any) -> bool:
+    def is_dict_of_model(cls: Type[Self], dictionary: Any) -> bool:
         """
         Checks whether the provided ``dictionary`` is a dictionary representation
         of this class.
@@ -107,7 +105,7 @@ class BaseModel(ABC):
         )
 
     @classmethod
-    def from_dict(cls: Type[BM], value: Dict[str, XRPL_VALUE_TYPE]) -> BM:
+    def from_dict(cls: Type[Self], value: Dict[str, XRPL_VALUE_TYPE]) -> Self:
         """
         Construct a new BaseModel from a dictionary of parameters.
 
@@ -139,7 +137,7 @@ class BaseModel(ABC):
 
     @classmethod
     def _from_dict_single_param(
-        cls: Type[BM],
+        cls: Type[Self],
         param: str,
         param_type: Type[Any],
         param_value: Union[int, str, bool, BaseModel, Enum, List[Any], Dict[str, Any]],
@@ -214,13 +212,13 @@ class BaseModel(ABC):
         raise XRPLModelException(error_message)
 
     @classmethod
-    def _get_only_init_args(cls: Type[BM], args: Dict[str, Any]) -> Dict[str, Any]:
+    def _get_only_init_args(cls: Type[Self], args: Dict[str, Any]) -> Dict[str, Any]:
         init_keys = {field.name for field in fields(cls) if field.init is True}
         valid_args = {key: value for key, value in args.items() if key in init_keys}
         return valid_args
 
     @classmethod
-    def from_xrpl(cls: Type[BM], value: Union[str, Dict[str, Any]]) -> BM:
+    def from_xrpl(cls: Type[Self], value: Union[str, Dict[str, Any]]) -> Self:
         """
         Creates a BaseModel object based on a JSON-like dictionary of keys in the JSON
         format used by the binary codec, or an actual JSON string representing the same

--- a/xrpl/models/currencies/issued_currency.py
+++ b/xrpl/models/currencies/issued_currency.py
@@ -4,10 +4,13 @@ This format is used for some book order requests.
 
 See https://xrpl.org/currency-formats.html#specifying-currency-amounts
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Dict, Union
+
+from typing_extensions import Self
 
 import xrpl.models.amounts  # not a direct import, to get around circular imports
 from xrpl.constants import HEX_CURRENCY_REGEX, ISO_CURRENCY_REGEX
@@ -47,7 +50,7 @@ class IssuedCurrency(BaseModel):
     :meta hide-value:
     """
 
-    def _get_errors(self: IssuedCurrency) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
         if self.currency.upper() == "XRP":
             errors["currency"] = "Currency must not be XRP for issued currency"
@@ -56,7 +59,7 @@ class IssuedCurrency(BaseModel):
         return errors
 
     def to_amount(
-        self: IssuedCurrency, value: Union[str, int, float]
+        self: Self, value: Union[str, int, float]
     ) -> xrpl.models.amounts.IssuedCurrencyAmount:
         """
         Converts an IssuedCurrency to an IssuedCurrencyAmount.

--- a/xrpl/models/currencies/xrp.py
+++ b/xrpl/models/currencies/xrp.py
@@ -8,10 +8,13 @@ object.
 
 See https://xrpl.org/currency-formats.html#specifying-currency-amounts
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Any, Dict, Type, Union
+
+from typing_extensions import Self
 
 from xrpl.models.base_model import BaseModel
 from xrpl.models.exceptions import XRPLModelException
@@ -52,7 +55,7 @@ class XRP(BaseModel):
             raise XRPLModelException("Not a valid XRP type")
         return XRP()
 
-    def to_dict(self: XRP) -> Dict[str, Any]:
+    def to_dict(self: Self) -> Dict[str, Any]:
         """
         Returns the dictionary representation of an XRP currency object.
 
@@ -61,7 +64,7 @@ class XRP(BaseModel):
         """
         return {**super().to_dict(), "currency": "XRP"}
 
-    def to_amount(self: XRP, value: Union[str, int, float]) -> str:
+    def to_amount(self: Self, value: Union[str, int, float]) -> str:
         """
         Converts value to XRP.
 
@@ -78,7 +81,7 @@ class XRP(BaseModel):
             return xrp_to_drops(float(value))
         return xrp_to_drops(value)
 
-    def __repr__(self: XRP) -> str:
+    def __repr__(self: Self) -> str:
         """
         Generate string representation of XRP.
 

--- a/xrpl/models/currencies/xrp.py
+++ b/xrpl/models/currencies/xrp.py
@@ -38,7 +38,7 @@ class XRP(BaseModel):
     currency: str = field(default="XRP", init=False)
 
     @classmethod
-    def from_dict(cls: Type[XRP], value: Dict[str, Any]) -> XRP:
+    def from_dict(cls: Type[Self], value: Dict[str, Any]) -> Self:
         """
         Construct a new XRP from a dictionary of parameters.
 
@@ -53,7 +53,7 @@ class XRP(BaseModel):
         """
         if len(value) != 1 or "currency" not in value or value["currency"] != "XRP":
             raise XRPLModelException("Not a valid XRP type")
-        return XRP()
+        return cls()
 
     def to_dict(self: Self) -> Dict[str, Any]:
         """

--- a/xrpl/models/nested_model.py
+++ b/xrpl/models/nested_model.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, Type, TypeVar, Union
 
+from typing_extensions import Self
+
 from xrpl.models.base_model import BaseModel, _key_to_json
 
 NM = TypeVar("NM", bound="NestedModel")  # any type inherited from NestedModel
@@ -62,7 +64,7 @@ class NestedModel(BaseModel):
             return super(NestedModel, cls).from_dict(value)
         return super(NestedModel, cls).from_dict(value[_get_nested_name(cls)])
 
-    def to_dict(self: NestedModel) -> Dict[str, Any]:
+    def to_dict(self: Self) -> Dict[str, Any]:
         """
         Returns the dictionary representation of a NestedModel.
 

--- a/xrpl/models/nested_model.py
+++ b/xrpl/models/nested_model.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Type, TypeVar, Union
+from typing import Any, Dict, Type, Union
 
 from typing_extensions import Self
 
 from xrpl.models.base_model import BaseModel, _key_to_json
-
-NM = TypeVar("NM", bound="NestedModel")  # any type inherited from NestedModel
 
 
 def _get_nested_name(cls: Union[NestedModel, Type[NestedModel]]) -> str:
@@ -23,7 +21,7 @@ class NestedModel(BaseModel):
     """The base class for models that involve a nested dictionary e.g. memos."""
 
     @classmethod
-    def is_dict_of_model(cls: Type[NM], dictionary: Any) -> bool:
+    def is_dict_of_model(cls: Type[Self], dictionary: Any) -> bool:
         """
         Returns True if the input dictionary was derived by the `to_dict`
         method of an instance of this class. In other words, True if this is
@@ -47,7 +45,7 @@ class NestedModel(BaseModel):
         )
 
     @classmethod
-    def from_dict(cls: Type[NM], value: Dict[str, Any]) -> NM:
+    def from_dict(cls: Type[Self], value: Dict[str, Any]) -> Self:
         """
         Construct a new NestedModel from a dictionary of parameters.
 

--- a/xrpl/models/path.py
+++ b/xrpl/models/path.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
+from typing_extensions import Self
+
 from xrpl.models.base_model import BaseModel
 from xrpl.models.utils import require_kwargs_on_init
 
@@ -23,7 +25,7 @@ class PathStep(BaseModel):
     type: Optional[int] = None
     type_hex: Optional[str] = None
 
-    def _get_errors(self: PathStep) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         return {
             key: value
             for key, value in {
@@ -35,14 +37,14 @@ class PathStep(BaseModel):
             if value is not None
         }
 
-    def _get_account_error(self: PathStep) -> Optional[str]:
+    def _get_account_error(self: Self) -> Optional[str]:
         if self.account is None:
             return None
         if self.currency is not None or self.issuer is not None:
             return "Cannot set account if currency or issuer are set"
         return None
 
-    def _get_currency_error(self: PathStep) -> Optional[str]:
+    def _get_currency_error(self: Self) -> Optional[str]:
         if self.currency is None:
             return None
         if self.account is not None:
@@ -51,7 +53,7 @@ class PathStep(BaseModel):
             return "Cannot set issuer if currency is XRP"
         return None
 
-    def _get_issuer_error(self: PathStep) -> Optional[str]:
+    def _get_issuer_error(self: Self) -> Optional[str]:
         if self.issuer is None:
             return None
         if self.account is not None:

--- a/xrpl/models/requests/channel_authorize.py
+++ b/xrpl/models/requests/channel_authorize.py
@@ -12,10 +12,13 @@ anything else using the same key pair. See
 
 `See channel_authorize <https://xrpl.org/channel_authorize.html>`_
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Dict, Optional
+
+from typing_extensions import Self
 
 from xrpl.constants import CryptoAlgorithm
 from xrpl.models.requests.request import Request, RequestMethod
@@ -63,7 +66,7 @@ class ChannelAuthorize(Request):
     passphrase: Optional[str] = None
     key_type: Optional[CryptoAlgorithm] = None
 
-    def _get_errors(self: ChannelAuthorize) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
         signing_methods = [
             method

--- a/xrpl/models/requests/generic_request.py
+++ b/xrpl/models/requests/generic_request.py
@@ -1,8 +1,11 @@
 """A generic request that can be used for unsupported requests."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Any, Dict, Type, Union, cast
+
+from typing_extensions import Self
 
 from xrpl.models.exceptions import XRPLModelException
 from xrpl.models.requests.request import Request, RequestMethod
@@ -25,7 +28,7 @@ class GenericRequest(Request):
     :meta hide-value:
     """
 
-    def __init__(self: GenericRequest, **kwargs: Any) -> None:
+    def __init__(self: Self, **kwargs: Any) -> None:
         """
         Initializes a GenericRequest.
 
@@ -70,7 +73,7 @@ class GenericRequest(Request):
 
         return cls(**value)
 
-    def to_dict(self: GenericRequest) -> Dict[str, Any]:
+    def to_dict(self: Self) -> Dict[str, Any]:
         """
         Returns the dictionary representation of a GenericRequest.
 

--- a/xrpl/models/requests/generic_request.py
+++ b/xrpl/models/requests/generic_request.py
@@ -45,7 +45,7 @@ class GenericRequest(Request):
             object.__setattr__(self, key, value)
 
     @classmethod
-    def from_dict(cls: Type[GenericRequest], value: Dict[str, Any]) -> GenericRequest:
+    def from_dict(cls: Type[Self], value: Dict[str, Any]) -> Self:
         """
         Construct a new GenericRequest from a dictionary of parameters. Also converts
         from JSON and WS formatting.

--- a/xrpl/models/requests/get_aggregate_price.py
+++ b/xrpl/models/requests/get_aggregate_price.py
@@ -46,7 +46,7 @@ class GetAggregatePrice(Request):
     def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
         if len(self.oracles) == 0:
-            errors["GetAggregatePrice"] = (
-                "Oracles array must contain at least one element"
-            )
+            errors[
+                "GetAggregatePrice"
+            ] = "Oracles array must contain at least one element"
         return errors

--- a/xrpl/models/requests/get_aggregate_price.py
+++ b/xrpl/models/requests/get_aggregate_price.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
+from typing_extensions import Self
+
 from xrpl.models.requests.ledger_entry import Oracle
 from xrpl.models.requests.request import Request, RequestMethod
 from xrpl.models.required import REQUIRED
@@ -41,10 +43,10 @@ class GetAggregatePrice(Request):
     """Defines a time range in seconds for filtering out older price data. Default
     value is 0, which doesn't filter any data"""
 
-    def _get_errors(self: GetAggregatePrice) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
         if len(self.oracles) == 0:
-            errors[
-                "GetAggregatePrice"
-            ] = "Oracles array must contain at least one element"
+            errors["GetAggregatePrice"] = (
+                "Oracles array must contain at least one element"
+            )
         return errors

--- a/xrpl/models/requests/ledger_entry.py
+++ b/xrpl/models/requests/ledger_entry.py
@@ -5,11 +5,14 @@ See ledger format for information on the
 different types of objects you can retrieve.
 `See ledger entry <https://xrpl.org/ledger_entry.html>`_
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, List, Optional, Union
+
+from typing_extensions import Self
 
 from xrpl.models.base_model import BaseModel
 from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
@@ -262,7 +265,7 @@ class LedgerEntry(Request, LookupByLedgerRequest):
     nft_page: Optional[str] = None
     """Must be the object ID of the NFToken page, as hexadecimal"""
 
-    def _get_errors(self: LedgerEntry) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
         query_params = [
             param

--- a/xrpl/models/requests/request.py
+++ b/xrpl/models/requests/request.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, Optional, Type, TypeVar, Union, cast
+from typing import Any, Dict, Optional, Type, Union, cast
 
 from typing_extensions import Self
 
@@ -90,9 +90,6 @@ class RequestMethod(str, Enum):
     GENERIC_REQUEST = "zzgeneric_request"
 
 
-R = TypeVar("R", bound="Request")
-
-
 @dataclass(frozen=True)
 class Request(BaseModel):
     """
@@ -110,7 +107,7 @@ class Request(BaseModel):
     id: Optional[Union[str, int]] = None
 
     @classmethod
-    def from_dict(cls: Type[R], value: Dict[str, Any]) -> R:
+    def from_dict(cls: Type[Self], value: Dict[str, Any]) -> Self:
         """
         Construct a new Request from a dictionary of parameters.
 

--- a/xrpl/models/requests/request.py
+++ b/xrpl/models/requests/request.py
@@ -146,7 +146,7 @@ class Request(BaseModel):
         return super(Request, cls).from_dict(value)
 
     @classmethod
-    def get_method(cls: Type[Request], method: str) -> Type[Request]:
+    def get_method(cls: Type[Self], method: str) -> Type[Request]:
         """
         Returns the correct request method based on the string name.
 

--- a/xrpl/models/requests/request.py
+++ b/xrpl/models/requests/request.py
@@ -2,11 +2,14 @@
 The base class for all network request types.
 Represents fields common to all request types.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Optional, Type, TypeVar, Union, cast
+
+from typing_extensions import Self
 
 import xrpl.models.requests  # bare import to get around circular dependency
 from xrpl.models.base_model import BaseModel
@@ -176,7 +179,7 @@ class Request(BaseModel):
             return cast(Type[Request], getattr(xrpl.models.requests, parsed_name))
         return xrpl.models.requests.GenericRequest
 
-    def to_dict(self: Request) -> Dict[str, Any]:
+    def to_dict(self: Self) -> Dict[str, Any]:
         """
         Returns the dictionary representation of a Request.
 

--- a/xrpl/models/requests/sign.py
+++ b/xrpl/models/requests/sign.py
@@ -68,7 +68,7 @@ class Sign(Request):
     fee_div_max: int = 1
 
     @classmethod
-    def from_dict(cls: Type[Sign], value: Dict[str, Any]) -> Sign:
+    def from_dict(cls: Type[Self], value: Dict[str, Any]) -> Self:
         """
         Construct a new Sign from a dictionary of parameters.
 

--- a/xrpl/models/requests/sign.py
+++ b/xrpl/models/requests/sign.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Type
 
+from typing_extensions import Self
+
 from xrpl.constants import CryptoAlgorithm
 from xrpl.models.requests.request import Request, RequestMethod
 from xrpl.models.required import REQUIRED
@@ -83,7 +85,7 @@ class Sign(Request):
             fixed_value = value
         return super(Sign, cls).from_dict(fixed_value)
 
-    def to_dict(self: Sign) -> Dict[str, Any]:
+    def to_dict(self: Self) -> Dict[str, Any]:
         """
         Returns the dictionary representation of a Sign.
 
@@ -95,7 +97,7 @@ class Sign(Request):
         return_dict["tx_json"] = self.transaction.to_xrpl()
         return return_dict
 
-    def _get_errors(self: Sign) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
         if not self._has_only_one_seed():
             errors[
@@ -107,7 +109,7 @@ class Sign(Request):
 
         return errors
 
-    def _has_only_one_seed(self: Sign) -> bool:
+    def _has_only_one_seed(self: Self) -> bool:
         present_items = [
             item
             for item in [self.secret, self.seed, self.seed_hex, self.passphrase]

--- a/xrpl/models/requests/sign_and_submit.py
+++ b/xrpl/models/requests/sign_and_submit.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Type
 
+from typing_extensions import Self
+
 from xrpl.constants import CryptoAlgorithm
 from xrpl.models.requests.submit import Submit
 from xrpl.models.required import REQUIRED
@@ -92,7 +94,7 @@ class SignAndSubmit(Submit):
             fixed_value = value
         return super(SignAndSubmit, cls).from_dict(fixed_value)
 
-    def to_dict(self: SignAndSubmit) -> Dict[str, Any]:
+    def to_dict(self: Self) -> Dict[str, Any]:
         """
         Returns the dictionary representation of a SignAndSubmit.
 
@@ -104,7 +106,7 @@ class SignAndSubmit(Submit):
         return_dict["tx_json"] = self.transaction.to_xrpl()
         return return_dict
 
-    def _get_errors(self: SignAndSubmit) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
         if not self._has_only_one_seed():
             errors[
@@ -116,7 +118,7 @@ class SignAndSubmit(Submit):
 
         return errors
 
-    def _has_only_one_seed(self: SignAndSubmit) -> bool:
+    def _has_only_one_seed(self: Self) -> bool:
         present_items = [
             item
             for item in [self.secret, self.seed, self.seed_hex, self.passphrase]

--- a/xrpl/models/requests/sign_and_submit.py
+++ b/xrpl/models/requests/sign_and_submit.py
@@ -77,7 +77,7 @@ class SignAndSubmit(Submit):
     fee_div_max: int = 1
 
     @classmethod
-    def from_dict(cls: Type[SignAndSubmit], value: Dict[str, Any]) -> SignAndSubmit:
+    def from_dict(cls: Type[Self], value: Dict[str, Any]) -> Self:
         """
         Construct a new SignAndSubmit from a dictionary of parameters.
 

--- a/xrpl/models/requests/sign_for.py
+++ b/xrpl/models/requests/sign_for.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Type
 
+from typing_extensions import Self
+
 from xrpl.constants import CryptoAlgorithm
 from xrpl.models.requests.request import Request, RequestMethod
 from xrpl.models.required import REQUIRED
@@ -74,7 +76,7 @@ class SignFor(Request):
             fixed_value = value
         return super(SignFor, cls).from_dict(fixed_value)
 
-    def to_dict(self: SignFor) -> Dict[str, Any]:
+    def to_dict(self: Self) -> Dict[str, Any]:
         """
         Returns the dictionary representation of a SignFor.
 
@@ -86,7 +88,7 @@ class SignFor(Request):
         return_dict["tx_json"] = self.transaction.to_xrpl()
         return return_dict
 
-    def _get_errors(self: SignFor) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
         if not self._has_only_one_seed():
             errors[
@@ -98,7 +100,7 @@ class SignFor(Request):
 
         return errors
 
-    def _has_only_one_seed(self: SignFor) -> bool:
+    def _has_only_one_seed(self: Self) -> bool:
         present_items = [
             item
             for item in [self.secret, self.seed, self.seed_hex, self.passphrase]

--- a/xrpl/models/requests/sign_for.py
+++ b/xrpl/models/requests/sign_for.py
@@ -59,7 +59,7 @@ class SignFor(Request):
     key_type: Optional[CryptoAlgorithm] = None
 
     @classmethod
-    def from_dict(cls: Type[SignFor], value: Dict[str, Any]) -> SignFor:
+    def from_dict(cls: Type[Self], value: Dict[str, Any]) -> Self:
         """
         Construct a new SignFor from a dictionary of parameters.
 

--- a/xrpl/models/requests/submit.py
+++ b/xrpl/models/requests/submit.py
@@ -23,12 +23,12 @@ twice since it has the same sequence number as the old transaction.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, Type, TypeVar
+from typing import Any, Dict, Type
+
+from typing_extensions import Self
 
 from xrpl.models.requests.request import Request, RequestMethod
 from xrpl.models.utils import require_kwargs_on_init
-
-S = TypeVar("S", bound="Submit")  # any type inherited from Submit
 
 
 @require_kwargs_on_init
@@ -62,7 +62,7 @@ class Submit(Request):
     method: RequestMethod = field(default=RequestMethod.SUBMIT, init=False)
 
     @classmethod
-    def from_dict(cls: Type[S], value: Dict[str, Any]) -> S:
+    def from_dict(cls: Type[Self], value: Dict[str, Any]) -> Self:
         """
         Construct a new Submit from a dictionary of parameters.
 

--- a/xrpl/models/requests/submit_multisigned.py
+++ b/xrpl/models/requests/submit_multisigned.py
@@ -45,9 +45,7 @@ class SubmitMultisigned(Request):
     fail_hard: bool = False
 
     @classmethod
-    def from_dict(
-        cls: Type[SubmitMultisigned], value: Dict[str, Any]
-    ) -> SubmitMultisigned:
+    def from_dict(cls: Type[Self], value: Dict[str, Any]) -> Self:
         """
         Construct a new SubmitMultisigned object from a dictionary of parameters.
 

--- a/xrpl/models/requests/submit_multisigned.py
+++ b/xrpl/models/requests/submit_multisigned.py
@@ -7,10 +7,13 @@ This command requires the MultiSign amendment to be enabled.
 
 `See submit_multisigned <https://xrpl.org/submit_multisigned.html>`_
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Any, Dict, Type
+
+from typing_extensions import Self
 
 from xrpl.models.requests.request import Request, RequestMethod
 from xrpl.models.required import REQUIRED
@@ -59,7 +62,7 @@ class SubmitMultisigned(Request):
             fixed_value["tx_json"] = Transaction.from_xrpl(fixed_value["tx_json"])
         return super(SubmitMultisigned, cls).from_dict(fixed_value)
 
-    def to_dict(self: SubmitMultisigned) -> Dict[str, Any]:
+    def to_dict(self: Self) -> Dict[str, Any]:
         """
         Returns the dictionary representation of a SubmitMultisigned object.
 

--- a/xrpl/models/requests/tx.py
+++ b/xrpl/models/requests/tx.py
@@ -3,10 +3,13 @@ The tx method retrieves information on a single transaction.
 
 `See tx <https://xrpl.org/tx.html>`_
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Dict, Optional
+
+from typing_extensions import Self
 
 from xrpl.models.requests.request import Request, RequestMethod
 from xrpl.models.utils import require_kwargs_on_init
@@ -70,7 +73,7 @@ class Tx(Request):
     confirms whether it was able to search all the ledgers in the requested range.
     """
 
-    def _get_errors(self: Tx) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
         if not self._has_only_one_input():
             errors[
@@ -78,7 +81,7 @@ class Tx(Request):
             ] = "Must have only one of `ctid` or `transaction`, but not both."
         return errors
 
-    def _has_only_one_input(self: Tx) -> bool:
+    def _has_only_one_input(self: Self) -> bool:
         unique_ids = [self.transaction, self.ctid]
         present_items = list(filter(bool, unique_ids))
         return len(present_items) == 1

--- a/xrpl/models/response.py
+++ b/xrpl/models/response.py
@@ -3,12 +3,15 @@ The base class for all network response types.
 
 Represents fields common to all response types.
 """
+
 from __future__ import annotations
 
 import warnings
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Optional, Union
+
+from typing_extensions import Self
 
 from xrpl.models.base_model import BaseModel
 from xrpl.models.required import REQUIRED
@@ -58,7 +61,7 @@ class Response(BaseModel):
     id: Optional[Union[int, str]] = None
     type: Optional[ResponseType] = None
 
-    def __post_init__(self: Response) -> None:
+    def __post_init__(self: Self) -> None:
         """Called by dataclasses immediately after __init__."""
         super().__post_init__()
         if self.contains_partial_payment():
@@ -68,7 +71,7 @@ class Response(BaseModel):
                 stacklevel=2,
             )
 
-    def is_successful(self: Response) -> bool:
+    def is_successful(self: Self) -> bool:
         """
         Returns whether the request was successfully received and understood by the
         server.
@@ -78,7 +81,7 @@ class Response(BaseModel):
         """
         return self.status == ResponseStatus.SUCCESS
 
-    def contains_partial_payment(self: Response) -> bool:
+    def contains_partial_payment(self: Self) -> bool:
         """
         Returns whether the request contains at least one transactions with
         the partial payment flag set.
@@ -89,7 +92,7 @@ class Response(BaseModel):
         """
         return self._do_contains_partial_payment(self.result)
 
-    def _do_contains_partial_payment(self: Response, val: Any) -> bool:
+    def _do_contains_partial_payment(self: Self, val: Any) -> bool:
         flagged = []
         if isinstance(val, dict):
             formatted = {key.strip().lower(): value for key, value in val.items()}
@@ -108,7 +111,7 @@ class Response(BaseModel):
             ]
         return len(flagged) > 0
 
-    def _is_partial_payment(self: Response, key: str, val: Any) -> bool:
+    def _is_partial_payment(self: Self, key: str, val: Any) -> bool:
         if isinstance(val, dict):
             return self._do_contains_partial_payment(val)
         try:

--- a/xrpl/models/transactions/account_set.py
+++ b/xrpl/models/transactions/account_set.py
@@ -1,11 +1,12 @@
 """Model for AccountSet transaction type."""
+
 from __future__ import annotations  # Requires Python 3.7+
 
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, Optional
 
-from typing_extensions import Final
+from typing_extensions import Final, Self
 
 from xrpl.models.flags import FlagInterface
 from xrpl.models.transactions.transaction import Transaction
@@ -225,7 +226,7 @@ class AccountSet(Transaction):
         init=False,
     )
 
-    def _get_errors(self: AccountSet) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         return {
             key: value
             for key, value in {
@@ -239,7 +240,7 @@ class AccountSet(Transaction):
             if value is not None
         }
 
-    def _get_tick_size_error(self: AccountSet) -> Optional[str]:
+    def _get_tick_size_error(self: Self) -> Optional[str]:
         if self.tick_size is None:
             return None
         if self.tick_size > _MAX_TICK_SIZE:
@@ -248,7 +249,7 @@ class AccountSet(Transaction):
             return f"`tick_size` is below {_MIN_TICK_SIZE}."
         return None
 
-    def _get_transfer_rate_error(self: AccountSet) -> Optional[str]:
+    def _get_transfer_rate_error(self: Self) -> Optional[str]:
         if self.transfer_rate is None:
             return None
         if self.transfer_rate > _MAX_TRANSFER_RATE:
@@ -260,19 +261,19 @@ class AccountSet(Transaction):
             return f"`transfer_rate` is below {_MIN_TRANSFER_RATE}."
         return None
 
-    def _get_domain_error(self: AccountSet) -> Optional[str]:
+    def _get_domain_error(self: Self) -> Optional[str]:
         if self.domain is not None and self.domain.lower() != self.domain:
             return f"Domain {self.domain} is not lowercase"
         if self.domain is not None and len(self.domain) > _MAX_DOMAIN_LENGTH:
             return f"Must not be longer than {_MAX_DOMAIN_LENGTH} characters"
         return None
 
-    def _get_clear_flag_error(self: AccountSet) -> Optional[str]:
+    def _get_clear_flag_error(self: Self) -> Optional[str]:
         if self.clear_flag is not None and self.clear_flag == self.set_flag:
             return "Must not be equal to the set_flag"
         return None
 
-    def _get_nftoken_minter_error(self: AccountSet) -> Optional[str]:
+    def _get_nftoken_minter_error(self: Self) -> Optional[str]:
         if (
             self.set_flag != AccountSetAsfFlag.ASF_AUTHORIZED_NFTOKEN_MINTER
             and self.nftoken_minter is not None

--- a/xrpl/models/transactions/amm_bid.py
+++ b/xrpl/models/transactions/amm_bid.py
@@ -1,10 +1,11 @@
 """Model for AMMBid transaction type."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
-from typing_extensions import Final
+from typing_extensions import Final, Self
 
 from xrpl.models.amounts.issued_currency_amount import IssuedCurrencyAmount
 from xrpl.models.auth_account import AuthAccount
@@ -66,7 +67,7 @@ class AMMBid(Transaction):
         init=False,
     )
 
-    def _get_errors(self: AMMBid) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         return {
             key: value
             for key, value in {
@@ -76,7 +77,7 @@ class AMMBid(Transaction):
             if value is not None
         }
 
-    def _get_auth_accounts_error(self: AMMBid) -> Optional[str]:
+    def _get_auth_accounts_error(self: Self) -> Optional[str]:
         if (
             self.auth_accounts is not None
             and len(self.auth_accounts) > _MAX_AUTH_ACCOUNTS

--- a/xrpl/models/transactions/amm_create.py
+++ b/xrpl/models/transactions/amm_create.py
@@ -1,10 +1,11 @@
 """Model for AMMCreate transaction type."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Dict, Optional
 
-from typing_extensions import Final
+from typing_extensions import Final, Self
 
 from xrpl.models.amounts import Amount
 from xrpl.models.required import REQUIRED
@@ -62,7 +63,7 @@ class AMMCreate(Transaction):
         init=False,
     )
 
-    def _get_errors(self: AMMCreate) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         return {
             key: value
             for key, value in {
@@ -72,7 +73,7 @@ class AMMCreate(Transaction):
             if value is not None
         }
 
-    def _get_trading_fee_error(self: AMMCreate) -> Optional[str]:
+    def _get_trading_fee_error(self: Self) -> Optional[str]:
         if self.trading_fee < 0 or self.trading_fee > AMM_MAX_TRADING_FEE:
             return f"Must be between 0 and {AMM_MAX_TRADING_FEE}"
         return None

--- a/xrpl/models/transactions/amm_deposit.py
+++ b/xrpl/models/transactions/amm_deposit.py
@@ -1,9 +1,12 @@
 """Model for AMMDeposit transaction type."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, Optional
+
+from typing_extensions import Self
 
 from xrpl.models.amounts import Amount, IssuedCurrencyAmount
 from xrpl.models.currencies import Currency
@@ -94,7 +97,7 @@ class AMMDeposit(Transaction):
         init=False,
     )
 
-    def _get_errors(self: AMMDeposit) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
         if self.amount2 is not None and self.amount is None:
             errors["AMMDeposit"] = "Must set `amount` with `amount2`"

--- a/xrpl/models/transactions/amm_vote.py
+++ b/xrpl/models/transactions/amm_vote.py
@@ -1,8 +1,11 @@
 """Model for AMMVote transaction type."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Dict, Optional
+
+from typing_extensions import Self
 
 from xrpl.models.currencies import Currency
 from xrpl.models.required import REQUIRED
@@ -46,7 +49,7 @@ class AMMVote(Transaction):
         init=False,
     )
 
-    def _get_errors(self: AMMVote) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         return {
             key: value
             for key, value in {
@@ -56,7 +59,7 @@ class AMMVote(Transaction):
             if value is not None
         }
 
-    def _get_trading_fee_error(self: AMMVote) -> Optional[str]:
+    def _get_trading_fee_error(self: Self) -> Optional[str]:
         if self.trading_fee < 0 or self.trading_fee > AMM_MAX_TRADING_FEE:
             return f"Must be between 0 and {AMM_MAX_TRADING_FEE}"
         return None

--- a/xrpl/models/transactions/amm_withdraw.py
+++ b/xrpl/models/transactions/amm_withdraw.py
@@ -1,9 +1,12 @@
 """Model for AMMWithdraw transaction type."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, Optional
+
+from typing_extensions import Self
 
 from xrpl.models.amounts import Amount, IssuedCurrencyAmount
 from xrpl.models.currencies import Currency
@@ -91,7 +94,7 @@ class AMMWithdraw(Transaction):
         init=False,
     )
 
-    def _get_errors(self: AMMWithdraw) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
         if self.amount2 is not None and self.amount is None:
             errors["AMMWithdraw"] = "Must set `amount` with `amount2`"

--- a/xrpl/models/transactions/check_cash.py
+++ b/xrpl/models/transactions/check_cash.py
@@ -1,8 +1,11 @@
 """Model for CheckCash transaction type."""
+
 from __future__ import annotations  # Requires Python 3.7+
 
 from dataclasses import dataclass, field
 from typing import Dict, Optional
+
+from typing_extensions import Self
 
 from xrpl.models.amounts import Amount
 from xrpl.models.required import REQUIRED
@@ -49,7 +52,7 @@ class CheckCash(Transaction):
         init=False,
     )
 
-    def _get_errors(self: CheckCash) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
         if not (self.amount is None) ^ (self.deliver_min is None):
             errors[

--- a/xrpl/models/transactions/clawback.py
+++ b/xrpl/models/transactions/clawback.py
@@ -1,8 +1,11 @@
 """Model for Clawback transaction type and related flags."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Dict
+
+from typing_extensions import Self
 
 from xrpl.models.amounts import IssuedCurrencyAmount, is_issued_currency, is_xrp
 from xrpl.models.required import REQUIRED
@@ -29,7 +32,7 @@ class Clawback(Transaction):
         init=False,
     )
 
-    def _get_errors(self: Clawback) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
 
         # Amount transaction errors

--- a/xrpl/models/transactions/deposit_preauth.py
+++ b/xrpl/models/transactions/deposit_preauth.py
@@ -1,8 +1,11 @@
 """Model for DepositPreauth transaction type."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Dict, Optional
+
+from typing_extensions import Self
 
 from xrpl.models.transactions.transaction import Transaction
 from xrpl.models.transactions.types import TransactionType
@@ -36,7 +39,7 @@ class DepositPreauth(Transaction):
         init=False,
     )
 
-    def _get_errors(self: DepositPreauth) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
         if self.authorize and self.unauthorize:
             errors[

--- a/xrpl/models/transactions/did_set.py
+++ b/xrpl/models/transactions/did_set.py
@@ -6,7 +6,7 @@ import re
 from dataclasses import dataclass, field
 from typing import Dict, Optional, Pattern
 
-from typing_extensions import Final
+from typing_extensions import Final, Self
 
 from xrpl.models.transactions.transaction import Transaction
 from xrpl.models.transactions.types import TransactionType
@@ -29,7 +29,7 @@ class DIDSet(Transaction):
         init=False,
     )
 
-    def _get_errors(self: DIDSet) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
 
         if self.did_document is None and self.data is None and self.uri is None:

--- a/xrpl/models/transactions/escrow_create.py
+++ b/xrpl/models/transactions/escrow_create.py
@@ -1,8 +1,11 @@
 """Model for EscrowCreate transaction type."""
+
 from __future__ import annotations  # Requires Python 3.7+
 
 from dataclasses import dataclass, field
 from typing import Dict, Optional
+
+from typing_extensions import Self
 
 from xrpl.models.amounts import Amount
 from xrpl.models.required import REQUIRED
@@ -69,7 +72,7 @@ class EscrowCreate(Transaction):
         init=False,
     )
 
-    def _get_errors(self: EscrowCreate) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
         if (
             self.cancel_after is not None

--- a/xrpl/models/transactions/escrow_finish.py
+++ b/xrpl/models/transactions/escrow_finish.py
@@ -1,8 +1,11 @@
 """Model for EscrowFinish transaction type."""
+
 from __future__ import annotations  # Requires Python 3.7+
 
 from dataclasses import dataclass, field
 from typing import Dict, Optional
+
+from typing_extensions import Self
 
 from xrpl.models.required import REQUIRED
 from xrpl.models.transactions.transaction import Transaction
@@ -52,7 +55,7 @@ class EscrowFinish(Transaction):
         init=False,
     )
 
-    def _get_errors(self: EscrowFinish) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
         if self.condition and not self.fulfillment:
             errors[

--- a/xrpl/models/transactions/nftoken_accept_offer.py
+++ b/xrpl/models/transactions/nftoken_accept_offer.py
@@ -1,8 +1,11 @@
 """Model for NFTokenAcceptOffer transaction type."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Dict, Optional
+
+from typing_extensions import Self
 
 from xrpl.models.amounts import Amount, get_amount_value
 from xrpl.models.transactions.transaction import Transaction
@@ -75,7 +78,7 @@ class NFTokenAcceptOffer(Transaction):
         init=False,
     )
 
-    def _get_errors(self: NFTokenAcceptOffer) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         return {
             key: value
             for key, value in {
@@ -87,21 +90,21 @@ class NFTokenAcceptOffer(Transaction):
             if value is not None
         }
 
-    def _get_nftoken_sell_offer_error(self: NFTokenAcceptOffer) -> Optional[str]:
+    def _get_nftoken_sell_offer_error(self: Self) -> Optional[str]:
         if self.nftoken_broker_fee is not None and self.nftoken_sell_offer is None:
             return "Must be set if using brokered mode"
         if self.nftoken_sell_offer is None and self.nftoken_buy_offer is None:
             return "Must set either nftoken_buy_offer or nftoken_sell_offer"
         return None
 
-    def _get_nftoken_buy_offer_error(self: NFTokenAcceptOffer) -> Optional[str]:
+    def _get_nftoken_buy_offer_error(self: Self) -> Optional[str]:
         if self.nftoken_broker_fee is not None and self.nftoken_buy_offer is None:
             return "Must be set if using brokered mode"
         if self.nftoken_sell_offer is None and self.nftoken_buy_offer is None:
             return "Must set either nftoken_buy_offer or nftoken_sell_offer"
         return None
 
-    def _get_nftoken_broker_fee_error(self: NFTokenAcceptOffer) -> Optional[str]:
+    def _get_nftoken_broker_fee_error(self: Self) -> Optional[str]:
         if (
             self.nftoken_broker_fee is not None
             and get_amount_value(self.nftoken_broker_fee) <= 0

--- a/xrpl/models/transactions/nftoken_cancel_offer.py
+++ b/xrpl/models/transactions/nftoken_cancel_offer.py
@@ -1,8 +1,11 @@
 """Model for NFTokenCancelOffer transaction type."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
+
+from typing_extensions import Self
 
 from xrpl.models.required import REQUIRED
 from xrpl.models.transactions.transaction import Transaction
@@ -42,7 +45,7 @@ class NFTokenCancelOffer(Transaction):
         init=False,
     )
 
-    def _get_errors(self: NFTokenCancelOffer) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         return {
             key: value
             for key, value in {
@@ -52,7 +55,7 @@ class NFTokenCancelOffer(Transaction):
             if value is not None
         }
 
-    def _get_nftoken_offers_error(self: NFTokenCancelOffer) -> Optional[str]:
+    def _get_nftoken_offers_error(self: Self) -> Optional[str]:
         if len(self.nftoken_offers) < 1:
             return "Must specify at least one NFTokenOffer to cancel"
         return None

--- a/xrpl/models/transactions/nftoken_create_offer.py
+++ b/xrpl/models/transactions/nftoken_create_offer.py
@@ -1,9 +1,12 @@
 """Model for NFTokenCreateOffer transaction type and related flag."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, Optional
+
+from typing_extensions import Self
 
 from xrpl.models.amounts import Amount, get_amount_value
 from xrpl.models.flags import FlagInterface
@@ -93,7 +96,7 @@ class NFTokenCreateOffer(Transaction):
         init=False,
     )
 
-    def _get_errors(self: NFTokenCreateOffer) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         return {
             key: value
             for key, value in {
@@ -105,7 +108,7 @@ class NFTokenCreateOffer(Transaction):
             if value is not None
         }
 
-    def _get_amount_error(self: NFTokenCreateOffer) -> Optional[str]:
+    def _get_amount_error(self: Self) -> Optional[str]:
         if (
             not self.has_flag(NFTokenCreateOfferFlag.TF_SELL_NFTOKEN)
             and get_amount_value(self.amount) <= 0
@@ -113,12 +116,12 @@ class NFTokenCreateOffer(Transaction):
             return "Must be greater than 0 for a buy offer"
         return None
 
-    def _get_destination_error(self: NFTokenCreateOffer) -> Optional[str]:
+    def _get_destination_error(self: Self) -> Optional[str]:
         if self.destination == self.account:
             return "Must not be equal to the account"
         return None
 
-    def _get_owner_error(self: NFTokenCreateOffer) -> Optional[str]:
+    def _get_owner_error(self: Self) -> Optional[str]:
         if (
             not self.has_flag(NFTokenCreateOfferFlag.TF_SELL_NFTOKEN)
             and self.owner is None

--- a/xrpl/models/transactions/nftoken_mint.py
+++ b/xrpl/models/transactions/nftoken_mint.py
@@ -1,11 +1,12 @@
 """Model for NFTokenMint transaction type and related flags."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, Optional
 
-from typing_extensions import Final
+from typing_extensions import Final, Self
 
 from xrpl.models.flags import FlagInterface
 from xrpl.models.required import REQUIRED
@@ -110,7 +111,7 @@ class NFTokenMint(Transaction):
         init=False,
     )
 
-    def _get_errors(self: NFTokenMint) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         return {
             key: value
             for key, value in {
@@ -122,17 +123,17 @@ class NFTokenMint(Transaction):
             if value is not None
         }
 
-    def _get_issuer_error(self: NFTokenMint) -> Optional[str]:
+    def _get_issuer_error(self: Self) -> Optional[str]:
         if self.issuer == self.account:
             return "Must not be the same as the account"
         return None
 
-    def _get_transfer_fee_error(self: NFTokenMint) -> Optional[str]:
+    def _get_transfer_fee_error(self: Self) -> Optional[str]:
         if self.transfer_fee is not None and self.transfer_fee > _MAX_TRANSFER_FEE:
             return f"Must not be greater than {_MAX_TRANSFER_FEE}"
         return None
 
-    def _get_uri_error(self: NFTokenMint) -> Optional[str]:
+    def _get_uri_error(self: Self) -> Optional[str]:
         if self.uri is not None and len(self.uri) > _MAX_URI_LENGTH:
             return f"Must not be longer than {_MAX_URI_LENGTH} characters"
         return None

--- a/xrpl/models/transactions/oracle_set.py
+++ b/xrpl/models/transactions/oracle_set.py
@@ -6,6 +6,8 @@ import datetime
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
+from typing_extensions import Self
+
 from xrpl.models.nested_model import NestedModel
 from xrpl.models.required import REQUIRED
 from xrpl.models.transactions.transaction import Transaction
@@ -88,7 +90,7 @@ class OracleSet(Transaction):
         init=False,
     )
 
-    def _get_errors(self: OracleSet) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
 
         # If price_data_series is not set, do not perform further validation

--- a/xrpl/models/transactions/payment.py
+++ b/xrpl/models/transactions/payment.py
@@ -1,9 +1,12 @@
 """Model for Payment transaction type and related flags."""
+
 from __future__ import annotations  # Requires Python 3.7+
 
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, List, Optional
+
+from typing_extensions import Self
 
 from xrpl.models.amounts import Amount, is_xrp
 from xrpl.models.flags import FlagInterface
@@ -126,7 +129,7 @@ class Payment(Transaction):
         init=False,
     )
 
-    def _get_errors(self: Payment) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
 
         # XRP transaction errors

--- a/xrpl/models/transactions/pseudo_transactions/unl_modify.py
+++ b/xrpl/models/transactions/pseudo_transactions/unl_modify.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict
 
+from typing_extensions import Self
+
 from xrpl.models.required import REQUIRED
 from xrpl.models.transactions.pseudo_transactions.pseudo_transaction import (
     PseudoTransaction,
@@ -61,7 +63,7 @@ class UNLModify(PseudoTransaction):
     amendment has been enabled, and applies to all ledgers afterward.
     """
 
-    def _get_errors(self: UNLModify) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
         if self.unl_modify_disabling not in {0, 1}:
             errors[

--- a/xrpl/models/transactions/signer_list_set.py
+++ b/xrpl/models/transactions/signer_list_set.py
@@ -1,11 +1,12 @@
 """Model for SignerListSet transaction type."""
+
 from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Pattern
 
-from typing_extensions import Final
+from typing_extensions import Final, Self
 
 from xrpl.models.nested_model import NestedModel
 from xrpl.models.required import REQUIRED
@@ -78,7 +79,7 @@ class SignerListSet(Transaction):
         init=False,
     )
 
-    def _get_errors(self: SignerListSet) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
 
         # deleting a signer list requires self.signer_quorum == 0 and

--- a/xrpl/models/transactions/transaction.py
+++ b/xrpl/models/transactions/transaction.py
@@ -421,7 +421,7 @@ class Transaction(BaseModel):
 
     @classmethod
     def get_transaction_type(
-        cls: Type[Transaction], transaction_type: str
+        cls: Type[Self], transaction_type: str
     ) -> Type[Transaction]:
         """
         Returns the correct transaction type based on the string name.

--- a/xrpl/models/transactions/transaction.py
+++ b/xrpl/models/transactions/transaction.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from hashlib import sha512
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union
+from typing import Any, Dict, List, Optional, Type, Union
 
 from typing_extensions import Final, Self
 
@@ -151,9 +151,6 @@ class Signer(NestedModel):
 
     :meta hide-value:
     """
-
-
-T = TypeVar("T", bound="Transaction")  # any type inherited from Transaction
 
 
 @require_kwargs_on_init
@@ -331,7 +328,7 @@ class Transaction(BaseModel):
         return encode(self.to_xrpl())
 
     @classmethod
-    def from_dict(cls: Type[T], value: Dict[str, Any]) -> T:
+    def from_dict(cls: Type[Self], value: Dict[str, Any]) -> Self:
         """
         Construct a new Transaction from a dictionary of parameters.
 

--- a/xrpl/models/transactions/transaction.py
+++ b/xrpl/models/transactions/transaction.py
@@ -1,11 +1,12 @@
 """The base model for all transactions and their nested object types."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
 from hashlib import sha512
 from typing import Any, Dict, List, Optional, Type, TypeVar, Union
 
-from typing_extensions import Final
+from typing_extensions import Final, Self
 
 from xrpl.core.binarycodec import decode, encode
 from xrpl.models.amounts import IssuedCurrencyAmount
@@ -101,7 +102,7 @@ class Memo(NestedModel):
     the memo data.
     """
 
-    def _get_errors(self: Memo) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
         present_memo_fields = [
             field
@@ -252,7 +253,7 @@ class Transaction(BaseModel):
     network_id: Optional[int] = None
     """The network id of the transaction."""
 
-    def _get_errors(self: Transaction) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         # import must be here to avoid circular dependencies
         from xrpl.wallet.main import Wallet
 
@@ -271,7 +272,7 @@ class Transaction(BaseModel):
 
         return errors
 
-    def to_dict(self: Transaction) -> Dict[str, Any]:
+    def to_dict(self: Self) -> Dict[str, Any]:
         """
         Returns the dictionary representation of a Transaction.
 
@@ -287,7 +288,7 @@ class Transaction(BaseModel):
         }
 
     def _iter_to_int(
-        self: Transaction,
+        self: Self,
         lst: List[int],
     ) -> int:
         """Calculate flag as int."""
@@ -296,7 +297,7 @@ class Transaction(BaseModel):
             accumulator |= flag
         return accumulator
 
-    def _flags_to_int(self: Transaction) -> int:
+    def _flags_to_int(self: Self) -> int:
         if isinstance(self.flags, int):
             return self.flags
         check_false_flag_definition(tx_type=self.transaction_type, tx_flags=self.flags)
@@ -310,7 +311,7 @@ class Transaction(BaseModel):
 
         return self._iter_to_int(lst=self.flags)
 
-    def to_xrpl(self: Transaction) -> Dict[str, Any]:
+    def to_xrpl(self: Self) -> Dict[str, Any]:
         """
         Creates a JSON-like dictionary in the JSON format used by the binary codec
         based on the Transaction object.
@@ -320,7 +321,7 @@ class Transaction(BaseModel):
         """
         return transaction_json_to_binary_codec_form(self.to_dict())
 
-    def blob(self: Transaction) -> str:
+    def blob(self: Self) -> str:
         """
         Creates the canonical binary format of the Transaction object.
 
@@ -363,7 +364,7 @@ class Transaction(BaseModel):
                 del value["transaction_type"]
             return super(Transaction, cls).from_dict(value)
 
-    def has_flag(self: Transaction, flag: int) -> bool:
+    def has_flag(self: Self, flag: int) -> bool:
         """
         Returns whether the transaction has the given flag value set.
 
@@ -384,7 +385,7 @@ class Transaction(BaseModel):
         else:  # is List[int]
             return flag in self.flags
 
-    def is_signed(self: Transaction) -> bool:
+    def is_signed(self: Self) -> bool:
         """
         Checks if a transaction has been signed.
 
@@ -402,7 +403,7 @@ class Transaction(BaseModel):
             self.signing_pub_key is not None and len(self.signing_pub_key) > 0
         ) and (self.txn_signature is not None and len(self.txn_signature) > 0)
 
-    def get_hash(self: Transaction) -> str:
+    def get_hash(self: Self) -> str:
         """
         Hashes the Transaction object as the ledger does. Only valid for signed
         Transaction objects.

--- a/xrpl/models/transactions/xchain_account_create_commit.py
+++ b/xrpl/models/transactions/xchain_account_create_commit.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict
 
+from typing_extensions import Self
+
 from xrpl.models.required import REQUIRED
 from xrpl.models.transactions.transaction import Transaction
 from xrpl.models.transactions.types import TransactionType
@@ -59,7 +61,7 @@ class XChainAccountCreateCommit(Transaction):
         init=False,
     )
 
-    def _get_errors(self: XChainAccountCreateCommit) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
 
         if self.signature_reward != REQUIRED and not self.signature_reward.isnumeric():

--- a/xrpl/models/transactions/xchain_claim.py
+++ b/xrpl/models/transactions/xchain_claim.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, Optional, Union
 
+from typing_extensions import Self
+
 from xrpl.models.amounts import Amount
 from xrpl.models.currencies import XRP
 from xrpl.models.required import REQUIRED
@@ -71,7 +73,7 @@ class XChainClaim(Transaction):
         init=False,
     )
 
-    def _get_errors(self: XChainClaim) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
 
         bridge = self.xchain_bridge

--- a/xrpl/models/transactions/xchain_create_bridge.py
+++ b/xrpl/models/transactions/xchain_create_bridge.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, Optional
 
+from typing_extensions import Self
+
 from xrpl.models.currencies import XRP
 from xrpl.models.required import REQUIRED
 from xrpl.models.transactions.transaction import Transaction
@@ -53,7 +55,7 @@ class XChainCreateBridge(Transaction):
         init=False,
     )
 
-    def _get_errors(self: XChainCreateBridge) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
 
         bridge = self.xchain_bridge

--- a/xrpl/models/transactions/xchain_create_claim_id.py
+++ b/xrpl/models/transactions/xchain_create_claim_id.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict
 
+from typing_extensions import Self
+
 from xrpl.core.addresscodec import is_valid_classic_address
 from xrpl.models.required import REQUIRED
 from xrpl.models.transactions.transaction import Transaction
@@ -52,7 +54,7 @@ class XChainCreateClaimID(Transaction):
         init=False,
     )
 
-    def _get_errors(self: XChainCreateClaimID) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
 
         if self.signature_reward != REQUIRED and not self.signature_reward.isnumeric():

--- a/xrpl/models/transactions/xchain_modify_bridge.py
+++ b/xrpl/models/transactions/xchain_modify_bridge.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, Optional
 
+from typing_extensions import Self
+
 from xrpl.models.currencies import XRP
 from xrpl.models.flags import FlagInterface
 from xrpl.models.required import REQUIRED
@@ -71,7 +73,7 @@ class XChainModifyBridge(Transaction):
         init=False,
     )
 
-    def _get_errors(self: XChainModifyBridge) -> Dict[str, str]:
+    def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
 
         bridge = self.xchain_bridge

--- a/xrpl/wallet/main.py
+++ b/xrpl/wallet/main.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import List, Optional, Type
 
+from typing_extensions import Self
+
 from xrpl.constants import CryptoAlgorithm, XRPLException
 from xrpl.core import addresscodec
 from xrpl.core.addresscodec import classic_address_to_xaddress, ensure_classic_address
@@ -19,7 +21,7 @@ class Wallet:
     """
 
     @property
-    def address(self: Wallet) -> str:
+    def address(self: Self) -> str:
         """
         The XRPL address that publicly identifies this wallet,
         as a base58 string. This is the same value as the `classic_address`.
@@ -29,7 +31,7 @@ class Wallet:
     # TODO: Just alias classic_address once mypy has resolved this issue:
     #       https://github.com/python/mypy/issues/6700
     @property
-    def classic_address(self: Wallet) -> str:
+    def classic_address(self: Self) -> str:
         """
         `classic_address` is the same as `address`. It is called `classic_address` to
         differentiate it from the x-address standard, which encodes the network,
@@ -39,7 +41,7 @@ class Wallet:
         return self._address
 
     def __init__(
-        self: Wallet,
+        self: Self,
         public_key: str,
         private_key: str,
         *,
@@ -117,8 +119,8 @@ class Wallet:
 
     @classmethod
     def create(
-        cls: Type[Wallet], algorithm: CryptoAlgorithm = CryptoAlgorithm.ED25519
-    ) -> Wallet:
+        cls: Type[Self], algorithm: CryptoAlgorithm = CryptoAlgorithm.ED25519
+    ) -> Self:
         """
         Generates a new seed and Wallet.
 
@@ -130,16 +132,16 @@ class Wallet:
             The wallet that is generated from the given seed.
         """
         seed = generate_seed(algorithm=algorithm)
-        return Wallet.from_seed(seed, algorithm=algorithm)
+        return cls.from_seed(seed, algorithm=algorithm)
 
     @classmethod
     def from_seed(
-        cls: Type[Wallet],
+        cls: Type[Self],
         seed: str,
         *,
         master_address: Optional[str] = None,
         algorithm: CryptoAlgorithm = CryptoAlgorithm.ED25519,
-    ) -> Wallet:
+    ) -> Self:
         """
         Generates a new Wallet from seed (secret).
 
@@ -166,12 +168,12 @@ class Wallet:
 
     @classmethod
     def from_entropy(
-        cls: Type[Wallet],
+        cls: Type[Self],
         entropy: str,
         *,
         master_address: Optional[str] = None,
         algorithm: CryptoAlgorithm = CryptoAlgorithm.ED25519,
-    ) -> Wallet:
+    ) -> Self:
         """
         Generates a new Wallet from entropy (hexadecimal string of random numbers).
 
@@ -195,18 +197,16 @@ class Wallet:
             )
 
         seed = generate_seed(entropy, algorithm)
-        return Wallet.from_seed(
-            seed, master_address=master_address, algorithm=algorithm
-        )
+        return cls.from_seed(seed, master_address=master_address, algorithm=algorithm)
 
     @classmethod
     def from_secret_numbers(
-        self: Type[Wallet],
+        cls: Type[Self],
         secret_numbers: List[str] | str,
         *,
         master_address: Optional[str] = None,
         algorithm: CryptoAlgorithm = CryptoAlgorithm.SECP256K1,
-    ) -> Wallet:
+    ) -> Self:
         """
         Generates a new Wallet from secret numbers.
 
@@ -253,12 +253,12 @@ class Wallet:
             hexed = hex(no)[2:].zfill(4)
             entropy += hexed
 
-        return Wallet.from_entropy(
+        return cls.from_entropy(
             entropy, master_address=master_address, algorithm=algorithm
         )
 
     def get_xaddress(
-        self: Wallet, *, tag: Optional[int] = None, is_test: bool = False
+        self: Self, *, tag: Optional[int] = None, is_test: bool = False
     ) -> str:
         """
         Returns the X-Address of the Wallet's account.
@@ -273,7 +273,7 @@ class Wallet:
         """
         return classic_address_to_xaddress(self.address, tag, is_test)
 
-    def __str__(self: Wallet) -> str:
+    def __str__(self: Self) -> str:
         """
         Returns a string representation of a Wallet.
 


### PR DESCRIPTION
## High Level Overview of Change

This PR replaces the `self: ClassName` paradigm with `self: Self`, added in [Python 3.11](https://peps.python.org/pep-0673/) but supported in `typing_extensions` for all versions. This allows us to remove most of the awkward, unintuitive uses of `TypeVar`.

### Context of Change

It's cleaner and better for handling inheritance.

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

### Did you update CHANGELOG.md?

- [x] No, this change does not impact library users

## Test Plan

CI passes.
