### PR TITLE
feat: add support for the `simulate` RPC (XLS-69d)

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -2,7 +2,7 @@ name: Integration test
 
 env:
   POETRY_VERSION: 1.8.3
-  RIPPLED_DOCKER_IMAGE: rippleci/rippled:2.3.0
+  RIPPLED_DOCKER_IMAGE: rippleci/rippled:develop
 
 on:
   push:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,5 +27,10 @@
       "source.organizeImports": "always"
     }
   },
-  "isort.args": ["--profile", "black"]
+  "isort.args": [
+    "--profile",
+    "black"
+  ],
+  "python.testing.pytestEnabled": false,
+  "python.testing.unittestEnabled": true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [[Unreleased]]
 
 ### Added
-- Support for the `simulate` RPC
+- Support for the `simulate` RPC ([XLS-69](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0069d-simulate))
 
 ### Fixed
-- `Sign` `SignFor`, and `SignAndSubmit` now work with Websocket clients
+- `Sign`, `SignFor`, and `SignAndSubmit` methods now properly handle WebSocket clients
 
 ## [4.0.0] - 2024-12-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support for the `simulate` RPC
 
+### Fixed
+- `Sign` `SignFor`, and `SignAndSubmit` now work with Websocket clients
+
 ## [4.0.0] - 2024-12-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [[Unreleased]]
 
+### Added
+- Support for the `simulate` RPC
+
 ## [4.0.0] - 2024-12-23
 
 ### Added

--- a/tests/integration/reqs/test_simulate.py
+++ b/tests/integration/reqs/test_simulate.py
@@ -12,8 +12,12 @@ class TestSimulate(IntegrationTestCase):
         )
 
         self.assertEqual(response.type, "response")
-        self.assertIn("meta", response.result, "Key 'meta' not found in simulate response.")
-        self.assertIsInstance(response.result["meta"], dict, "'meta' should be a dictionary.")
+        self.assertIn(
+            "meta", response.result, "Key 'meta' not found in simulate response."
+        )
+        self.assertIsInstance(
+            response.result["meta"], dict, "'meta' should be a dictionary."
+        )
         self.assertEqual(response.result["engine_result"], "tesSUCCESS")
         self.assertEqual(response.result["engine_result_code"], 0)
         self.assertFalse(response.result["applied"])

--- a/tests/integration/reqs/test_simulate.py
+++ b/tests/integration/reqs/test_simulate.py
@@ -8,9 +8,7 @@ class TestSimulate(IntegrationTestCase):
     @test_async_and_sync(globals())
     async def test_basic_functionality(self, client):
         response = await client.request(
-            Simulate(
-                transaction=AccountSet(account=WALLET.classic_address, network_id=63456)
-            )
+            Simulate(transaction=AccountSet(account=WALLET.classic_address))
         )
 
         self.assertEqual(response.type, "response")

--- a/tests/integration/reqs/test_simulate.py
+++ b/tests/integration/reqs/test_simulate.py
@@ -1,0 +1,18 @@
+from tests.integration.integration_test_case import IntegrationTestCase
+from tests.integration.it_utils import test_async_and_sync
+from tests.integration.reusable_values import WALLET
+from xrpl.models import AccountSet, Simulate
+
+
+class TestSimulate(IntegrationTestCase):
+    @test_async_and_sync(globals())
+    async def test_basic_functionality(self, client):
+        response = await client.request(
+            Simulate(transaction=AccountSet(account=WALLET.classic_address))
+        )
+
+        self.assertEqual(response.type, "response")
+        self.assertIsInstance(response.result["meta"], dict)
+        self.assertEqual(response.result["engine_result"], "tesSUCCESS")
+        self.assertEqual(response.result["engine_result_code"], 0)
+        self.assertFalse(response.result["applied"])

--- a/tests/integration/reqs/test_simulate.py
+++ b/tests/integration/reqs/test_simulate.py
@@ -12,7 +12,8 @@ class TestSimulate(IntegrationTestCase):
         )
 
         self.assertEqual(response.type, "response")
