### PR TITLE
Empty strings in DIDSet transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [[Unreleased]]
+
+### Added
 - Add support for the DeliverMax field in Payment transactions
+
+### Fixed
 - Allow empty strings for the purpose of removing fields in DIDSet transaction
 
 ## [2.6.0] - 2024-06-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [[Unreleased]]
 - Add support for the DeliverMax field in Payment transactions
+- Allow empty strings for the purpose of removing fields in DIDSet transaction
 
 ## [2.6.0] - 2024-06-03
 

--- a/tests/unit/models/transactions/test_did_set.py
+++ b/tests/unit/models/transactions/test_did_set.py
@@ -63,7 +63,12 @@ class TestDIDSet(TestCase):
                 "{'did_set': 'Must have one of `did_document`, `data`, and `uri`.'}",
             )
 
-    def test_delete_data_field(self):
+    def test_DIDSet_all_empty_fields(self):
+        with self.assertRaises(XRPLModelException):
+            DIDSet(account=_ACCOUNT, data="", did_document="", uri="")
+
+    def test_delete_multiple_DID_fields(self):
+        # create a valid DID object
         tx = DIDSet(
             account=_ACCOUNT,
             did_document=_VALID_FIELD,
@@ -76,6 +81,27 @@ class TestDIDSet(TestCase):
         tx = DIDSet(
             account=_ACCOUNT,
             data="",
+        )
+
+        self.assertTrue(tx.is_valid())
+
+        # delete URI field
+        tx = DIDSet(
+            account=_ACCOUNT,
+            uri="",
+        )
+
+        self.assertTrue(tx.is_valid())
+
+        # delete did_document field
+
+        # Note: It is invalid to render a DID LedgerObject empty by removing all the
+        # fields. However, that condition can only be detected by reading the
+        # LedgerEntry, which is out-of-scope for the library. rippled generated a
+        # `tecEMPTY_DID` error code in this case
+        tx = DIDSet(
+            account=_ACCOUNT,
+            did_document="",
         )
 
         self.assertTrue(tx.is_valid())

--- a/tests/unit/models/transactions/test_did_set.py
+++ b/tests/unit/models/transactions/test_did_set.py
@@ -77,31 +77,10 @@ class TestDIDSet(TestCase):
         )
         self.assertTrue(tx.is_valid())
 
-        # delete data field
+        # remove the data field from the above DID object
         tx = DIDSet(
             account=_ACCOUNT,
             data="",
-        )
-
-        self.assertTrue(tx.is_valid())
-
-        # delete URI field
-        tx = DIDSet(
-            account=_ACCOUNT,
-            uri="",
-        )
-
-        self.assertTrue(tx.is_valid())
-
-        # delete did_document field
-
-        # Note: It is invalid to render a DID LedgerObject empty by removing all the
-        # fields. However, that condition can only be detected by reading the
-        # LedgerEntry, which is out-of-scope for the library. rippled generated a
-        # `tecEMPTY_DID` error code in this case
-        tx = DIDSet(
-            account=_ACCOUNT,
-            did_document="",
         )
 
         self.assertTrue(tx.is_valid())

--- a/tests/unit/models/transactions/test_did_set.py
+++ b/tests/unit/models/transactions/test_did_set.py
@@ -63,11 +63,11 @@ class TestDIDSet(TestCase):
                 "{'did_set': 'Must have one of `did_document`, `data`, and `uri`.'}",
             )
 
-    def test_DIDSet_all_empty_fields(self):
+    def test_all_empty_fields(self):
         with self.assertRaises(XRPLModelException):
             DIDSet(account=_ACCOUNT, data="", did_document="", uri="")
 
