### PR TITLE
remove # type: ignore after each REQUIRED

### DIFF
--- a/tools/generate_tx_models.py
+++ b/tools/generate_tx_models.py
@@ -117,7 +117,7 @@ def _main(
             param_name = param[2:]
             param_type = sfields[param_name][0]
             if is_required:
-                param_type_output = f"{TYPE_MAP[param_type]} = REQUIRED  # type: ignore"
+                param_type_output = f"{TYPE_MAP[param_type]} = REQUIRED"
             else:
                 param_type_output = f"Optional[{TYPE_MAP[param_type]}] = None"
             return f"    {_key_to_json(param_name)}: {param_type_output}"

--- a/xrpl/models/amounts/issued_currency_amount.py
+++ b/xrpl/models/amounts/issued_currency_amount.py
@@ -25,7 +25,7 @@ class IssuedCurrencyAmount(IssuedCurrency):
     See https://xrpl.org/currency-formats.html#issued-currency-amounts.
     """
 
-    value: Union[str, int, float] = REQUIRED  # type: ignore
+    value: Union[str, int, float] = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/auth_account.py
+++ b/xrpl/models/auth_account.py
@@ -1,4 +1,5 @@
 """Model used in AMMBid transaction."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -13,7 +14,7 @@ from xrpl.models.utils import KW_ONLY_DATACLASS, require_kwargs_on_init
 class AuthAccount(NestedModel):
     """Represents one entry in a list of AuthAccounts used in AMMBid transaction."""
 
-    account: str = REQUIRED  # type: ignore
+    account: str = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/currencies/issued_currency.py
+++ b/xrpl/models/currencies/issued_currency.py
@@ -36,14 +36,14 @@ class IssuedCurrency(BaseModel):
     See https://xrpl.org/currency-formats.html#specifying-currency-amounts
     """
 
-    currency: str = REQUIRED  # type: ignore
+    currency: str = REQUIRED
     """
     This field is required.
 
     :meta hide-value:
     """
 
-    issuer: str = REQUIRED  # type: ignore
+    issuer: str = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/requests/account_channels.py
+++ b/xrpl/models/requests/account_channels.py
@@ -7,6 +7,7 @@ All information retrieved is relative to a particular version of the ledger.
 
 `See account_channels <https://xrpl.org/account_channels.html>`_
 """
+
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
@@ -29,7 +30,7 @@ class AccountChannels(Request, LookupByLedgerRequest):
     """
 
     method: RequestMethod = field(default=RequestMethod.ACCOUNT_CHANNELS, init=False)
-    account: str = REQUIRED  # type: ignore
+    account: str = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/requests/account_currencies.py
+++ b/xrpl/models/requests/account_currencies.py
@@ -7,6 +7,7 @@ interfaces.
 
 `See account_currencies <https://xrpl.org/account_currencies.html>`_
 """
+
 from dataclasses import dataclass, field
 
 from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
@@ -27,7 +28,7 @@ class AccountCurrencies(Request, LookupByLedgerRequest):
     `See account_currencies <https://xrpl.org/account_currencies.html>`_
     """
 
-    account: str = REQUIRED  # type: ignore
+    account: str = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/requests/account_info.py
+++ b/xrpl/models/requests/account_info.py
@@ -6,6 +6,7 @@ All information retrieved is relative to a particular version of the ledger.
 
 `See account_info <https://xrpl.org/account_info.html>`_
 """
+
 from dataclasses import dataclass, field
 
 from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
@@ -25,7 +26,7 @@ class AccountInfo(Request, LookupByLedgerRequest):
     `See account_info <https://xrpl.org/account_info.html>`_
     """
 
-    account: str = REQUIRED  # type: ignore
+    account: str = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/requests/account_lines.py
+++ b/xrpl/models/requests/account_lines.py
@@ -5,6 +5,7 @@ particular version of the ledger.
 
 `See account_lines <https://xrpl.org/account_lines.html>`_
 """
+
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
@@ -24,7 +25,7 @@ class AccountLines(Request, LookupByLedgerRequest):
     `See account_lines <https://xrpl.org/account_lines.html>`_
     """
 
-    account: str = REQUIRED  # type: ignore
+    account: str = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/requests/account_nfts.py
+++ b/xrpl/models/requests/account_nfts.py
@@ -1,4 +1,5 @@
 """This method retrieves all of the NFTs currently owned by the specified account."""
+
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
@@ -16,7 +17,7 @@ class AccountNFTs(Request, LookupByLedgerRequest):
     """
 
     method: RequestMethod = field(default=RequestMethod.ACCOUNT_NFTS, init=False)
-    account: str = REQUIRED  # type: ignore
+    account: str = REQUIRED
     """
     The unique identifier of an account, typically the account's address. The
     request returns NFTs owned by this account. This value is required.

--- a/xrpl/models/requests/account_objects.py
+++ b/xrpl/models/requests/account_objects.py
@@ -6,6 +6,7 @@ AccountLinesRequest instead.
 
 `See account_objects <https://xrpl.org/account_objects.html>`_
 """
+
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Optional
@@ -47,7 +48,7 @@ class AccountObjects(Request, LookupByLedgerRequest):
     `See account_objects <https://xrpl.org/account_objects.html>`_
     """
 
-    account: str = REQUIRED  # type: ignore
+    account: str = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/requests/account_offers.py
+++ b/xrpl/models/requests/account_offers.py
@@ -4,6 +4,7 @@ outstanding as of a particular ledger version.
 
 `See account_offers <https://xrpl.org/account_offers.html>`_
 """
+
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
@@ -22,7 +23,7 @@ class AccountOffers(Request, LookupByLedgerRequest):
     `See account_offers <https://xrpl.org/account_offers.html>`_
     """
 
-    account: str = REQUIRED  # type: ignore
+    account: str = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/requests/account_tx.py
+++ b/xrpl/models/requests/account_tx.py
@@ -4,6 +4,7 @@ specified account.
 
 `See account_tx <https://xrpl.org/account_tx.html>`_
 """
+
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
@@ -22,7 +23,7 @@ class AccountTx(Request, LookupByLedgerRequest):
     `See account_tx <https://xrpl.org/account_tx.html>`_
     """
 
-    account: str = REQUIRED  # type: ignore
+    account: str = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/requests/book_offers.py
+++ b/xrpl/models/requests/book_offers.py
@@ -2,6 +2,7 @@
 The book_offers method retrieves a list of offers, also known
 as the order book, between two currencies.
 """
+
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -19,14 +20,14 @@ class BookOffers(Request, LookupByLedgerRequest):
     as the order book, between two currencies.
     """
 
-    taker_gets: Currency = REQUIRED  # type: ignore
+    taker_gets: Currency = REQUIRED
     """
     This field is required.
 
     :meta hide-value:
     """
 
-    taker_pays: Currency = REQUIRED  # type: ignore
+    taker_pays: Currency = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/requests/channel_authorize.py
+++ b/xrpl/models/requests/channel_authorize.py
@@ -46,14 +46,14 @@ class ChannelAuthorize(Request):
     """
 
     method: RequestMethod = field(default=RequestMethod.CHANNEL_AUTHORIZE, init=False)
-    channel_id: str = REQUIRED  # type: ignore
+    channel_id: str = REQUIRED
     """
     This field is required.
 
     :meta hide-value:
     """
 
-    amount: str = REQUIRED  # type: ignore
+    amount: str = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/requests/channel_verify.py
+++ b/xrpl/models/requests/channel_verify.py
@@ -3,6 +3,7 @@ The channel_verify method checks the validity of a
 signature that can be used to redeem a specific amount of
 XRP from a payment channel.
 """
+
 from dataclasses import dataclass, field
 
 from xrpl.models.requests.request import Request, RequestMethod
@@ -20,28 +21,28 @@ class ChannelVerify(Request):
     """
 
     method: RequestMethod = field(default=RequestMethod.CHANNEL_VERIFY, init=False)
-    channel_id: str = REQUIRED  # type: ignore
+    channel_id: str = REQUIRED
     """
     This field is required.
 
     :meta hide-value:
     """
 
-    amount: str = REQUIRED  # type: ignore
+    amount: str = REQUIRED
     """
     This field is required.
 
     :meta hide-value:
     """
 
-    public_key: str = REQUIRED  # type: ignore
+    public_key: str = REQUIRED
     """
     This field is required.
 
     :meta hide-value:
     """
 
-    signature: str = REQUIRED  # type: ignore
+    signature: str = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/requests/deposit_authorized.py
+++ b/xrpl/models/requests/deposit_authorized.py
@@ -4,6 +4,7 @@ is authorized to send payments directly to another. See
 Deposit Authorization for information on how to require
 authorization to deliver money to your account.
 """
+
 from dataclasses import dataclass, field
 
 from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
@@ -21,14 +22,14 @@ class DepositAuthorized(Request, LookupByLedgerRequest):
     authorization to deliver money to your account.
     """
 
-    source_account: str = REQUIRED  # type: ignore
+    source_account: str = REQUIRED
     """
     This field is required.
 
     :meta hide-value:
     """
 
-    destination_account: str = REQUIRED  # type: ignore
+    destination_account: str = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/requests/gateway_balances.py
+++ b/xrpl/models/requests/gateway_balances.py
@@ -4,6 +4,7 @@ excluding amounts held by operational addresses.
 
 `See gateway_balances <https://xrpl.org/gateway_balances.html>`_
 """
+
 from dataclasses import dataclass, field
 from typing import List, Optional, Union
 
@@ -22,7 +23,7 @@ class GatewayBalances(Request, LookupByLedgerRequest):
     `See gateway_balances <https://xrpl.org/gateway_balances.html>`_
     """
 
-    account: str = REQUIRED  # type: ignore
+    account: str = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/requests/get_aggregate_price.py
+++ b/xrpl/models/requests/get_aggregate_price.py
@@ -26,13 +26,13 @@ class GetAggregatePrice(Request):
 
     method: RequestMethod = field(default=RequestMethod.GET_AGGREGATE_PRICE, init=False)
 
-    base_asset: str = REQUIRED  # type: ignore
+    base_asset: str = REQUIRED
     """The currency code of the asset to be priced"""
 
-    quote_asset: str = REQUIRED  # type: ignore
+    quote_asset: str = REQUIRED
     """The currency code of the asset to quote the price of the base asset"""
 
-    oracles: List[Oracle] = REQUIRED  # type: ignore
+    oracles: List[Oracle] = REQUIRED
     """The oracle identifier"""
 
     trim: Optional[int] = None

--- a/xrpl/models/requests/ledger_entry.py
+++ b/xrpl/models/requests/ledger_entry.py
@@ -51,14 +51,14 @@ class DepositPreauth(BaseModel):
     object ID.
     """
 
-    owner: str = REQUIRED  # type: ignore
+    owner: str = REQUIRED
     """
     This field is required.
 
     :meta hide-value:
     """
 
-    authorized: str = REQUIRED  # type: ignore
+    authorized: str = REQUIRED
     """
     This field is required.
 
@@ -74,14 +74,14 @@ class Directory(BaseModel):
     object ID.
     """
 
-    owner: str = REQUIRED  # type: ignore
+    owner: str = REQUIRED
     """
     This field is required.
 
     :meta hide-value:
     """
 
-    dir_root: str = REQUIRED  # type: ignore
+    dir_root: str = REQUIRED
     """
     This field is required.
 
@@ -98,14 +98,14 @@ class Escrow(BaseModel):
     object ID.
     """
 
-    owner: str = REQUIRED  # type: ignore
+    owner: str = REQUIRED
     """
     This field is required.
 
     :meta hide-value:
     """
 
-    seq: int = REQUIRED  # type: ignore
+    seq: int = REQUIRED
     """
     This field is required.
 
@@ -121,14 +121,14 @@ class Offer(BaseModel):
     object ID.
     """
 
-    account: str = REQUIRED  # type: ignore
+    account: str = REQUIRED
     """
     This field is required.
 
     :meta hide-value:
     """
 
-    seq: int = REQUIRED  # type: ignore
+    seq: int = REQUIRED
     """
     This field is required.
 
@@ -144,14 +144,14 @@ class Oracle(BaseModel):
     object ID.
     """
 
-    account: str = REQUIRED  # type: ignore
+    account: str = REQUIRED
     """
     This field is required.
 
     :meta hide-value:
     """
 
-    oracle_document_id: Union[str, int] = REQUIRED  # type: ignore
+    oracle_document_id: Union[str, int] = REQUIRED
     """
     This field is required.
 
@@ -164,14 +164,14 @@ class Oracle(BaseModel):
 class RippleState(BaseModel):
     """Required fields for requesting a RippleState if not querying by object ID."""
 
-    accounts: List[str] = REQUIRED  # type: ignore
+    accounts: List[str] = REQUIRED
     """
     This field is required.
 
     :meta hide-value:
     """
 
-    currency: str = REQUIRED  # type: ignore
+    currency: str = REQUIRED
     """
     This field is required.
 
@@ -184,14 +184,14 @@ class RippleState(BaseModel):
 class Ticket(BaseModel):
     """Required fields for requesting a Ticket if not querying by object ID."""
 
-    owner: str = REQUIRED  # type: ignore
+    owner: str = REQUIRED
     """
     This field is required.
 
     :meta hide-value:
     """
 
-    ticket_sequence: int = REQUIRED  # type: ignore
+    ticket_sequence: int = REQUIRED
     """
     This field is required.
 
@@ -204,7 +204,7 @@ class Ticket(BaseModel):
 class XChainClaimID(XChainBridge):
     """Required fields for requesting an XChainClaimID if not querying by object ID."""
 
-    xchain_claim_id: Union[int, str] = REQUIRED  # type: ignore
+    xchain_claim_id: Union[int, str] = REQUIRED
     """
     The `XChainClaimID` associated with a cross-chain transfer, which was created in an
     `XChainCreateClaimID` transaction. This field is required.
@@ -221,7 +221,7 @@ class XChainCreateAccountClaimID(XChainBridge):
     object ID.
     """
 
-    xchain_create_account_claim_id: Union[int, str] = REQUIRED  # type: ignore
+    xchain_create_account_claim_id: Union[int, str] = REQUIRED
     """
     The `XChainCreateAccountClaimID` associated with a cross-chain account create. This
     field is required.

--- a/xrpl/models/requests/manifest.py
+++ b/xrpl/models/requests/manifest.py
@@ -4,6 +4,7 @@ The manifest method reports the current
 public key. The "manifest" is the public portion
 of that validator's configured token.
 """
+
 from dataclasses import dataclass, field
 
 from xrpl.models.requests.request import Request, RequestMethod
@@ -22,7 +23,7 @@ class Manifest(Request):
     """
 
     method: RequestMethod = field(default=RequestMethod.MANIFEST, init=False)
-    public_key: str = REQUIRED  # type: ignore
+    public_key: str = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/requests/nft_buy_offers.py
+++ b/xrpl/models/requests/nft_buy_offers.py
@@ -2,6 +2,7 @@
 The `nft_buy_offers` method retrieves all of buy offers
 for the specified NFToken.
 """
+
 from dataclasses import dataclass, field
 
 from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
@@ -18,7 +19,7 @@ class NFTBuyOffers(Request, LookupByLedgerRequest):
     """
 
     method: RequestMethod = field(default=RequestMethod.NFT_BUY_OFFERS, init=False)
-    nft_id: str = REQUIRED  # type: ignore
+    nft_id: str = REQUIRED
     """
     The unique identifier of an NFToken.
     The request returns buy offers for this NFToken. This value is required.

--- a/xrpl/models/requests/nft_history.py
+++ b/xrpl/models/requests/nft_history.py
@@ -2,6 +2,7 @@
 The `nft_history` method retreives a list of transactions that involved the
 specified NFToken.
 """
+
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
@@ -19,7 +20,7 @@ class NFTHistory(Request, LookupByLedgerRequest):
     """
 
     method: RequestMethod = field(default=RequestMethod.NFT_HISTORY, init=False)
-    nft_id: str = REQUIRED  # type: ignore
+    nft_id: str = REQUIRED
     """
     The unique identifier of an NFToken.
     The request returns past transactions of this NFToken. This value is required.

--- a/xrpl/models/requests/nft_info.py
+++ b/xrpl/models/requests/nft_info.py
@@ -2,6 +2,7 @@
 The `nft_info` method retrieves all the information about the
 NFToken
 """
+
 from dataclasses import dataclass, field
 
 from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
@@ -18,7 +19,7 @@ class NFTInfo(Request, LookupByLedgerRequest):
     """
 
     method: RequestMethod = field(default=RequestMethod.NFT_INFO, init=False)
-    nft_id: str = REQUIRED  # type: ignore
+    nft_id: str = REQUIRED
     """
     The unique identifier of an NFToken.
     The request returns information of this NFToken. This value is required.

--- a/xrpl/models/requests/nft_sell_offers.py
+++ b/xrpl/models/requests/nft_sell_offers.py
@@ -2,6 +2,7 @@
 The `nft_sell_offers` method retrieves all of sell offers
 for the specified NFToken.
 """
+
 from dataclasses import dataclass, field
 
 from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
@@ -18,7 +19,7 @@ class NFTSellOffers(Request, LookupByLedgerRequest):
     """
 
     method: RequestMethod = field(default=RequestMethod.NFT_SELL_OFFERS, init=False)
-    nft_id: str = REQUIRED  # type: ignore
+    nft_id: str = REQUIRED
     """
     The unique identifier of an NFToken.
     The request returns sell offers for this NFToken. This value is required.

--- a/xrpl/models/requests/nfts_by_issuer.py
+++ b/xrpl/models/requests/nfts_by_issuer.py
@@ -2,6 +2,7 @@
 The `nfts_by_issuer` method retrieves all of the NFTokens
 issued by an account
 """
+
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
@@ -19,7 +20,7 @@ class NFTsByIssuer(Request, LookupByLedgerRequest):
     """
 
     method: RequestMethod = field(default=RequestMethod.NFTS_BY_ISSUER, init=False)
-    issuer: str = REQUIRED  # type: ignore
+    issuer: str = REQUIRED
     """
     The unique identifier for an account that issues NFTokens
     The request returns NFTokens issued by this account. This field is required

--- a/xrpl/models/requests/no_ripple_check.py
+++ b/xrpl/models/requests/no_ripple_check.py
@@ -5,6 +5,7 @@ recommended settings.
 
 `See noripple_check <https://xrpl.org/noripple_check.html>`_
 """
+
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional
@@ -32,7 +33,7 @@ class NoRippleCheck(Request, LookupByLedgerRequest):
     `See noripple_check <https://xrpl.org/noripple_check.html>`_
     """
 
-    account: str = REQUIRED  # type: ignore
+    account: str = REQUIRED
     """
     This field is required.
 
@@ -40,7 +41,7 @@ class NoRippleCheck(Request, LookupByLedgerRequest):
     """
 
     method: RequestMethod = field(default=RequestMethod.NO_RIPPLE_CHECK, init=False)
-    role: NoRippleCheckRole = REQUIRED  # type: ignore
+    role: NoRippleCheckRole = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/requests/path_find.py
+++ b/xrpl/models/requests/path_find.py
@@ -26,6 +26,7 @@ returning poor results. (Note: A server returning less-than-optimal
 results is not necessarily proof of malicious behavior; it could also be
 a symptom of heavy server load.)
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -80,28 +81,28 @@ class PathFind(Request):
     a symptom of heavy server load.)
     """
 
-    subcommand: PathFindSubcommand = REQUIRED  # type: ignore
+    subcommand: PathFindSubcommand = REQUIRED
     """
     This field is required.
 
     :meta hide-value:
     """
 
-    source_account: str = REQUIRED  # type: ignore
+    source_account: str = REQUIRED
     """
     This field is required.
 
     :meta hide-value:
     """
 
-    destination_account: str = REQUIRED  # type: ignore
+    destination_account: str = REQUIRED
     """
     This field is required.
 
     :meta hide-value:
     """
 
-    destination_amount: Amount = REQUIRED  # type: ignore
+    destination_amount: Amount = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/requests/request.py
+++ b/xrpl/models/requests/request.py
@@ -101,7 +101,7 @@ class Request(BaseModel):
     Represents fields common to all request types.
     """
 