-        self.assertIsInstance(response.result["meta"], dict)
+        self.assertIn("meta", response.result, "Key 'meta' not found in simulate response.")
+        self.assertIsInstance(response.result["meta"], dict, "'meta' should be a dictionary.")
         self.assertEqual(response.result["engine_result"], "tesSUCCESS")
         self.assertEqual(response.result["engine_result_code"], 0)
         self.assertFalse(response.result["applied"])

--- a/tests/integration/reqs/test_simulate.py
+++ b/tests/integration/reqs/test_simulate.py
@@ -8,7 +8,9 @@ class TestSimulate(IntegrationTestCase):
     @test_async_and_sync(globals())
     async def test_basic_functionality(self, client):
         response = await client.request(
-            Simulate(transaction=AccountSet(account=WALLET.classic_address))
+            Simulate(
+                transaction=AccountSet(account=WALLET.classic_address, network_id=63456)
+            )
         )
 
         self.assertEqual(response.type, "response")

--- a/tests/integration/sugar/test_transaction.py
+++ b/tests/integration/sugar/test_transaction.py
@@ -9,16 +9,15 @@ from tests.integration.reusable_values import WALLET
 from xrpl.asyncio.ledger import get_fee, get_latest_validated_ledger_sequence
 from xrpl.asyncio.transaction import (
     XRPLReliableSubmissionException,
+    _calculate_fee_per_transaction_type,
     autofill,
     autofill_and_sign,
     sign,
+    sign_and_submit,
+    simulate,
 )
 from xrpl.asyncio.transaction import submit as submit_transaction_alias_async
 from xrpl.asyncio.transaction import submit_and_wait
-from xrpl.asyncio.transaction.main import (
-    _calculate_fee_per_transaction_type,
-    sign_and_submit,
-)
 from xrpl.clients import XRPLRequestFailureException
 from xrpl.core.addresscodec import classic_address_to_xaddress
 from xrpl.core.binarycodec.main import encode
@@ -254,6 +253,79 @@ class TestTransaction(IntegrationTestCase):
         self.assertIsNone(transaction.network_id)
         self.assertEqual(client.network_id, 1)
 
