### PR TITLE
Remove deprecated `accounts` and `type` parameters from ledger request model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow empty strings for the purpose of removing fields in DIDSet transaction
 
 ### Removed
-- Remove deprecated `full` parameter from ledger request model
+- Remove deprecated `full`, `accounts`, and `type` parameters from ledger request model
 
 ## [2.6.0] - 2024-06-03
 

--- a/xrpl/models/requests/ledger.py
+++ b/xrpl/models/requests/ledger.py
@@ -3,9 +3,7 @@ Retrieve information about the public ledger.
 `See ledger <https://xrpl.org/ledger.html>`_
 """
 from dataclasses import dataclass, field
-from typing import Optional
 
-from xrpl.models.requests.ledger_entry import LedgerEntryType
 from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
 from xrpl.models.utils import KW_ONLY_DATACLASS, require_kwargs_on_init
 

--- a/xrpl/models/requests/ledger.py
+++ b/xrpl/models/requests/ledger.py
@@ -19,10 +19,8 @@ class Ledger(Request, LookupByLedgerRequest):
     """
 
     method: RequestMethod = field(default=RequestMethod.LEDGER, init=False)
-    accounts: bool = False
     transactions: bool = False
     expand: bool = False
     owner_funds: bool = False
     binary: bool = False
     queue: bool = False
-    type: Optional[LedgerEntryType] = None


### PR DESCRIPTION
## High Level Overview of Change

Remove deprecated `accounts` and `type` parameters from ledger request model

### Context of Change

In the [ledger API](https://xrpl.org/docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger/), the accounts and type request parameters has been deprecated for quite awhile now. As of Clio 2.2.0 with this particular commit https://github.com/XRPLF/clio/pull/1360, this API will return a request error if you provide that parameter. This change removes this parameter from the ledger request model. This change would not impact lib users as this setting this parameter previously would not have been used by rippled or Clio

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update CHANGELOG.md?

- [x] Yes
- [ ] No, this change does not impact library users

## Test Plan

Existing integration tests should continue to pass and manual testing of ledger API with xrpl-py against Clio 2.2.0 should succeed