-    method: RequestMethod = REQUIRED  # type: ignore
+    method: RequestMethod = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/requests/ripple_path_find.py
+++ b/xrpl/models/requests/ripple_path_find.py
@@ -11,6 +11,7 @@ Although the rippled server tries to find the cheapest path or
 combination of paths for making a payment, it is not guaranteed that
 the paths returned by this method are, in fact, the best paths.
 """
+
 from dataclasses import dataclass, field
 from typing import List, Optional
 
@@ -38,21 +39,21 @@ class RipplePathFind(Request, LookupByLedgerRequest):
     the paths returned by this method are, in fact, the best paths.
     """
 
-    source_account: str = REQUIRED  # type: ignore
+    source_account: str = REQUIRED
     """
     This field is required.
 
     :meta hide-value:
     """
 
-    destination_account: str = REQUIRED  # type: ignore
+    destination_account: str = REQUIRED
     """
     This field is required.
 
     :meta hide-value:
     """
 
-    destination_amount: Amount = REQUIRED  # type: ignore
+    destination_amount: Amount = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/requests/sign.py
+++ b/xrpl/models/requests/sign.py
@@ -50,7 +50,7 @@ class Sign(Request):
     """
 
     method: RequestMethod = field(default=RequestMethod.SIGN, init=False)
-    transaction: Transaction = REQUIRED  # type: ignore
+    transaction: Transaction = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/requests/sign_and_submit.py
+++ b/xrpl/models/requests/sign_and_submit.py
@@ -59,7 +59,7 @@ class SignAndSubmit(Submit):
     `See submit <https://xrpl.org/submit.html>`_
     """
 