+    @test_async_and_sync(
+        globals(),
+        [
+            "xrpl.transaction.sign_and_submit",
+        ],
+    )
+    async def test_sign_and_submit(self, client):
+        payment_dict = {
+            "account": ACCOUNT,
+            "fee": "10",
+            "amount": "100",
+            "destination": DESTINATION,
+        }
+        payment_transaction = Payment.from_dict(payment_dict)
+        response = await sign_and_submit(payment_transaction, client, WALLET)
+        self.assertTrue(response.is_successful())
+
+    @test_async_and_sync(globals(), async_only=True)
+    async def test_basic_calculate_fee_per_transaction_type(self, client):
+        fee = await _calculate_fee_per_transaction_type(
+            Payment(
+                account="rweYz56rfmQ98cAdRaeTxQS9wVMGnrdsFp",
+                amount=IssuedCurrencyAmount(
+                    currency="USD",
+                    issuer="rweYz56rfmQ98cAdRaeTxQS9wVMGnrdsFp",
+                    value="0.0001",
+                ),
+                destination="rweYz56rfmQ98cAdRaeTxQS9wVMGnrdsFp",
+                send_max=IssuedCurrencyAmount(
+                    currency="BTC",
+                    issuer="rweYz56rfmQ98cAdRaeTxQS9wVMGnrdsFp",
+                    value="0.0000002831214446",
+                ),
+            ),
+            client,
+        )
+
+        # The expected fee is read from the below-specified config file
+        expected_fee = ""
+        with open(".ci-config/rippled.cfg", "r", encoding="utf-8") as file:
+            lines = file.readlines()  # Read all lines into a list
+
+            for value in lines:
+                kv_pairs = value.split()
+                # This step assumes that no non-`voting` section in the config file
+                # uses the reference_fee key-value pair.
+                if "reference_fee" in kv_pairs:
+                    expected_fee = kv_pairs[2]
+                    break
+
+        self.assertEqual(fee, expected_fee)
+
+    @test_async_and_sync(
+        globals(),
+        [
+            "xrpl.transaction.simulate",
+        ],
+    )
+    async def test_simulate(self, client):
+        response = await simulate(AccountSet(account=WALLET.address), client)
+
+        self.assertTrue(response.is_successful())
+        self.assertEqual(response.type, "response")
+        self.assertIn(
+            "meta", response.result, "Key 'meta' not found in simulate response."
+        )
+        self.assertIsInstance(
+            response.result["meta"], dict, "'meta' should be a dictionary."
+        )
+        self.assertEqual(response.result["engine_result"], "tesSUCCESS")
+        self.assertEqual(response.result["engine_result_code"], 0)
+        self.assertFalse(response.result["applied"])
+
 
 class TestSubmitAndWait(IntegrationTestCase):
     @test_async_and_sync(
@@ -419,60 +491,3 @@ class TestSubmitAndWait(IntegrationTestCase):
         signed_payment_transaction = sign(payment_transaction, WALLET)
         with self.assertRaises(XRPLReliableSubmissionException):
             await submit_and_wait(signed_payment_transaction, client)
-
-    @test_async_and_sync(
-        globals(),
-        [
-            "xrpl.transaction.sign_and_submit",
-        ],
-    )
-    async def test_sign_and_submit(self, client):
-        payment_dict = {
-            "account": ACCOUNT,
-            "fee": "10",
-            "amount": "100",
-            "destination": DESTINATION,
-        }
-        payment_transaction = Payment.from_dict(payment_dict)
-        response = await sign_and_submit(payment_transaction, client, WALLET)
-        self.assertTrue(response.is_successful())
-
-    @test_async_and_sync(
-        globals(),
-        [
-            "xrpl.transaction._calculate_fee_per_transaction_type",
-        ],
-    )
-    async def test_basic_calculate_fee_per_transaction_type(self, client):
-        fee = await _calculate_fee_per_transaction_type(
-            Payment(
-                account="rweYz56rfmQ98cAdRaeTxQS9wVMGnrdsFp",
-                amount=IssuedCurrencyAmount(
-                    currency="USD",
-                    issuer="rweYz56rfmQ98cAdRaeTxQS9wVMGnrdsFp",
-                    value="0.0001",
-                ),
-                destination="rweYz56rfmQ98cAdRaeTxQS9wVMGnrdsFp",
-                send_max=IssuedCurrencyAmount(
-                    currency="BTC",
-                    issuer="rweYz56rfmQ98cAdRaeTxQS9wVMGnrdsFp",
-                    value="0.0000002831214446",
-                ),
-            ),
-            client,
-        )
-
-        # The expected fee is read from the below-specified config file
-        expected_fee = ""
-        with open(".ci-config/rippled.cfg", "r", encoding="utf-8") as file:
-            lines = file.readlines()  # Read all lines into a list
-
-            for value in lines:
-                kv_pairs = value.split()
-                # This step assumes that no non-`voting` section in the config file
-                # uses the reference_fee key-value pair.
-                if "reference_fee" in kv_pairs:
-                    expected_fee = kv_pairs[2]
-                    break
-
-        self.assertEqual(fee, expected_fee)

--- a/tests/unit/models/requests/test_simulate.py
+++ b/tests/unit/models/requests/test_simulate.py
@@ -38,23 +38,6 @@ class TestSimulate(unittest.TestCase):
             "{'transaction': 'Cannot simulate a signed transaction.'}",
         )
 