-    def test_delete_multiple_DID_fields(self):
+    def test_delete_multiple_fields(self):
         # create a valid DID object
         tx = DIDSet(
             account=_ACCOUNT,

--- a/tests/unit/models/transactions/test_did_set.py
+++ b/tests/unit/models/transactions/test_did_set.py
@@ -67,7 +67,7 @@ class TestDIDSet(TestCase):
         with self.assertRaises(XRPLModelException):
             DIDSet(account=_ACCOUNT, data="", did_document="", uri="")
 
-    def test_remove_data_field(self):
+    def test_empty_data_field(self):
         # create a valid DID object
         tx = DIDSet(
             account=_ACCOUNT,

--- a/tests/unit/models/transactions/test_did_set.py
+++ b/tests/unit/models/transactions/test_did_set.py
@@ -58,6 +58,10 @@ class TestDIDSet(TestCase):
             DIDSet(
                 account=_ACCOUNT,
             )
+        self.assertEqual(
+            error.exception.args[0],
+            "{'did_set': 'Must have one of `did_document`, `data`, and `uri`.'}",
+        )
 
     def test_create_did_object_all_empty_fields(self):
         with self.assertRaises(XRPLModelException):

--- a/tests/unit/models/transactions/test_did_set.py
+++ b/tests/unit/models/transactions/test_did_set.py
@@ -71,16 +71,6 @@ class TestDIDSet(TestCase):
         # create a valid DID object
         tx = DIDSet(
             account=_ACCOUNT,
-            did_document=_VALID_FIELD,
-            uri=_VALID_FIELD,
-            data=_VALID_FIELD,
-        )
-        self.assertTrue(tx.is_valid())
-
-        # remove the data field from the above DID object
-        tx = DIDSet(
-            account=_ACCOUNT,
             data="",
         )
-
         self.assertTrue(tx.is_valid())

--- a/tests/unit/models/transactions/test_did_set.py
+++ b/tests/unit/models/transactions/test_did_set.py
@@ -63,11 +63,11 @@ class TestDIDSet(TestCase):
                 "{'did_set': 'Must have one of `did_document`, `data`, and `uri`.'}",
             )
 
-    def test_all_empty_fields(self):
+    def test_create_did_object_all_empty_fields(self):
         with self.assertRaises(XRPLModelException):
             DIDSet(account=_ACCOUNT, data="", did_document="", uri="")
 
-    def test_delete_multiple_fields(self):
+    def test_remove_data_field(self):
         # create a valid DID object
         tx = DIDSet(
             account=_ACCOUNT,

--- a/tests/unit/models/transactions/test_did_set.py
+++ b/tests/unit/models/transactions/test_did_set.py
@@ -62,3 +62,20 @@ class TestDIDSet(TestCase):
                 error.exception.args[0],
                 "{'did_set': 'Must have one of `did_document`, `data`, and `uri`.'}",
             )
+
+    def test_delete_data_field(self):
+        tx = DIDSet(
+            account=_ACCOUNT,
+            did_document=_VALID_FIELD,
+            uri=_VALID_FIELD,
+            data=_VALID_FIELD,
+        )
+        self.assertTrue(tx.is_valid())
+
+        # delete data field
+        tx = DIDSet(
+            account=_ACCOUNT,
+            data="",
+        )
+
+        self.assertTrue(tx.is_valid())

--- a/xrpl/models/transactions/did_set.py
+++ b/xrpl/models/transactions/did_set.py
@@ -12,8 +12,6 @@ from xrpl.models.transactions.transaction import Transaction
 from xrpl.models.transactions.types import TransactionType
 from xrpl.models.utils import require_kwargs_on_init
 
-# DID LedgerObject fields are removed with an empty string as input.
-# Hence, empty strings need to be supported in the regex
 HEX_REGEX: Final[Pattern[str]] = re.compile("[a-fA-F0-9]*")
 
 

--- a/xrpl/models/transactions/did_set.py
+++ b/xrpl/models/transactions/did_set.py
@@ -12,7 +12,9 @@ from xrpl.models.transactions.transaction import Transaction
 from xrpl.models.transactions.types import TransactionType
 from xrpl.models.utils import require_kwargs_on_init
 
-HEX_REGEX: Final[Pattern[str]] = re.compile("[a-fA-F0-9]+")
+# DID LedgerObject fields are removed with an empty string as input.
+# Hence, empty strings need to be supported in the regex
+HEX_REGEX: Final[Pattern[str]] = re.compile("[a-fA-F0-9]*")
 
 
 @require_kwargs_on_init
@@ -35,6 +37,14 @@ class DIDSet(Transaction):
         if self.did_document is None and self.data is None and self.uri is None:
             errors["did_set"] = "Must have one of `did_document`, `data`, and `uri`."
             # Can return here because there are no fields to process
+            return errors
+
+        if self.did_document == "" and self.data == "" and self.uri == "":
+            errors["did_set"] = (
+                "At least one of DID fields `did_document`, `data`, and `uri` "
+                + "must be of positive length"
+            )
+
             return errors
 
         def _process_field(name: str, value: Optional[str]) -> None:

--- a/xrpl/models/transactions/did_set.py
+++ b/xrpl/models/transactions/did_set.py
@@ -23,21 +23,23 @@ class DIDSet(Transaction):
     did_document: Optional[str] = None
     """
     The DID document associated with the DID.
-    You must include either Data, DIDDocument, or URI when you submit the DIDSet
-    transaction. If all three fields are missing, the transaction fails.
 
-    Note: To delete the Data, DIDDocument, or URI field from an existing DID ledger
+    To delete the Data, DIDDocument, or URI field from an existing DID ledger
     entry, add the field as an empty string.
     """
 
     data: Optional[str] = None
     """
     The public attestations of identity credentials associated with the DID.
+    To delete the Data, DIDDocument, or URI field from an existing DID ledger
+    entry, add the field as an empty string.
     """
 
     uri: Optional[str] = None
     """
     The Universal Resource Identifier associated with the DID.
+    To delete the Data, DIDDocument, or URI field from an existing DID ledger
+    entry, add the field as an empty string.
     """
 
     transaction_type: TransactionType = field(

--- a/xrpl/models/transactions/did_set.py
+++ b/xrpl/models/transactions/did_set.py
@@ -42,7 +42,7 @@ class DIDSet(Transaction):
         if self.did_document == "" and self.data == "" and self.uri == "":
             errors["did_set"] = (
                 "At least one of the fields `did_document`, `data`, and `uri` "
-                + "must be of positive length"
+                + "must have a length greater than zero"
             )
 
             return errors

--- a/xrpl/models/transactions/did_set.py
+++ b/xrpl/models/transactions/did_set.py
@@ -21,8 +21,24 @@ class DIDSet(Transaction):
     """Represents a DIDSet transaction."""
 
     did_document: Optional[str] = None
+    """
+    The DID document associated with the DID.
+    You must include either Data, DIDDocument, or URI when you submit the DIDSet
+    transaction. If all three fields are missing, the transaction fails.
+
+    Note: To delete the Data, DIDDocument, or URI field from an existing DID ledger
+    entry, add the field as an empty string.
+    """
+
     data: Optional[str] = None
+    """
+    The public attestations of identity credentials associated with the DID.
+    """
+
     uri: Optional[str] = None
+    """
+    The Universal Resource Identifier associated with the DID.
+    """
 
     transaction_type: TransactionType = field(
         default=TransactionType.DID_SET,

--- a/xrpl/models/transactions/did_set.py
+++ b/xrpl/models/transactions/did_set.py
@@ -41,7 +41,7 @@ class DIDSet(Transaction):
 
         if self.did_document == "" and self.data == "" and self.uri == "":
             errors["did_set"] = (
-                "At least one of DID fields `did_document`, `data`, and `uri` "
+                "At least one of the fields `did_document`, `data`, and `uri` "
                 + "must be of positive length"
             )
 


### PR DESCRIPTION
## High Level Overview of Change
Fix https://github.com/XRPLF/xrpl-py/issues/716

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

Fields within a DID object can only be deleted by setting an empty string. However, the regex in the `DIDSet` model do not account for empty strings.

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update CHANGELOG.md?

- [x] Yes
- [ ] No, this change does not impact library users

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

Unit tests have been added to this effect

<!--
## Future Tasks
For future tasks related to PR.
-->
