### PR TITLE
feat: add support for Batch amendment

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
     "keypair",
     "keypairs",
     "multisign",
+    "multisigned",
     "nftoken",
     "PATHSET",
     "rippletest",

--- a/tests/unit/models/transactions/test_transaction.py
+++ b/tests/unit/models/transactions/test_transaction.py
@@ -1,8 +1,9 @@
 from unittest import TestCase
 
 from xrpl.asyncio.transaction.main import sign
+from xrpl.core.addresscodec.main import classic_address_to_xaddress
 from xrpl.models.exceptions import XRPLModelException
-from xrpl.models.transactions import AccountSet, OfferCreate, Payment
+from xrpl.models.transactions import AccountSet, DepositPreauth, OfferCreate, Payment
 from xrpl.models.transactions.transaction import Transaction
 from xrpl.models.transactions.types.transaction_type import TransactionType
 from xrpl.transaction.multisign import multisign
@@ -152,6 +153,17 @@ class TestTransaction(TestCase):
 
     def test_is_signed_for_multisigned_transaction(self):
         tx = AccountSet(account=_WALLET.address, domain=EXAMPLE_DOMAIN)
+        tx_1 = sign(tx, _FIRST_SIGNER, multisign=True)
+        tx_2 = sign(tx, _SECOND_SIGNER, multisign=True)
+
+        multisigned_tx = multisign(tx, [tx_1, tx_2])
+        self.assertTrue(multisigned_tx.is_signed())
+
+    def test_multisigned_transaction_xaddress(self):
+        tx = DepositPreauth(
+            account=classic_address_to_xaddress(_WALLET.address, 1, False),
+            authorize=classic_address_to_xaddress(_ACCOUNT, 1, False),
+        )
         tx_1 = sign(tx, _FIRST_SIGNER, multisign=True)
         tx_2 = sign(tx, _SECOND_SIGNER, multisign=True)
 

--- a/tests/unit/models/transactions/test_transaction.py
+++ b/tests/unit/models/transactions/test_transaction.py
@@ -171,7 +171,7 @@ class TestTransaction(TestCase):
         self.assertTrue(multisigned_tx.is_signed())
 
     # test the usage  of DeliverMax field in Payment transactions