-    def test_simulate_with_invalid_tx_blob(self):
-        with self.assertRaises(XRPLModelException) as e:
-            Simulate(tx_blob="12000022800000002400000001201B001FBD60")
-        self.assertEqual(
-            e.exception.args[0],
-            "{'tx_blob': 'Invalid transaction blob.'}",
-        )
-
-    def test_simulate_with_signed_tx_blob(self):
-        signed_tx = sign(_TRANSACTION, _WALLET)
-        with self.assertRaises(XRPLModelException) as e:
-            Simulate(tx_blob=signed_tx.blob())
-        self.assertEqual(
-            e.exception.args[0],
-            "{'tx_blob': 'Cannot simulate a signed transaction.'}",
-        )
-
     def test_simulate_with_valid_tx_blob(self):
         tx_blob = _TRANSACTION.blob()
         simulate = Simulate(tx_blob=tx_blob)
@@ -69,5 +52,14 @@ class TestSimulate(unittest.TestCase):
         self.assertIsNone(simulate.tx_blob)
         self.assertEqual(simulate.transaction, _TRANSACTION)
         self.assertIsNone(simulate.binary)
+        self.assertEqual(simulate.method, "simulate")
+        self.assertTrue(simulate.is_valid())
+
+    def test_simulate_with_binary(self):
+        tx_blob = _TRANSACTION.blob()
+        simulate = Simulate(tx_blob=tx_blob, binary=True)
+        self.assertEqual(simulate.tx_blob, tx_blob)
+        self.assertIsNone(simulate.transaction)
+        self.assertTrue(simulate.binary)
         self.assertEqual(simulate.method, "simulate")
         self.assertTrue(simulate.is_valid())

--- a/tests/unit/models/requests/test_simulate.py
+++ b/tests/unit/models/requests/test_simulate.py
@@ -1,0 +1,73 @@
+import unittest
+
+from xrpl.models import AccountSet, Simulate
+from xrpl.models.exceptions import XRPLModelException
+from xrpl.transaction import sign
+from xrpl.wallet import Wallet
+
+_WALLET = Wallet.create()
+_TRANSACTION = AccountSet(account=_WALLET.address, sequence=1)
+
+
+class TestSimulate(unittest.TestCase):
+    def test_simulate_with_both_tx_blob_and_transaction(self):
+        with self.assertRaises(XRPLModelException) as e:
+            Simulate(
+                tx_blob=_TRANSACTION.blob(),
+                transaction=_TRANSACTION,
+            )
+        self.assertEqual(
+            e.exception.args[0],
+            "{'tx': 'Must have exactly one of `tx_blob` and `transaction` fields.'}",
+        )
+
+    def test_simulate_with_neither_tx_blob_nor_transaction(self):
+        with self.assertRaises(XRPLModelException) as e:
+            Simulate()
+        self.assertEqual(
+            e.exception.args[0],
+            "{'tx': 'Must have exactly one of `tx_blob` and `transaction` fields.'}",
+        )
+
+    def test_simulate_with_signed_transaction(self):
+        signed_tx = sign(_TRANSACTION, _WALLET)
+        with self.assertRaises(XRPLModelException) as e:
+            Simulate(transaction=signed_tx)
+        self.assertEqual(
+            e.exception.args[0],
+            "{'transaction': 'Cannot simulate a signed transaction.'}",
+        )
+
+    def test_simulate_with_invalid_tx_blob(self):
+        with self.assertRaises(XRPLModelException) as e:
+            Simulate(tx_blob="12000022800000002400000001201B001FBD60")
+        self.assertEqual(
+            e.exception.args[0],
+            "{'tx_blob': 'Invalid transaction blob.'}",
+        )
+
+    def test_simulate_with_signed_tx_blob(self):
+        signed_tx = sign(_TRANSACTION, _WALLET)
+        with self.assertRaises(XRPLModelException) as e:
+            Simulate(tx_blob=signed_tx.blob())
+        self.assertEqual(
+            e.exception.args[0],
+            "{'tx_blob': 'Cannot simulate a signed transaction.'}",
+        )
+
+    def test_simulate_with_valid_tx_blob(self):
+        tx_blob = _TRANSACTION.blob()
+        simulate = Simulate(tx_blob=tx_blob)
+        self.assertEqual(simulate.tx_blob, tx_blob)
+        self.assertIsNone(simulate.transaction)
+        self.assertIsNone(simulate.binary)
+        self.assertEqual(simulate.method, "simulate")
+        self.assertTrue(simulate.is_valid())
+
+    def test_simulate_with_valid_transaction(self):
+        simulate = Simulate(transaction=_TRANSACTION)
+        self.assertIsNone(simulate.tx_blob)
+        self.assertEqual(simulate.transaction, _TRANSACTION)
+        self.assertIsNone(simulate.binary)
+        self.assertEqual(simulate.method, "simulate")
+        self.assertTrue(simulate.is_valid())