-    transaction: Transaction = REQUIRED  # type: ignore
+    transaction: Transaction = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/requests/sign_for.py
+++ b/xrpl/models/requests/sign_for.py
@@ -38,14 +38,14 @@ class SignFor(Request):
     """
 
     method: RequestMethod = field(default=RequestMethod.SIGN_FOR, init=False)
-    account: str = REQUIRED  # type: ignore
+    account: str = REQUIRED
     """
     This field is required.
 
     :meta hide-value:
     """
 
-    transaction: Transaction = REQUIRED  # type: ignore
+    transaction: Transaction = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/requests/submit_multisigned.py
+++ b/xrpl/models/requests/submit_multisigned.py
@@ -35,7 +35,7 @@ class SubmitMultisigned(Request):
     """
 
     method: RequestMethod = field(default=RequestMethod.SUBMIT_MULTISIGNED, init=False)
-    tx_json: Transaction = REQUIRED  # type: ignore
+    tx_json: Transaction = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/requests/submit_only.py
+++ b/xrpl/models/requests/submit_only.py
@@ -53,7 +53,7 @@ class SubmitOnly(Submit):
     """
 
     # submit-only mode
-    tx_blob: str = REQUIRED  # type: ignore
+    tx_blob: str = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/requests/subscribe.py
+++ b/xrpl/models/requests/subscribe.py
@@ -6,6 +6,7 @@ WebSocket API only.
 
 `See subscribe <https://xrpl.org/subscribe.html>`_
 """
+
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import List, Optional
@@ -35,21 +36,21 @@ class StreamParameter(str, Enum):
 class SubscribeBook(BaseModel):
     """Format for elements in the ``books`` array for Subscribe only."""
 
-    taker_gets: Currency = REQUIRED  # type: ignore
+    taker_gets: Currency = REQUIRED
     """
     This field is required.
 
     :meta hide-value:
     """
 
-    taker_pays: Currency = REQUIRED  # type: ignore
+    taker_pays: Currency = REQUIRED
     """
     This field is required.
 
     :meta hide-value:
     """
 
-    taker: str = REQUIRED  # type: ignore
+    taker: str = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/requests/transaction_entry.py
+++ b/xrpl/models/requests/transaction_entry.py
@@ -27,7 +27,7 @@ class TransactionEntry(Request, LookupByLedgerRequest):
     """
 
     method: RequestMethod = field(default=RequestMethod.TRANSACTION_ENTRY, init=False)
-    tx_hash: str = REQUIRED  # type: ignore
+    tx_hash: str = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/requests/unsubscribe.py
+++ b/xrpl/models/requests/unsubscribe.py
@@ -6,6 +6,7 @@ WebSocket API only.
 
 `See unsubscribe <https://xrpl.org/unsubscribe.html>`_
 """