-    def test_payment_txn_API_no_deliver_max(self):
+    def test_payment_txn_api_no_deliver_max(self):
         delivered_amount = "200000"
         payment_tx_json = {
             "Account": "rGWTUVmm1fB5QUjMYn8KfnyrFNgDiD9H9e",
@@ -187,7 +187,7 @@ class TestTransaction(TestCase):
         payment_txn = Payment.from_xrpl(payment_tx_json)
         self.assertEqual(delivered_amount, payment_txn.to_dict()["amount"])
 
-    def test_payment_txn_API_no_amount(self):
+    def test_payment_txn_api_no_amount(self):
         delivered_amount = "200000"
         payment_tx_json = {
             "Account": "rGWTUVmm1fB5QUjMYn8KfnyrFNgDiD9H9e",
@@ -203,7 +203,7 @@ class TestTransaction(TestCase):
         payment_txn = Payment.from_xrpl(payment_tx_json)
         self.assertEqual(delivered_amount, payment_txn.to_dict()["amount"])
 
-    def test_payment_txn_API_different_amount_and_deliver_max(self):
+    def test_payment_txn_api_different_amount_and_deliver_max(self):
         payment_tx_json = {
             "Account": "rGWTUVmm1fB5QUjMYn8KfnyrFNgDiD9H9e",
             "Destination": "rw71Qs1UYQrSQ9hSgRohqNNQcyjCCfffkQ",
@@ -219,7 +219,7 @@ class TestTransaction(TestCase):
         with self.assertRaises(XRPLModelException):
             Payment.from_xrpl(payment_tx_json)
 
-    def test_payment_txn_API_identical_amount_and_deliver_max(self):
+    def test_payment_txn_api_identical_amount_and_deliver_max(self):
         delivered_amount = "200000"
         payment_tx_json = {
             "Account": "rGWTUVmm1fB5QUjMYn8KfnyrFNgDiD9H9e",

--- a/xrpl/core/binarycodec/definitions/definitions.json
+++ b/xrpl/core/binarycodec/definitions/definitions.json
@@ -261,6 +261,16 @@
       }
     ],
     [
+      "BatchIndex",
+      {
+        "nth": 20,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt8"
+      }
+    ],
+    [
       "LedgerEntryType",
       {
         "nth": 1,
@@ -364,6 +374,16 @@
       "HookApiVersion",
       {
         "nth": 20,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt16"
+      }
+    ],
+    [
+      "LedgerFixType",
+      {
+        "nth": 21,
         "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
@@ -1981,6 +2001,16 @@
       }
     ],
     [
+      "InnerResult",
+      {
+        "nth": 30,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Blob"
+      }
+    ],
+    [
       "Account",
       {
         "nth": 1,
@@ -2141,6 +2171,16 @@
       }
     ],
     [
+      "OuterAccount",
+      {
+        "nth": 24,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "AccountID"
+      }
+    ],
+    [
       "Indexes",
       {
         "nth": 1,
@@ -2174,6 +2214,16 @@
       "NFTokenOffers",
       {
         "nth": 4,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Vector256"
+      }
+    ],
+    [
+      "TxIDs",
+      {
+        "nth": 5,
         "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
@@ -2551,6 +2601,46 @@
       }
     ],
     [
+      "RawTransaction",
+      {
+        "nth": 33,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STObject"
+      }
+    ],
+    [
+      "BatchExecution",
+      {
+        "nth": 34,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STObject"
+      }
+    ],
+    [
+      "BatchTxn",
+      {
+        "nth": 35,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STObject"
+      }
+    ],
+    [
+      "BatchSigner",
+      {
+        "nth": 36,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STObject"
+      }
+    ],
+    [
       "Signers",
       {
         "nth": 3,
@@ -2739,6 +2829,36 @@
         "isSigningField": true,
         "type": "STArray"
       }
+    ],
+    [
+      "BatchExecutions",
+      {
+        "nth": 26,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STArray"
+      }
+    ],
+    [
+      "RawTransactions",
+      {
+        "nth": 27,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STArray"
+      }
+    ],
+    [
+      "BatchSigners",
+      {
+        "nth": 28,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": false,
+        "type": "STArray"
+      }
     ]
   ],
   "TRANSACTION_RESULTS": {
@@ -2808,6 +2928,7 @@
     "temEMPTY_DID": -254,
     "temARRAY_EMPTY": -253,
     "temARRAY_TOO_LARGE": -252,
+    "temINVALID_BATCH": -251,
 
     "tefFAILURE": -199,
     "tefALREADY": -198,
@@ -2830,6 +2951,7 @@
     "tefTOO_BIG": -181,
     "tefNO_TICKET": -180,
     "tefNFTOKEN_IS_NOT_TRANSFERABLE": -179,
+    "tefINVALID_LEDGER_FIX_TYPE": -178,
 
     "terRETRY": -99,
     "terFUNDS_SPENT": -98,
@@ -2923,7 +3045,8 @@
     "tecINVALID_UPDATE_TIME": 188,
     "tecTOKEN_PAIR_NOT_FOUND": 189,
     "tecARRAY_EMPTY": 190,
-    "tecARRAY_TOO_LARGE": 191
+    "tecARRAY_TOO_LARGE": 191,
+    "tecBATCH_FAILURE": 192
   },
   "TRANSACTION_TYPES": {
     "Invalid": -1,
@@ -2974,6 +3097,8 @@
     "DIDDelete": 50,
     "OracleSet": 51,
     "OracleDelete": 52,
+    "LedgerStateFix": 53,
+    "Batch": 54,
     "EnableAmendment": 100,
     "SetFee": 101,
     "UNLModify": 102

--- a/xrpl/models/transactions/__init__.py
+++ b/xrpl/models/transactions/__init__.py
@@ -34,6 +34,7 @@ from xrpl.models.transactions.did_set import DIDSet
 from xrpl.models.transactions.escrow_cancel import EscrowCancel
 from xrpl.models.transactions.escrow_create import EscrowCreate
 from xrpl.models.transactions.escrow_finish import EscrowFinish
+from xrpl.models.transactions.ledger_state_fix import LedgerStateFix
 from xrpl.models.transactions.metadata import TransactionMetadata
 from xrpl.models.transactions.nftoken_accept_offer import NFTokenAcceptOffer
 from xrpl.models.transactions.nftoken_burn import NFTokenBurn
@@ -119,6 +120,7 @@ __all__ = [
     "EscrowCancel",
     "EscrowCreate",
     "EscrowFinish",
+    "LedgerStateFix",
     "Memo",
     "NFTokenAcceptOffer",
     "NFTokenBurn",

--- a/xrpl/models/transactions/__init__.py
+++ b/xrpl/models/transactions/__init__.py
@@ -24,6 +24,7 @@ from xrpl.models.transactions.amm_withdraw import (
     AMMWithdrawFlag,
     AMMWithdrawFlagInterface,
 )
+from xrpl.models.transactions.batch import Batch
 from xrpl.models.transactions.check_cancel import CheckCancel
 from xrpl.models.transactions.check_cash import CheckCash
 from xrpl.models.transactions.check_create import CheckCreate
@@ -110,6 +111,7 @@ __all__ = [
     "AMMWithdrawFlag",
     "AMMWithdrawFlagInterface",
     "AuthAccount",
+    "Batch",
     "CheckCancel",
     "CheckCash",
     "CheckCreate",

--- a/xrpl/models/transactions/batch.py
+++ b/xrpl/models/transactions/batch.py
@@ -1,0 +1,63 @@
+"""Model for Batch transaction type."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from xrpl.models.nested_model import NestedModel
+from xrpl.models.required import REQUIRED
+from xrpl.models.transactions.transaction import Signer, Transaction
+from xrpl.models.transactions.types import TransactionType
+from xrpl.models.utils import KW_ONLY_DATACLASS, require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True, **KW_ONLY_DATACLASS)
+class BatchSigner(NestedModel):
+    """Represents a Batch signer."""
+
+    account: str = REQUIRED  # type: ignore
+
+    signing_pub_key: Optional[str] = None
+
+    txn_signature: Optional[str] = None
+
+    signers: Optional[List[Signer]] = None
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True, **KW_ONLY_DATACLASS)
+class BatchTxn(NestedModel):
+    """Represents the info indicating a Batch transaction."""
+
+    outer_account: str = REQUIRED  # type: ignore
+
+    sequence: Optional[int] = None
+
+    ticket_sequence: Optional[int] = None
+
+    batch_index: int = REQUIRED  # type: ignore
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True, **KW_ONLY_DATACLASS)
+class BatchInnerTransaction(Transaction):
+    """Represents a Batch inner transaction."""
+
+    BatchTxn: BatchTxn = REQUIRED  # type: ignore
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True, **KW_ONLY_DATACLASS)
+class Batch(Transaction):
+    """Represents a Batch transaction."""
+
+    raw_transactions: List[BatchInnerTransaction] = REQUIRED  # type: ignore
+    tx_ids: List[str] = REQUIRED  # type: ignore
+    batch_signers: Optional[List[BatchSigner]] = None
+
+    transaction_type: TransactionType = field(
+        default=TransactionType.BATCH,
+        init=False,
+    )

--- a/xrpl/models/transactions/batch.py
+++ b/xrpl/models/transactions/batch.py
@@ -28,33 +28,11 @@ class BatchSigner(NestedModel):
 
 @require_kwargs_on_init
 @dataclass(frozen=True, **KW_ONLY_DATACLASS)
-class BatchTxn(NestedModel):
-    """Represents the info indicating a Batch transaction."""
-
-    outer_account: str = REQUIRED  # type: ignore
-
-    sequence: Optional[int] = None
-
-    ticket_sequence: Optional[int] = None
-
-    batch_index: int = REQUIRED  # type: ignore
-
-
-@require_kwargs_on_init
-@dataclass(frozen=True, **KW_ONLY_DATACLASS)
-class BatchInnerTransaction(Transaction):
-    """Represents a Batch inner transaction."""
-
-    BatchTxn: BatchTxn = REQUIRED  # type: ignore
-
-
-@require_kwargs_on_init
-@dataclass(frozen=True, **KW_ONLY_DATACLASS)
 class Batch(Transaction):
     """Represents a Batch transaction."""
 
-    raw_transactions: List[BatchInnerTransaction] = REQUIRED  # type: ignore
-    tx_ids: List[str] = REQUIRED  # type: ignore
+    raw_transactions: List[Transaction] = REQUIRED  # type: ignore
+    tx_ids: Optional[List[str]] = None
     batch_signers: Optional[List[BatchSigner]] = None
 
     transaction_type: TransactionType = field(

--- a/xrpl/models/transactions/ledger_state_fix.py
+++ b/xrpl/models/transactions/ledger_state_fix.py
@@ -1,0 +1,25 @@
+"""Model for LedgerStateFix transaction type."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from xrpl.models.required import REQUIRED
+from xrpl.models.transactions.transaction import Transaction
+from xrpl.models.transactions.types import TransactionType
+from xrpl.models.utils import KW_ONLY_DATACLASS, require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True, **KW_ONLY_DATACLASS)
+class LedgerStateFix(Transaction):
+    """Represents a LedgerStateFix transaction."""
+
+    ledger_fix_type: int = REQUIRED  # type: ignore
+    owner: Optional[str] = None
+
+    transaction_type: TransactionType = field(
+        default=TransactionType.LEDGER_STATE_FIX,
+        init=False,
+    )

--- a/xrpl/models/transactions/transaction.py
+++ b/xrpl/models/transactions/transaction.py
@@ -16,6 +16,7 @@ from xrpl.models.flags import check_false_flag_definition, interface_to_flag_lis
 from xrpl.models.nested_model import NestedModel
 from xrpl.models.requests import PathStep
 from xrpl.models.required import REQUIRED
+from xrpl.models.transactions.batch import BatchInnerTransaction
 from xrpl.models.transactions.types import PseudoTransactionType, TransactionType
 from xrpl.models.types import XRPL_VALUE_TYPE
 from xrpl.models.utils import KW_ONLY_DATACLASS, require_kwargs_on_init
@@ -411,7 +412,11 @@ class Transaction(BaseModel):
         Raises:
             XRPLModelException: if the Transaction is unsigned.
         """
-        if self.txn_signature is None and self.signers is None:
+        if (
+            self.txn_signature is None
+            and self.signers is None
+            and not isinstance(self, BatchInnerTransaction)
+        ):
             raise XRPLModelException(
                 "Cannot get the hash from an unsigned Transaction."
             )

--- a/xrpl/models/transactions/types/transaction_type.py
+++ b/xrpl/models/transactions/types/transaction_type.py
@@ -14,6 +14,7 @@ class TransactionType(str, Enum):
     AMM_DEPOSIT = "AMMDeposit"
     AMM_VOTE = "AMMVote"
     AMM_WITHDRAW = "AMMWithdraw"
+    BATCH = "Batch"
     CHECK_CANCEL = "CheckCancel"
     CHECK_CASH = "CheckCash"
     CHECK_CREATE = "CheckCreate"

--- a/xrpl/models/transactions/types/transaction_type.py
+++ b/xrpl/models/transactions/types/transaction_type.py
@@ -24,6 +24,7 @@ class TransactionType(str, Enum):
     ESCROW_CANCEL = "EscrowCancel"
     ESCROW_CREATE = "EscrowCreate"
     ESCROW_FINISH = "EscrowFinish"
+    LEDGER_STATE_FIX = "LedgerStateFix"
     NFTOKEN_ACCEPT_OFFER = "NFTokenAcceptOffer"
     NFTOKEN_BURN = "NFTokenBurn"
     NFTOKEN_CANCEL_OFFER = "NFTokenCancelOffer"


### PR DESCRIPTION
## High Level Overview of Change

This PR:
* Adds models for the `Batch` transactions
* Updates definitions.json to handle the new field types
* Adds support to the binary codec to properly sign multi-account `Batch` transactions
* Adds helper functions for signing and combining multi-account `Batch` transactions
* Adds support to `autofill` for filling in the `BatchTxn` and `TxIDs` fields
* Adds support for Batchnet to the faucets

### Context of Change

https://github.com/XRPLF/rippled/pull/5060

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update HISTORY.md?

- [x] Yes
- [ ] No, this change does not impact library users

## Test Plan

Added tests for the new features.