--- a/tests/unit/models/test_base_model.py
+++ b/tests/unit/models/test_base_model.py
@@ -124,7 +124,7 @@ class TestFromDict(TestCase):
 
     def test_from_dict_recursive_transaction(self):
         transaction = CheckCreate.from_dict(check_create_dict)
-        sign_dict = {"secret": secret, "transaction": transaction.to_dict()}
+        sign_dict = {"secret": secret, "tx_json": transaction.to_xrpl()}
         sign = Sign.from_dict(sign_dict)
 
         expected_dict = {
@@ -136,12 +136,11 @@ class TestFromDict(TestCase):
             "offline": False,
             "api_version": _DEFAULT_API_VERSION,
         }
-        del expected_dict["transaction"]
         self.assertEqual(expected_dict, sign.to_dict())
 
     def test_from_dict_recursive_transaction_tx_json(self):
         transaction = CheckCreate.from_dict(check_create_dict)
-        sign_dict = {"secret": secret, "tx_json": transaction.to_dict()}
+        sign_dict = {"secret": secret, "tx_json": transaction.to_xrpl()}
         sign = Sign.from_dict(sign_dict)
 
         expected_dict = {

--- a/xrpl/asyncio/transaction/__init__.py
+++ b/xrpl/asyncio/transaction/__init__.py
@@ -6,6 +6,7 @@ from xrpl.asyncio.transaction.main import (
     autofill_and_sign,
     sign,
     sign_and_submit,
+    simulate,
     submit,
     transaction_json_to_binary_codec_form,
 )
@@ -19,6 +20,7 @@ __all__ = [
     "autofill_and_sign",
     "sign",
     "sign_and_submit",
+    "simulate",
     "submit",
     "submit_and_wait",
     "transaction_json_to_binary_codec_form",

--- a/xrpl/asyncio/transaction/main.py
+++ b/xrpl/asyncio/transaction/main.py
@@ -208,10 +208,7 @@ async def simulate(
     final_tx = Transaction.from_dict(transaction_json)
 
     # send the `simulate` request
-    transaction_blob = encode(final_tx.to_xrpl())
-    response = await client._request_impl(
-        Simulate(tx_blob=transaction_blob, binary=binary)
-    )
+    response = await client._request_impl(Simulate(transaction=final_tx, binary=binary))
     if response.is_successful():
         return response
 

--- a/xrpl/asyncio/transaction/main.py
+++ b/xrpl/asyncio/transaction/main.py
@@ -13,10 +13,15 @@ from xrpl.constants import XRPLException
 from xrpl.core.addresscodec import is_valid_xaddress, xaddress_to_classic_address
 from xrpl.core.binarycodec import encode, encode_for_multisigning, encode_for_signing
 from xrpl.core.keypairs.main import sign as keypairs_sign
-from xrpl.models.requests import ServerState, SubmitOnly
-from xrpl.models.response import Response
-from xrpl.models.transactions import EscrowFinish
-from xrpl.models.transactions.transaction import Signer, Transaction
+from xrpl.models import (
+    EscrowFinish,
+    Response,
+    ServerState,
+    Signer,
+    Simulate,
+    SubmitOnly,
+    Transaction,
+)
 from xrpl.models.transactions.transaction import (
     transaction_json_to_binary_codec_form as model_transaction_to_binary_codec,
 )
@@ -152,9 +157,9 @@ async def submit(
     Submits a transaction to the ledger.
 
     Args:
-        transaction: the Transaction to be submitted.
-        client: the network client with which to submit the transaction.
-        fail_hard: an optional boolean. If True, and the transaction fails for
+        transaction: The Transaction to be submitted.
+        client: The network client with which to submit the transaction.
+        fail_hard: An optional boolean. If True, and the transaction fails for
             the initial server, do not retry or relay the transaction to other
             servers. Defaults to False.
 
@@ -167,6 +172,45 @@ async def submit(
     transaction_blob = encode(transaction.to_xrpl())
     response = await client._request_impl(
         SubmitOnly(tx_blob=transaction_blob, fail_hard=fail_hard)
+    )
+    if response.is_successful():
+        return response
+
+    raise XRPLRequestFailureException(response.result)
+
+
+async def simulate(
+    transaction: Transaction,
+    client: Client,
+    *,
+    binary: bool = False,
+) -> Response:
+    """
+    Simulates a transaction without actually submitting it to the network.
+
+    Args:
+        transaction: The transaction to simulate.
+        client: The network client with which to submit the transaction.
+        binary: Whether the return data should be encoded in the XRPL's binary format.
+            Defaults to False.
+
+    Raises:
+        XRPLRequestFailureException: If the transaction fails in the simulated scenario.
+
+    Returns:
+        The response from the ledger.
+    """
+    # autofill the network ID
+    transaction_json = transaction.to_dict()
+    await get_network_id_and_build_version(client)
+    if "network_id" not in transaction_json and _tx_needs_networkID(client):
+        transaction_json["network_id"] = client.network_id
+    final_tx = Transaction.from_dict(transaction_json)
+
+    # send the `simulate` request
+    transaction_blob = encode(final_tx.to_xrpl())
+    response = await client._request_impl(
+        Simulate(tx_blob=transaction_blob, binary=binary)
     )
     if response.is_successful():
         return response

--- a/xrpl/models/nested_model.py
+++ b/xrpl/models/nested_model.py
@@ -59,8 +59,8 @@ class NestedModel(BaseModel):
             XRPLModelException: If the dictionary provided is invalid.
         """
         if _get_nested_name(cls) not in value:
-            return super(NestedModel, cls).from_dict(value)
-        return super(NestedModel, cls).from_dict(value[_get_nested_name(cls)])
+            return super().from_dict(value)
+        return super().from_dict(value[_get_nested_name(cls)])
 
     def to_dict(self: Self) -> Dict[str, Any]:
         """

--- a/xrpl/models/requests/__init__.py
+++ b/xrpl/models/requests/__init__.py
@@ -43,6 +43,7 @@ from xrpl.models.requests.server_state import ServerState
 from xrpl.models.requests.sign import Sign
 from xrpl.models.requests.sign_and_submit import SignAndSubmit
 from xrpl.models.requests.sign_for import SignFor
+from xrpl.models.requests.simulate import Simulate
 from xrpl.models.requests.submit import Submit
 from xrpl.models.requests.submit_multisigned import SubmitMultisigned
 from xrpl.models.requests.submit_only import SubmitOnly
@@ -99,6 +100,7 @@ __all__ = [
     "Sign",
     "SignAndSubmit",
     "SignFor",
+    "Simulate",
     "Submit",
     "SubmitMultisigned",
     "SubmitOnly",

--- a/xrpl/models/requests/request.py
+++ b/xrpl/models/requests/request.py
@@ -38,6 +38,7 @@ class RequestMethod(str, Enum):
     # transaction methods
     SIGN = "sign"
     SIGN_FOR = "sign_for"
+    SIMULATE = "simulate"
     SUBMIT = "submit"
     SUBMIT_MULTISIGNED = "submit_multisigned"
     TRANSACTION_ENTRY = "transaction_entry"

--- a/xrpl/models/requests/sign.py
+++ b/xrpl/models/requests/sign.py
@@ -79,7 +79,10 @@ class Sign(Request):
             A new Sign object, constructed using the given parameters.
         """
         if "tx_json" in value:
-            fixed_value = {**value, "transaction": value["tx_json"]}
+            fixed_value = {
+                **value,
+                "transaction": Transaction.from_xrpl(value["tx_json"]),
+            }
             del fixed_value["tx_json"]
         else:
             fixed_value = value

--- a/xrpl/models/requests/sign_and_submit.py
+++ b/xrpl/models/requests/sign_and_submit.py
@@ -88,11 +88,14 @@ class SignAndSubmit(Submit):
             A new SignAndSubmit object, constructed using the given parameters.
         """
         if "tx_json" in value:
-            fixed_value = {**value, "transaction": value["tx_json"]}
+            fixed_value = {
+                **value,
+                "transaction": Transaction.from_xrpl(value["tx_json"]),
+            }
             del fixed_value["tx_json"]
         else:
             fixed_value = value
-        return super(SignAndSubmit, cls).from_dict(fixed_value)
+        return super().from_dict(fixed_value)
 
     def to_dict(self: Self) -> Dict[str, Any]:
         """

--- a/xrpl/models/requests/sign_for.py
+++ b/xrpl/models/requests/sign_for.py
@@ -70,11 +70,14 @@ class SignFor(Request):
             A new SignFor object, constructed using the given parameters.
         """
         if "tx_json" in value:
-            fixed_value = {**value, "transaction": value["tx_json"]}
+            fixed_value = {
+                **value,
+                "transaction": Transaction.from_xrpl(value["tx_json"]),
+            }
             del fixed_value["tx_json"]
         else:
             fixed_value = value
-        return super(SignFor, cls).from_dict(fixed_value)
+        return super().from_dict(fixed_value)
 
     def to_dict(self: Self) -> Dict[str, Any]:
         """

--- a/xrpl/models/requests/simulate.py
+++ b/xrpl/models/requests/simulate.py
@@ -46,14 +46,15 @@ class Simulate(Request):
     def _get_errors(self: Self) -> Dict[str, str]:
         errors = super()._get_errors()
 
+        # Can't have both `tx_blob` and `transaction`
+        # Can't have neither `tx_blob` nor `transaction`
         if (self.tx_blob is None) == (self.transaction is None):
             errors["tx"] = (
                 "Must have exactly one of `tx_blob` and `transaction` fields."
             )
 
-        if self.transaction is not None:
-            if self.transaction.is_signed():
-                errors["transaction"] = "Cannot simulate a signed transaction."
+        if self.transaction is not None and self.transaction.is_signed():
+            errors["transaction"] = "Cannot simulate a signed transaction."
 
         return errors
 
@@ -79,7 +80,7 @@ class Simulate(Request):
                     "transaction": Transaction.from_xrpl(value["tx_json"]),
                 }
             except XRPLModelException as e:
-                raise XRPLModelException(f"Invalid tx_json format: {str(e)}")
+                raise XRPLModelException(f"Invalid tx_json format: {str(e)}") from e
             del fixed_value["tx_json"]
         else:
             fixed_value = value

--- a/xrpl/models/requests/simulate.py
+++ b/xrpl/models/requests/simulate.py
@@ -1,0 +1,35 @@
+"""This request simulates a transaction without submitting it to the network."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+from typing_extensions import Self
+
+from xrpl.models.requests.request import Request, RequestMethod
+from xrpl.models.transactions.transaction import Transaction
+from xrpl.models.utils import KW_ONLY_DATACLASS, require_kwargs_on_init
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True, **KW_ONLY_DATACLASS)
+class Simulate(Request):
+    """
+    The `simulate` method simulates a transaction without submitting it to the
+    network.
+    """
+
+    tx_blob: Optional[str] = None
+
+    tx_json: Optional[Transaction] = None
+
+    binary: Optional[bool] = None
+
+    method: RequestMethod = field(default=RequestMethod.SIMULATE, init=False)
+
+    def _get_errors(self: Self) -> Dict[str, str]:
+        errors = super()._get_errors()
+        if (self.tx_blob is None) == (self.tx_json is None):
+            errors["tx"] = "Must have exactly one of `tx_blob` and `tx_json` fields."
+        return errors

--- a/xrpl/models/requests/submit_multisigned.py
+++ b/xrpl/models/requests/submit_multisigned.py
@@ -58,7 +58,7 @@ class SubmitMultisigned(Request):
         fixed_value = {**value}
         if "TransactionType" in fixed_value["tx_json"]:  # xrpl format
             fixed_value["tx_json"] = Transaction.from_xrpl(fixed_value["tx_json"])
-        return super(SubmitMultisigned, cls).from_dict(fixed_value)
+        return super().from_dict(fixed_value)
 
     def to_dict(self: Self) -> Dict[str, Any]:
         """

--- a/xrpl/models/transactions/transaction.py
+++ b/xrpl/models/transactions/transaction.py
@@ -362,7 +362,7 @@ class Transaction(BaseModel):
                     )
                 value = {**value}
                 del value["transaction_type"]
-            return super(Transaction, cls).from_dict(value)
+            return super().from_dict(value)
 
     def has_flag(self: Self, flag: int) -> bool:
         """

--- a/xrpl/transaction/__init__.py
+++ b/xrpl/transaction/__init__.py
@@ -5,11 +5,11 @@ from xrpl.asyncio.transaction import (
     transaction_json_to_binary_codec_form,
 )
 from xrpl.transaction.main import (
-    _calculate_fee_per_transaction_type,
     autofill,
     autofill_and_sign,
     sign,
     sign_and_submit,
+    simulate,
     submit,
 )
 from xrpl.transaction.multisign import multisign
@@ -18,12 +18,12 @@ from xrpl.transaction.reliable_submission import submit_and_wait
 __all__ = [
     "autofill",
     "autofill_and_sign",
+    "multisign",
     "sign",
     "sign_and_submit",
+    "simulate",
     "submit",
     "submit_and_wait",
     "transaction_json_to_binary_codec_form",
-    "multisign",
     "XRPLReliableSubmissionException",
-    "_calculate_fee_per_transaction_type",
 ]

--- a/xrpl/transaction/main.py
+++ b/xrpl/transaction/main.py
@@ -133,27 +133,31 @@ def autofill(
     )
 
 
-def _calculate_fee_per_transaction_type(
+def simulate(
     transaction: Transaction,
     client: SyncClient,
-    signers_count: Optional[int] = None,
-) -> str:
+    *,
+    binary: bool = False,
+) -> Response:
     """
-    Calculate the total fee in drops for a transaction based on:
-    - the network fee
-    - the transaction condition
-
-    https://xrpl.org/transaction-cost.html#special-transaction-costs
+    Simulates a transaction without actually submitting it to the network.
 
     Args:
-        transaction: the Transaction to be submitted.
-        client: the network client with which to submit the transaction.
-        signers_count: the expected number of signers for this transaction.
-            Only used for multisigned transactions.
+        transaction: The transaction to simulate.
+        client: The network client with which to submit the transaction.
+        binary: Whether the return data should be encoded in the XRPL's binary format.
+            Defaults to False.
+
+    Raises:
+        XRPLRequestFailureException: If the transaction fails in the simulated scenario.
 
     Returns:
-        The expected Transaction fee in drops
+        The response from the ledger.
     """
     return asyncio.run(
-        main._calculate_fee_per_transaction_type(transaction, client, signers_count)
+        main.simulate(
+            transaction,
+            client,
+            binary=binary,
+        )
     )


### PR DESCRIPTION
## High Level Overview of Change

This PR adds support to xrpl-py for the new `simulate` RPC.

### Context of Change

Spec: https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0069d-simulate
rippled PR: https://github.com/XRPLF/rippled/pull/5069

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### Did you update CHANGELOG.md?

- [x] Yes

## Test Plan

TODO