### PR TITLE
feat: add input check for OracleSet params AssetPrice and Scale

### DIFF
--- a/tests/unit/models/transactions/test_oracle_set.py
+++ b/tests/unit/models/transactions/test_oracle_set.py
@@ -350,3 +350,47 @@ class TestSetOracle(TestCase):
             ],
         )
         self.assertTrue(tx.is_valid())
+
+    def test_invalid_price_data_series(self):
+        with self.assertRaises(XRPLModelException) as err:
+            OracleSet(
+                account=_ACCOUNT,
+                oracle_document_id=1,
+                provider=_PROVIDER,
+                asset_class=_ASSET_CLASS,
+                last_update_time=EPOCH_OFFSET,
+                price_data_series=[
+                    PriceData(
+                        base_asset=1, quote_asset="USD", asset_price=740, scale=1
+                    ),
+                    PriceData(
+                        base_asset="BTC", quote_asset="EUR", asset_price=100, scale=2
+                    ),
+                ],
+            )
+
+        self.assertEqual(
+            err.exception.args[0],
+            "{'price_data_series': 'BaseAsset field must be a string'}",
+        )
+
+        with self.assertRaises(XRPLModelException) as err:
+            OracleSet(
+                account=_ACCOUNT,
+                oracle_document_id=1,
+                provider=_PROVIDER,
+                asset_class=_ASSET_CLASS,
+                last_update_time=EPOCH_OFFSET,
+                price_data_series=[
+                    PriceData(base_asset="XRP", quote_asset="USD", asset_price=740),
+                    PriceData(
+                        base_asset="BTC", quote_asset="EUR", asset_price=100, scale=2
+                    ),
+                ],
+            )
+
+        self.assertEqual(
+            err.exception.args[0],
+            "{'price_data_series': "
+            "'Field must have both `AssetPrice` and `Scale` if any are present'}",
+        )

--- a/tests/unit/models/transactions/test_oracle_set.py
+++ b/tests/unit/models/transactions/test_oracle_set.py
@@ -360,28 +360,6 @@ class TestSetOracle(TestCase):
                 asset_class=_ASSET_CLASS,
                 last_update_time=EPOCH_OFFSET,
                 price_data_series=[
-                    PriceData(
-                        base_asset=1, quote_asset="USD", asset_price=740, scale=1
-                    ),
-                    PriceData(
-                        base_asset="BTC", quote_asset="EUR", asset_price=100, scale=2
-                    ),
-                ],
-            )
-
-        self.assertEqual(
-            err.exception.args[0],
-            "{'price_data_series': 'BaseAsset field must be a string'}",
-        )
-
-        with self.assertRaises(XRPLModelException) as err:
-            OracleSet(
-                account=_ACCOUNT,
-                oracle_document_id=1,
-                provider=_PROVIDER,
-                asset_class=_ASSET_CLASS,
-                last_update_time=EPOCH_OFFSET,
-                price_data_series=[
                     PriceData(base_asset="XRP", quote_asset="USD", asset_price=740),
                     PriceData(
                         base_asset="BTC", quote_asset="EUR", asset_price=100, scale=2

--- a/xrpl/models/transactions/oracle_set.py
+++ b/xrpl/models/transactions/oracle_set.py
@@ -102,29 +102,8 @@ class OracleSet(Transaction):
                     f" or equal to {MAX_ORACLE_DATA_SERIES}"
                 )
 
-            # nested object validation
+            # either asset_price and scale are both present or both excluded
             for price_data in self.price_data_series:
-                # validate base_asset
-                if not isinstance(price_data.base_asset, str):
-                    errors["price_data_series"] = "BaseAsset field must be a string"
-
-                # validate quote_asset
-                if not isinstance(price_data.quote_asset, str):
-                    errors["price_data_series"] = "QuoteAsset must be a string"
-
-                # validate asset_price
-                if price_data.asset_price is not None and not isinstance(
-                    price_data.asset_price, int
-                ):
-                    errors["price_data_series"] = "AssetPrice must be an integer"
-
-                # validate scale
-                if price_data.scale is not None and not isinstance(
-                    price_data.scale, int
-                ):
-                    errors["price_data_series"] = "Scale must be an integer"
-
-                # either asset_price and scale are both present or both excluded
                 if (price_data.asset_price is not None) != (
                     price_data.scale is not None
                 ):


### PR DESCRIPTION
## High Level Overview of Change

<!--
Add input check for OracleSet params AssetPrice and Scale either being both present or excluded. Additionally added checks for PriceDataSeries field types.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update CHANGELOG.md?

- [ ] Yes
- [x] No, this change does not impact library users

## Test Plan

<!--
Added unit tests to verify this validation.
-->