+
 from dataclasses import dataclass, field
 from typing import List, Optional
 
@@ -22,14 +23,14 @@ from xrpl.models.utils import KW_ONLY_DATACLASS, require_kwargs_on_init
 class UnsubscribeBook(BaseModel):
     """Format for elements in the ``books`` array for Unsubscribe only."""
 
-    taker_gets: Currency = REQUIRED  # type: ignore
+    taker_gets: Currency = REQUIRED
     """
     This field is required.
 
     :meta hide-value:
     """
 
-    taker_pays: Currency = REQUIRED  # type: ignore
+    taker_pays: Currency = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/required.py
+++ b/xrpl/models/required.py
@@ -4,6 +4,8 @@ allows us to not worry about argument ordering and treat all arguments to
 __init__ as kwargs.
 """
 
+from typing import Any
+
 from typing_extensions import Final
 
-REQUIRED: Final[object] = object()
+REQUIRED: Final[Any] = object()  # noqa: ANN401

--- a/xrpl/models/response.py
+++ b/xrpl/models/response.py
@@ -44,14 +44,14 @@ class Response(BaseModel):
     Represents fields common to all response types.
     """
 
-    status: ResponseStatus = REQUIRED  # type: ignore
+    status: ResponseStatus = REQUIRED
     """
     This field is required.
 
     :meta hide-value:
     """
 
-    result: Dict[str, Any] = REQUIRED  # type: ignore
+    result: Dict[str, Any] = REQUIRED
     """
     This field is required.
 
@@ -92,7 +92,7 @@ class Response(BaseModel):
         """
         return self._do_contains_partial_payment(self.result)
 
-    def _do_contains_partial_payment(self: Self, val: Any) -> bool:
+    def _do_contains_partial_payment(self: Self, val: Any) -> bool:  # noqa: ANN401
         flagged = []
         if isinstance(val, dict):
             formatted = {key.strip().lower(): value for key, value in val.items()}
@@ -111,7 +111,7 @@ class Response(BaseModel):
             ]
         return len(flagged) > 0
 
-    def _is_partial_payment(self: Self, key: str, val: Any) -> bool:
+    def _is_partial_payment(self: Self, key: str, val: Any) -> bool:  # noqa: ANN401
         if isinstance(val, dict):
             return self._do_contains_partial_payment(val)
         try:

--- a/xrpl/models/transactions/account_delete.py
+++ b/xrpl/models/transactions/account_delete.py
@@ -23,7 +23,7 @@ class AccountDelete(Transaction):
     delete an account.
     """
 
-    destination: str = REQUIRED  # type: ignore
+    destination: str = REQUIRED
     """
     The address of the account to which to send any remaining XRP.
     This field is required.

--- a/xrpl/models/transactions/amm_bid.py
+++ b/xrpl/models/transactions/amm_bid.py
@@ -32,12 +32,12 @@ class AMMBid(Transaction):
     to the AMM, decreasing the outstanding balance of LP Tokens.
     """
 
-    asset: Currency = REQUIRED  # type: ignore
+    asset: Currency = REQUIRED
     """
     The definition for one of the assets in the AMM's pool. This field is required.
     """
 
-    asset2: Currency = REQUIRED  # type: ignore
+    asset2: Currency = REQUIRED
     """
     The definition for the other asset in the AMM's pool. This field is required.
     """

--- a/xrpl/models/transactions/amm_create.py
+++ b/xrpl/models/transactions/amm_create.py
@@ -38,19 +38,19 @@ class AMMCreate(Transaction):
     so it's best to set the trading fee based on the volatility of the asset pair.
     """
 
-    amount: Amount = REQUIRED  # type: ignore
+    amount: Amount = REQUIRED
     """
     The first of the two assets to fund this AMM with. This must be a positive amount.
     This field is required.
     """
 
-    amount2: Amount = REQUIRED  # type: ignore
+    amount2: Amount = REQUIRED
     """
     The second of the two assets to fund this AMM with. This must be a positive amount.
     This field is required.
     """
 
-    trading_fee: int = REQUIRED  # type: ignore
+    trading_fee: int = REQUIRED
     """
     The fee to charge for trades against this AMM instance, in units of 1/100,000;
     a value of 1 is equivalent to 0.001%.

--- a/xrpl/models/transactions/amm_delete.py
+++ b/xrpl/models/transactions/amm_delete.py
@@ -1,4 +1,5 @@
 """Model for AMMDelete transaction type."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -27,12 +28,12 @@ class AMMDelete(Transaction):
     deleted by the last such transaction.
     """
 
-    asset: Currency = REQUIRED  # type: ignore
+    asset: Currency = REQUIRED
     """
     The definition for one of the assets in the AMM's pool. This field is required.
     """
 
-    asset2: Currency = REQUIRED  # type: ignore
+    asset2: Currency = REQUIRED
     """
     The definition for the other asset in the AMM's pool. This field is required.
     """

--- a/xrpl/models/transactions/amm_deposit.py
+++ b/xrpl/models/transactions/amm_deposit.py
@@ -57,12 +57,12 @@ class AMMDeposit(Transaction):
     to hold the LP Tokens.
     """
 
-    asset: Currency = REQUIRED  # type: ignore
+    asset: Currency = REQUIRED
     """
     The definition for one of the assets in the AMM's pool. This field is required.
     """
 
-    asset2: Currency = REQUIRED  # type: ignore
+    asset2: Currency = REQUIRED
     """
     The definition for the other asset in the AMM's pool. This field is required.
     """

--- a/xrpl/models/transactions/amm_vote.py
+++ b/xrpl/models/transactions/amm_vote.py
@@ -27,17 +27,17 @@ class AMMVote(Transaction):
     of the votes.
     """
 
-    asset: Currency = REQUIRED  # type: ignore
+    asset: Currency = REQUIRED
     """
     The definition for one of the assets in the AMM's pool. This field is required.
     """
 
-    asset2: Currency = REQUIRED  # type: ignore
+    asset2: Currency = REQUIRED
     """
     The definition for the other asset in the AMM's pool. This field is required.
     """
 
-    trading_fee: int = REQUIRED  # type: ignore
+    trading_fee: int = REQUIRED
     """
     The proposed fee to vote for, in units of 1/100,000; a value of 1 is equivalent
     to 0.001%.

--- a/xrpl/models/transactions/amm_withdraw.py
+++ b/xrpl/models/transactions/amm_withdraw.py
@@ -55,12 +55,12 @@ class AMMWithdraw(Transaction):
     AMM's liquidity provider tokens (LP Tokens).
     """
 
-    asset: Currency = REQUIRED  # type: ignore
+    asset: Currency = REQUIRED
     """
     The definition for one of the assets in the AMM's pool. This field is required.
     """
 
-    asset2: Currency = REQUIRED  # type: ignore
+    asset2: Currency = REQUIRED
     """
     The definition for the other asset in the AMM's pool. This field is required.
     """

--- a/xrpl/models/transactions/check_cancel.py
+++ b/xrpl/models/transactions/check_cancel.py
@@ -1,4 +1,5 @@
 """Model for CheckCancel transaction type."""
+
 from dataclasses import dataclass, field
 
 from xrpl.models.required import REQUIRED
@@ -18,7 +19,7 @@ class CheckCancel(Transaction):
     Check has expired, any address can cancel it.
     """
 
-    check_id: str = REQUIRED  # type: ignore
+    check_id: str = REQUIRED
     """
     The ID of the `Check ledger object
     <https://xrpl.org/check.html>`_ to cancel, as a 64-character

--- a/xrpl/models/transactions/check_cash.py
+++ b/xrpl/models/transactions/check_cash.py
@@ -24,7 +24,7 @@ class CheckCash(Transaction):
     Check can cash it.
     """
 
-    check_id: str = REQUIRED  # type: ignore
+    check_id: str = REQUIRED
     """
     The ID of the `Check ledger object
     <https://xrpl.org/check.html>`_ to cash, as a 64-character

--- a/xrpl/models/transactions/check_create.py
+++ b/xrpl/models/transactions/check_create.py
@@ -1,4 +1,5 @@
 """Model for CheckCreate transaction type."""
+
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -19,7 +20,7 @@ class CheckCreate(Transaction):
     transaction is the sender of the Check.
     """
 
-    destination: str = REQUIRED  # type: ignore
+    destination: str = REQUIRED
     """
     The address of the `account
     <https://xrpl.org/accounts.html>`_ that can cash the Check. This field is
@@ -28,7 +29,7 @@ class CheckCreate(Transaction):
     :meta hide-value:
     """
 
-    send_max: Amount = REQUIRED  # type: ignore
+    send_max: Amount = REQUIRED
     """
     Maximum amount of source token the Check is allowed to debit the
     sender, including transfer fees on non-XRP tokens. The Check can only

--- a/xrpl/models/transactions/clawback.py
+++ b/xrpl/models/transactions/clawback.py
@@ -19,7 +19,7 @@ from xrpl.models.utils import KW_ONLY_DATACLASS, require_kwargs_on_init
 class Clawback(Transaction):
     """The clawback transaction claws back issued funds from token holders."""
 
-    amount: IssuedCurrencyAmount = REQUIRED  # type: ignore
+    amount: IssuedCurrencyAmount = REQUIRED
     """
     The amount of currency to claw back. The issuer field is used for the token holder's
     address, from whom the tokens will be clawed back.

--- a/xrpl/models/transactions/escrow_cancel.py
+++ b/xrpl/models/transactions/escrow_cancel.py
@@ -17,14 +17,14 @@ class EscrowCancel(Transaction):
     expired.
     """
 
-    owner: str = REQUIRED  # type: ignore
+    owner: str = REQUIRED
     """
     The address of the account that funded the Escrow. This field is required.
 
     :meta hide-value:
     """
 
-    offer_sequence: int = REQUIRED  # type: ignore
+    offer_sequence: int = REQUIRED
     """
     Transaction sequence (or Ticket number) of the EscrowCreate transaction
     that created the Escrow. This field is required.

--- a/xrpl/models/transactions/escrow_create.py
+++ b/xrpl/models/transactions/escrow_create.py
@@ -22,7 +22,7 @@ class EscrowCreate(Transaction):
     transaction, which locks up XRP until a specific time or condition is met.
     """
 
-    amount: Amount = REQUIRED  # type: ignore
+    amount: Amount = REQUIRED
     """
     Amount of XRP, in drops, to deduct from the sender's balance and set
     aside in escrow. This field is required.
@@ -30,7 +30,7 @@ class EscrowCreate(Transaction):
     :meta hide-value:
     """
 
-    destination: str = REQUIRED  # type: ignore
+    destination: str = REQUIRED
     """
     The address that should receive the escrowed XRP when the time or
     condition is met. This field is required.

--- a/xrpl/models/transactions/escrow_finish.py
+++ b/xrpl/models/transactions/escrow_finish.py
@@ -21,14 +21,14 @@ class EscrowFinish(Transaction):
     transaction, delivers XRP from a held payment to the recipient.
     """
 
-    owner: str = REQUIRED  # type: ignore
+    owner: str = REQUIRED
     """
     The source account that funded the Escrow. This field is required.
 
     :meta hide-value:
     """
 
-    offer_sequence: int = REQUIRED  # type: ignore
+    offer_sequence: int = REQUIRED
     """
     Transaction sequence (or Ticket number) of the EscrowCreate transaction
     that created the Escrow. This field is required.

--- a/xrpl/models/transactions/nftoken_burn.py
+++ b/xrpl/models/transactions/nftoken_burn.py
@@ -23,7 +23,7 @@ class NFTokenBurn(Transaction):
     is reduced by one.
     """
 
-    account: str = REQUIRED  # type: ignore
+    account: str = REQUIRED
     """
     Identifies the AccountID that submitted this transaction. The account must
     be the present owner of the token or, if the lsfBurnable flag is set
@@ -33,7 +33,7 @@ class NFTokenBurn(Transaction):
     :meta hide-value:
     """
 
-    nftoken_id: str = REQUIRED  # type: ignore
+    nftoken_id: str = REQUIRED
     """
     Identifies the NFToken to be burned. This field is required.
 

--- a/xrpl/models/transactions/nftoken_cancel_offer.py
+++ b/xrpl/models/transactions/nftoken_cancel_offer.py
@@ -27,7 +27,7 @@ class NFTokenCancelOffer(Transaction):
     the NFTokenOffer has already expired.
     """
 
-    nftoken_offers: List[str] = REQUIRED  # type: ignore
+    nftoken_offers: List[str] = REQUIRED
     """
     An array of identifiers of NFTokenOffer objects that should be cancelled
     by this transaction.

--- a/xrpl/models/transactions/nftoken_create_offer.py
+++ b/xrpl/models/transactions/nftoken_create_offer.py
@@ -41,7 +41,7 @@ class NFTokenCreateOffer(Transaction):
     the submitting account does own.
     """
 
-    nftoken_id: str = REQUIRED  # type: ignore
+    nftoken_id: str = REQUIRED
     """
     Identifies the TokenID of the NFToken object that the
     offer references. This field is required.
@@ -49,7 +49,7 @@ class NFTokenCreateOffer(Transaction):
     :meta hide-value:
     """
 
-    amount: Amount = REQUIRED  # type: ignore
+    amount: Amount = REQUIRED
     """
     Indicates the amount expected or offered for the Token.
 

--- a/xrpl/models/transactions/nftoken_mint.py
+++ b/xrpl/models/transactions/nftoken_mint.py
@@ -66,7 +66,7 @@ class NFTokenMint(Transaction):
     specified by the transaction.
     """
 
-    nftoken_taxon: int = REQUIRED  # type: ignore
+    nftoken_taxon: int = REQUIRED
     """
     Indicates the taxon associated with this token. The taxon is generally a
     value chosen by the minter of the token and a given taxon may be used for

--- a/xrpl/models/transactions/offer_cancel.py
+++ b/xrpl/models/transactions/offer_cancel.py
@@ -1,4 +1,5 @@
 """Model for OfferCancel transaction type."""
+
 from dataclasses import dataclass, field
 
 from xrpl.models.required import REQUIRED
@@ -16,7 +17,7 @@ class OfferCancel(Transaction):
     <https://xrpl.org/decentralized-exchange.html>`_.
     """
 
-    offer_sequence: int = REQUIRED  # type: ignore
+    offer_sequence: int = REQUIRED
     """
     The Sequence number (or Ticket number) of a previous OfferCreate
     transaction. If specified, cancel any Offer object in the ledger that was

--- a/xrpl/models/transactions/offer_create.py
+++ b/xrpl/models/transactions/offer_create.py
@@ -1,4 +1,5 @@
 """Model for OfferCreate transaction type."""
+
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional
@@ -79,7 +80,7 @@ class OfferCreate(Transaction):
     Offers can be partially fulfilled.
     """
 
-    taker_gets: Amount = REQUIRED  # type: ignore
+    taker_gets: Amount = REQUIRED
     """
     The amount and type of currency being provided by the sender of this
     transaction. This field is required.
@@ -87,7 +88,7 @@ class OfferCreate(Transaction):
     :meta hide-value:
     """
 
-    taker_pays: Amount = REQUIRED  # type: ignore
+    taker_pays: Amount = REQUIRED
     """
     The amount and type of currency the sender of this transaction wants in
     exchange for the full ``taker_gets`` amount. This field is required.

--- a/xrpl/models/transactions/oracle_delete.py
+++ b/xrpl/models/transactions/oracle_delete.py
@@ -15,10 +15,10 @@ from xrpl.models.utils import require_kwargs_on_init
 class OracleDelete(Transaction):
     """Delete an Oracle ledger entry."""
 
-    account: str = REQUIRED  # type: ignore
+    account: str = REQUIRED
     """This account must match the account in the Owner field of the Oracle object."""
 
-    oracle_document_id: int = REQUIRED  # type: ignore
+    oracle_document_id: int = REQUIRED
     """A unique identifier of the price oracle for the Account."""
 
     transaction_type: TransactionType = field(

--- a/xrpl/models/transactions/oracle_set.py
+++ b/xrpl/models/transactions/oracle_set.py
@@ -40,10 +40,10 @@ class OracleSet(Transaction):
     Publish a registry of available price oracles with their unique OracleDocumentID .
     """
 
-    account: str = REQUIRED  # type: ignore
+    account: str = REQUIRED
     """This account must match the account in the Owner field of the Oracle object."""
 
-    oracle_document_id: int = REQUIRED  # type: ignore
+    oracle_document_id: int = REQUIRED
     """A unique identifier of the price oracle for the Account."""
 
     provider: Optional[str] = None
@@ -76,12 +76,12 @@ class OracleSet(Transaction):
     required when creating a new Oracle ledger entry, but is optional for updates.
     """
 
-    last_update_time: int = REQUIRED  # type: ignore
+    last_update_time: int = REQUIRED
     """LastUpdateTime is the specific point in time when the data was last updated.
     The LastUpdateTime is represented as Unix Time - the number of seconds since
     January 1, 1970 (00:00 UTC)."""
 
-    price_data_series: List[PriceData] = REQUIRED  # type: ignore
+    price_data_series: List[PriceData] = REQUIRED
     """An array of up to 10 PriceData objects, each representing the price information
     for a token pair. More than five PriceData objects require two owner reserves."""
 
@@ -157,12 +157,12 @@ class OracleSet(Transaction):
 class PriceData(NestedModel):
     """Represents one PriceData element. It is used in OracleSet transaction"""
 
-    base_asset: str = REQUIRED  # type: ignore
+    base_asset: str = REQUIRED
     """The primary asset in a trading pair. Any valid identifier, such as a stock
     symbol, bond CUSIP, or currency code is allowed. For example, in the BTC/USD pair,
     BTC is the base asset; in 912810RR9/BTC, 912810RR9 is the base asset."""
 
-    quote_asset: str = REQUIRED  # type: ignore
+    quote_asset: str = REQUIRED
     """The quote asset in a trading pair. The quote asset denotes the price of one unit
     of the base asset. For example, in the BTC/USD pair, BTC is the base asset; in
     912810RR9/BTC, 912810RR9 is the base asset."""

--- a/xrpl/models/transactions/payment.py
+++ b/xrpl/models/transactions/payment.py
@@ -74,7 +74,7 @@ class Payment(Transaction):
     <http://xrpl.local/payment.html#creating-accounts>`_.
     """
 
-    amount: Amount = REQUIRED  # type: ignore
+    amount: Amount = REQUIRED
     """
     The amount of currency to deliver. If the Partial Payment flag is set,
     deliver *up to* this amount instead. This field is required.
@@ -82,7 +82,7 @@ class Payment(Transaction):
     :meta hide-value:
     """
 
-    destination: str = REQUIRED  # type: ignore
+    destination: str = REQUIRED
     """
     The address of the account receiving the payment. This field is required.
 

--- a/xrpl/models/transactions/payment_channel_claim.py
+++ b/xrpl/models/transactions/payment_channel_claim.py
@@ -1,4 +1,5 @@
 """Model for PaymentChannelClaim transaction type."""
+
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional
@@ -65,7 +66,7 @@ class PaymentChannelClaim(Transaction):
     depending on the transaction sender's role in the specified channel.
     """
 
-    channel: str = REQUIRED  # type: ignore
+    channel: str = REQUIRED
     """
     The unique ID of the payment channel, as a 64-character hexadecimal
     string. This field is required.

--- a/xrpl/models/transactions/payment_channel_create.py
+++ b/xrpl/models/transactions/payment_channel_create.py
@@ -1,4 +1,5 @@
 """Model for PaymentChannelCreate transaction type."""
+
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -20,7 +21,7 @@ class PaymentChannelCreate(Transaction):
     channel.
     """
 
-    amount: Amount = REQUIRED  # type: ignore
+    amount: Amount = REQUIRED
     """
     The amount of XRP, in drops, to set aside in this channel. This field is
     required.
@@ -28,7 +29,7 @@ class PaymentChannelCreate(Transaction):
     :meta hide-value:
     """
 
-    destination: str = REQUIRED  # type: ignore
+    destination: str = REQUIRED
     """
     The account that can receive XRP from this channel, also known as the
     "destination address" of the channel. Cannot be the same as the sender.
@@ -37,7 +38,7 @@ class PaymentChannelCreate(Transaction):
     :meta hide-value:
     """
 
-    settle_delay: int = REQUIRED  # type: ignore
+    settle_delay: int = REQUIRED
     """
     The amount of time, in seconds, the source address must wait between
     requesting to close the channel and fully closing it. This field is
@@ -46,7 +47,7 @@ class PaymentChannelCreate(Transaction):
     :meta hide-value:
     """
 
-    public_key: str = REQUIRED  # type: ignore
+    public_key: str = REQUIRED
     """
     The public key of the key pair that the source will use to authorize
     claims against this  channel, as hexadecimal. This can be any valid

--- a/xrpl/models/transactions/payment_channel_fund.py
+++ b/xrpl/models/transactions/payment_channel_fund.py
@@ -1,4 +1,5 @@
 """Model for a PaymentChannelFund transaction type."""
+
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -19,7 +20,7 @@ class PaymentChannelFund(Transaction):
     of the channel can use this transaction.
     """
 
-    channel: str = REQUIRED  # type: ignore
+    channel: str = REQUIRED
     """
     The unique ID of the payment channel, as a 64-character hexadecimal
     string. This field is required.
@@ -27,7 +28,7 @@ class PaymentChannelFund(Transaction):
     :meta hide-value:
     """
 
-    amount: str = REQUIRED  # type: ignore
+    amount: str = REQUIRED
     """
     The amount of XRP, in drops, to add to the channel. This field is
     required.

--- a/xrpl/models/transactions/pseudo_transactions/enable_amendment.py
+++ b/xrpl/models/transactions/pseudo_transactions/enable_amendment.py
@@ -66,7 +66,7 @@ class EnableAmendment(PseudoTransaction):
     * A proposed amendment has been enabled.
     """
 
-    amendment: str = REQUIRED  # type: ignore
+    amendment: str = REQUIRED
     """
     A unique identifier for the amendment. This is not intended to be a
     human-readable name. See `Amendments <https://xrpl.org/amendments.html>`_ for a
@@ -75,7 +75,7 @@ class EnableAmendment(PseudoTransaction):
     :meta hide-value:
     """
 
-    ledger_sequence: int = REQUIRED  # type: ignore
+    ledger_sequence: int = REQUIRED
     """
     The ledger index where this pseudo-transaction appears. This distinguishes the
     pseudo-transaction from other occurrences of the same change.

--- a/xrpl/models/transactions/pseudo_transactions/pseudo_transaction.py
+++ b/xrpl/models/transactions/pseudo_transactions/pseudo_transaction.py
@@ -28,4 +28,4 @@ class PseudoTransaction(Transaction):
     signing_pub_key: str = field(default="", init=False)
     txn_signature: str = field(default="", init=False)
     source_tag: None = field(default=None, init=False)
-    transaction_type: PseudoTransactionType = REQUIRED  # type: ignore
+    transaction_type: PseudoTransactionType = REQUIRED

--- a/xrpl/models/transactions/pseudo_transactions/unl_modify.py
+++ b/xrpl/models/transactions/pseudo_transactions/unl_modify.py
@@ -24,7 +24,7 @@ class UNLModify(PseudoTransaction):
     gone offline or come back online.
     """
 
-    ledger_sequence: int = REQUIRED  # type: ignore
+    ledger_sequence: int = REQUIRED
     """
     The ledger index where this pseudo-transaction appears. This distinguishes the
     pseudo-transaction from other occurrences of the same change.
@@ -33,7 +33,7 @@ class UNLModify(PseudoTransaction):
     :meta hide-value:
     """
 
-    unl_modify_disabling: int = REQUIRED  # type: ignore
+    unl_modify_disabling: int = REQUIRED
     """
     If 1, this change represents adding a validator to the Negative UNL. If 0, this
     change represents removing a validator from the Negative UNL. (No other values
@@ -42,7 +42,7 @@ class UNLModify(PseudoTransaction):
     :meta hide-value:
     """
 
-    unl_modify_validator: str = REQUIRED  # type: ignore
+    unl_modify_validator: str = REQUIRED
     """
     The validator to add or remove, as identified by its master public key.
     This field is required.

--- a/xrpl/models/transactions/signer_list_set.py
+++ b/xrpl/models/transactions/signer_list_set.py
@@ -34,14 +34,14 @@ Matches hex-encoded WalletLocator in the format allowed by XRPL.
 class SignerEntry(NestedModel):
     """Represents one entry in a list of multi-signers authorized to an account."""
 
-    account: str = REQUIRED  # type: ignore
+    account: str = REQUIRED
     """
     This field is required.
 
     :meta hide-value:
     """
 
-    signer_weight: int = REQUIRED  # type: ignore
+    signer_weight: int = REQUIRED
     """
     This field is required.
 
@@ -66,7 +66,7 @@ class SignerListSet(Transaction):
     <https://xrpl.org/multi-signing.html>`_.
     """
 
-    signer_quorum: int = REQUIRED  # type: ignore
+    signer_quorum: int = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/transactions/ticket_create.py
+++ b/xrpl/models/transactions/ticket_create.py
@@ -17,7 +17,7 @@ class TicketCreate(Transaction):
     <https://xrpl.org/tickets.html>`_.
     """
 
-    ticket_count: int = REQUIRED  # type: ignore
+    ticket_count: int = REQUIRED
     """
     How many Tickets to create. This must be a positive number and cannot cause the
     account to own more than 250 Tickets after executing this transaction.

--- a/xrpl/models/transactions/transaction.py
+++ b/xrpl/models/transactions/transaction.py
@@ -127,7 +127,7 @@ class Signer(NestedModel):
     field.
     """
 
-    account: str = REQUIRED  # type: ignore
+    account: str = REQUIRED
     """
     The address of the Signer. This can be a funded account in the XRP
     Ledger or an unfunded address.
@@ -136,7 +136,7 @@ class Signer(NestedModel):
     :meta hide-value:
     """
 
-    txn_signature: str = REQUIRED  # type: ignore
+    txn_signature: str = REQUIRED
     """
     The signature that this Signer provided for this transaction.
     This field is required.
@@ -144,7 +144,7 @@ class Signer(NestedModel):
     :meta hide-value:
     """
 
-    signing_pub_key: str = REQUIRED  # type: ignore
+    signing_pub_key: str = REQUIRED
     """
     The public key that should be used to verify this Signer's signature.
     This field is required.
@@ -162,16 +162,14 @@ class Transaction(BaseModel):
     transaction types <https://xrpl.org/transaction-common-fields.html>`_.
     """
 
-    account: str = REQUIRED  # type: ignore
+    account: str = REQUIRED
     """
     The address of the sender of the transaction. Required.
 
     :meta hide-value:
     """
 
-    transaction_type: Union[
-        TransactionType, PseudoTransactionType
-    ] = REQUIRED  # type: ignore
+    transaction_type: Union[TransactionType, PseudoTransactionType] = REQUIRED
 
     fee: Optional[str] = None  # auto-fillable
     """

--- a/xrpl/models/transactions/trust_set.py
+++ b/xrpl/models/transactions/trust_set.py
@@ -4,6 +4,7 @@ Creates or modifies a trust line linking two accounts.
 
 `See TrustSet <https://xrpl.org/trustset.html>`_
 """
+
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional
@@ -70,7 +71,7 @@ class TrustSet(Transaction):
     `See TrustSet <https://xrpl.org/trustset.html>`_
     """
 
-    limit_amount: IssuedCurrencyAmount = REQUIRED  # type: ignore
+    limit_amount: IssuedCurrencyAmount = REQUIRED
     """
     This field is required.
 

--- a/xrpl/models/transactions/xchain_account_create_commit.py
+++ b/xrpl/models/transactions/xchain_account_create_commit.py
@@ -24,14 +24,14 @@ class XChainAccountCreateCommit(Transaction):
     chain.
     """
 
-    xchain_bridge: XChainBridge = REQUIRED  # type: ignore
+    xchain_bridge: XChainBridge = REQUIRED
     """
     The bridge to create accounts for. This field is required.
 
     :meta hide-value:
     """
 
-    signature_reward: str = REQUIRED  # type: ignore
+    signature_reward: str = REQUIRED
     """
     The amount, in XRP, to be used to reward the witness servers for providing
     signatures. This must match the amount on the ``Bridge`` ledger object. This
@@ -40,14 +40,14 @@ class XChainAccountCreateCommit(Transaction):
     :meta hide-value:
     """
 
-    destination: str = REQUIRED  # type: ignore
+    destination: str = REQUIRED
     """
     The destination account on the destination chain. This field is required.
 
     :meta hide-value:
     """
 
-    amount: str = REQUIRED  # type: ignore
+    amount: str = REQUIRED
     """
     The amount, in XRP, to use for account creation. This must be greater than
     or equal to the ``MinAccountCreateAmount`` specified in the ``Bridge``

--- a/xrpl/models/transactions/xchain_add_account_create_attestation.py
+++ b/xrpl/models/transactions/xchain_add_account_create_attestation.py
@@ -25,21 +25,21 @@ class XChainAddAccountCreateAttestation(Transaction):
     on the other chain.
     """
 
-    xchain_bridge: XChainBridge = REQUIRED  # type: ignore
+    xchain_bridge: XChainBridge = REQUIRED
     """
     The bridge associated with the attestation. This field is required.
 
     :meta hide-value:
     """
 
-    public_key: str = REQUIRED  # type: ignore
+    public_key: str = REQUIRED
     """
     The public key used to verify the signature. This field is required.
 
     :meta hide-value:
     """
 
-    signature: str = REQUIRED  # type: ignore
+    signature: str = REQUIRED
     """
     The signature attesting to the event on the other chain. This field is
     required.
@@ -47,7 +47,7 @@ class XChainAddAccountCreateAttestation(Transaction):
     :meta hide-value:
     """
 
-    other_chain_source: str = REQUIRED  # type: ignore
+    other_chain_source: str = REQUIRED
     """
     The account on the source chain that submitted the
     ``XChainAccountCreateCommit`` transaction that triggered the event
@@ -56,7 +56,7 @@ class XChainAddAccountCreateAttestation(Transaction):
     :meta hide-value:
     """
 
-    amount: Amount = REQUIRED  # type: ignore
+    amount: Amount = REQUIRED
     """
     The amount committed by the ``XChainAccountCreateCommit`` transaction on
     the source chain. This field is required.
@@ -64,7 +64,7 @@ class XChainAddAccountCreateAttestation(Transaction):
     :meta hide-value:
     """
 
-    attestation_reward_account: str = REQUIRED  # type: ignore
+    attestation_reward_account: str = REQUIRED
     """
     The account that should receive this signer's share of the
     ``SignatureReward``. This field is required.
@@ -72,7 +72,7 @@ class XChainAddAccountCreateAttestation(Transaction):
     :meta hide-value:
     """
 
-    attestation_signer_account: str = REQUIRED  # type: ignore
+    attestation_signer_account: str = REQUIRED
     """
     The account on the door account's signer list that is signing the
     transaction. This field is required.
@@ -80,7 +80,7 @@ class XChainAddAccountCreateAttestation(Transaction):
     :meta hide-value:
     """
 
-    was_locking_chain_send: Union[Literal[0], Literal[1]] = REQUIRED  # type: ignore
+    was_locking_chain_send: Union[Literal[0], Literal[1]] = REQUIRED
     """
     A boolean representing the chain where the event occurred. This field is
     required.
@@ -88,7 +88,7 @@ class XChainAddAccountCreateAttestation(Transaction):
     :meta hide-value:
     """
 
-    xchain_account_create_count: Union[str, int] = REQUIRED  # type: ignore
+    xchain_account_create_count: Union[str, int] = REQUIRED
     """
     The counter that represents the order that the claims must be processed in.
     This field is required.
@@ -96,7 +96,7 @@ class XChainAddAccountCreateAttestation(Transaction):
     :meta hide-value:
     """
 
-    destination: str = REQUIRED  # type: ignore
+    destination: str = REQUIRED
     """
     The destination account for the funds on the destination chain. This field
     is required.
@@ -104,7 +104,7 @@ class XChainAddAccountCreateAttestation(Transaction):
     :meta hide-value:
     """
 
-    signature_reward: Amount = REQUIRED  # type: ignore
+    signature_reward: Amount = REQUIRED
     """
     The signature reward paid in the ``XChainAccountCreateCommit`` transaction.
     This field is required.

--- a/xrpl/models/transactions/xchain_add_claim_attestation.py
+++ b/xrpl/models/transactions/xchain_add_claim_attestation.py
@@ -24,21 +24,21 @@ class XChainAddClaimAttestation(Transaction):
     server, attesting to an ``XChainCommit`` transaction.
     """
 
-    xchain_bridge: XChainBridge = REQUIRED  # type: ignore
+    xchain_bridge: XChainBridge = REQUIRED
     """
     The bridge to use to transfer funds. This field is required.
 
     :meta hide-value:
     """
 
-    public_key: str = REQUIRED  # type: ignore
+    public_key: str = REQUIRED
     """
     The public key used to verify the signature. This field is required.
 
     :meta hide-value:
     """
 
-    signature: str = REQUIRED  # type: ignore
+    signature: str = REQUIRED
     """
     The signature attesting to the event on the other chain. This field is
     required.
@@ -46,7 +46,7 @@ class XChainAddClaimAttestation(Transaction):
     :meta hide-value:
     """
 
-    other_chain_source: str = REQUIRED  # type: ignore
+    other_chain_source: str = REQUIRED
     """
     The account on the source chain that submitted the ``XChainCommit``
     transaction that triggered the event associated with the attestation. This
@@ -55,7 +55,7 @@ class XChainAddClaimAttestation(Transaction):
     :meta hide-value:
     """
 
-    amount: Amount = REQUIRED  # type: ignore
+    amount: Amount = REQUIRED
     """
     The amount committed by the ``XChainCommit`` transaction on the source
     chain. This field is required.
@@ -63,7 +63,7 @@ class XChainAddClaimAttestation(Transaction):
     :meta hide-value:
     """
 
-    attestation_reward_account: str = REQUIRED  # type: ignore
+    attestation_reward_account: str = REQUIRED
     """
     The account that should receive this signer's share of the
     ``SignatureReward``. This field is required.
@@ -71,7 +71,7 @@ class XChainAddClaimAttestation(Transaction):
     :meta hide-value:
     """
 
-    attestation_signer_account: str = REQUIRED  # type: ignore
+    attestation_signer_account: str = REQUIRED
     """
     The account on the door account's signer list that is signing the
     transaction. This field is required.
@@ -79,7 +79,7 @@ class XChainAddClaimAttestation(Transaction):
     :meta hide-value:
     """
 
-    was_locking_chain_send: Union[Literal[0], Literal[1]] = REQUIRED  # type: ignore
+    was_locking_chain_send: Union[Literal[0], Literal[1]] = REQUIRED
     """
     A boolean representing the chain where the event occurred. This field is
     required.
@@ -87,7 +87,7 @@ class XChainAddClaimAttestation(Transaction):
     :meta hide-value:
     """
 
-    xchain_claim_id: Union[str, int] = REQUIRED  # type: ignore
+    xchain_claim_id: Union[str, int] = REQUIRED
     """
     The ``XChainClaimID`` associated with the transfer, which was included in
     the ``XChainCommit`` transaction. This field is required.

--- a/xrpl/models/transactions/xchain_claim.py
+++ b/xrpl/models/transactions/xchain_claim.py
@@ -26,14 +26,14 @@ class XChainClaim(Transaction):
     equivalent of the value locked on the source chain.
     """
 
-    xchain_bridge: XChainBridge = REQUIRED  # type: ignore
+    xchain_bridge: XChainBridge = REQUIRED
     """
     The bridge to use for the transfer. This field is required.
 
     :meta hide-value:
     """
 
-    xchain_claim_id: Union[int, str] = REQUIRED  # type: ignore
+    xchain_claim_id: Union[int, str] = REQUIRED
     """
     The unique integer ID for the cross-chain transfer that was referenced in
     the corresponding ``XChainCommit`` transaction. This field is required.
@@ -41,7 +41,7 @@ class XChainClaim(Transaction):
     :meta hide-value:
     """
 
-    destination: str = REQUIRED  # type: ignore
+    destination: str = REQUIRED
     """
     The destination account on the destination chain. It must exist or the
     transaction will fail. However, if the transaction fails in this case, the
@@ -59,7 +59,7 @@ class XChainClaim(Transaction):
     :meta hide-value:
     """
 
-    amount: Amount = REQUIRED  # type: ignore
+    amount: Amount = REQUIRED
     """
     The amount to claim on the destination chain. This must match the amount
     attested to on the attestations associated with this ``XChainClaimID``.

--- a/xrpl/models/transactions/xchain_commit.py
+++ b/xrpl/models/transactions/xchain_commit.py
@@ -22,14 +22,14 @@ class XChainCommit(Transaction):
     chain so that they can be returned on the locking chain.
     """
 
-    xchain_bridge: XChainBridge = REQUIRED  # type: ignore
+    xchain_bridge: XChainBridge = REQUIRED
     """
     The bridge to use to transfer funds. This field is required.
 
     :meta hide-value:
     """
 
-    xchain_claim_id: Union[int, str] = REQUIRED  # type: ignore
+    xchain_claim_id: Union[int, str] = REQUIRED
     """
     The unique integer ID for a cross-chain transfer. This must be acquired on
     the destination chain (via a ``XChainCreateClaimID`` transaction) and
@@ -40,7 +40,7 @@ class XChainCommit(Transaction):
     :meta hide-value:
     """
 
-    amount: Amount = REQUIRED  # type: ignore
+    amount: Amount = REQUIRED
     """
     The asset to commit, and the quantity. This must match the door account's
     ``LockingChainIssue`` (if on the locking chain) or the door account's

--- a/xrpl/models/transactions/xchain_create_bridge.py
+++ b/xrpl/models/transactions/xchain_create_bridge.py
@@ -26,14 +26,14 @@ class XChainCreateBridge(Transaction):
     the bridge.
     """
 
-    xchain_bridge: XChainBridge = REQUIRED  # type: ignore
+    xchain_bridge: XChainBridge = REQUIRED
     """
     The bridge (door accounts and assets) to create. This field is required.
 
     :meta hide-value:
     """
 
-    signature_reward: str = REQUIRED  # type: ignore
+    signature_reward: str = REQUIRED
     """
     The total amount to pay the witness servers for their signatures. This
     amount will be split among the signers. This field is required.

--- a/xrpl/models/transactions/xchain_create_claim_id.py
+++ b/xrpl/models/transactions/xchain_create_claim_id.py
@@ -25,14 +25,14 @@ class XChainCreateClaimID(Transaction):
     cross-chain transfer of value.
     """
 
-    xchain_bridge: XChainBridge = REQUIRED  # type: ignore
+    xchain_bridge: XChainBridge = REQUIRED
     """
     The bridge to create the claim ID for. This field is required.
 
     :meta hide-value:
     """
 
-    signature_reward: str = REQUIRED  # type: ignore
+    signature_reward: str = REQUIRED
     """
     The amount, in XRP, to reward the witness servers for providing signatures.
     This must match the amount on the ``Bridge`` ledger object. This field is
@@ -41,7 +41,7 @@ class XChainCreateClaimID(Transaction):
     :meta hide-value:
     """
 
-    other_chain_source: str = REQUIRED  # type: ignore
+    other_chain_source: str = REQUIRED
     """
     The account that must send the corresponding ``XChainCommit`` transaction
     on the source chain. This field is required.

--- a/xrpl/models/transactions/xchain_modify_bridge.py
+++ b/xrpl/models/transactions/xchain_modify_bridge.py
@@ -44,7 +44,7 @@ class XChainModifyBridge(Transaction):
     parameters of the bridge.
     """
 
-    xchain_bridge: XChainBridge = REQUIRED  # type: ignore
+    xchain_bridge: XChainBridge = REQUIRED
     """
     The bridge to modify. This field is required.
 


### PR DESCRIPTION
## High Level Overview of Change

This PR adjusts the typing of `REQUIRED` so that you no longer need to except it from typing checks.

### Context of Change

* PR where it was added: https://github.com/XRPLF/xrpl-py/pull/112
* https://github.com/XRPLF/xrpl-py/pull/155/files#r592603289

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update CHANGELOG.md?

- [x] No, this change does not impact library users

## Test Plan

CI passes. Typing checks are satisfied.
