### PR TITLE
fix: Update asyncio.run to async await

### DIFF
--- a/xrpl/clients/sync_client.py
+++ b/xrpl/clients/sync_client.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
-
 from typing_extensions import Self
 
 from xrpl.asyncio.clients.client import Client
@@ -18,7 +16,7 @@ class SyncClient(Client):
     :meta private:
     """
 
-    def request(self: Self, request: Request) -> Response:
+    async def request(self: Self, request: Request) -> Response:
         """
         Makes a request with this client and returns the response.
 
@@ -28,4 +26,4 @@ class SyncClient(Client):
         Returns:
             The Response for the given Request.
         """
-        return asyncio.run(self._request_impl(request))
+        return await self._request_impl(request)

--- a/xrpl/transaction/reliable_submission.py
+++ b/xrpl/transaction/reliable_submission.py
@@ -1,6 +1,5 @@
 """High-level reliable submission methods with XRPL transactions."""
 
-import asyncio
 from typing import Optional
 
 from xrpl.asyncio.transaction import submit_and_wait as async_submit_and_wait
@@ -10,7 +9,7 @@ from xrpl.models.transactions.transaction import Transaction
 from xrpl.wallet.main import Wallet
 
 
-def submit_and_wait(
+async def submit_and_wait(
     transaction: Transaction,
     client: SyncClient,
     wallet: Optional[Wallet] = None,
@@ -44,8 +43,7 @@ def submit_and_wait(
     Returns:
         The response from the ledger.
     """
-    return asyncio.run(
-        async_submit_and_wait(
+    return await async_submit_and_wait(
             transaction,
             client,
             wallet,
@@ -53,4 +51,3 @@ def submit_and_wait(
             autofill=autofill,
             fail_hard=fail_hard,
         )
-    )

--- a/xrpl/wallet/wallet_generation.py
+++ b/xrpl/wallet/wallet_generation.py
@@ -1,6 +1,5 @@
 """Handles wallet generation from a faucet."""
 
-import asyncio
 from typing import Optional
 
 from xrpl.asyncio.wallet import generate_faucet_wallet as async_generate_faucet_wallet
@@ -8,7 +7,7 @@ from xrpl.clients.sync_client import SyncClient
 from xrpl.wallet.main import Wallet
 
 
-def generate_faucet_wallet(
+async def generate_faucet_wallet(
     client: SyncClient,
     wallet: Optional[Wallet] = None,
     debug: bool = False,
@@ -38,6 +37,4 @@ def generate_faucet_wallet(
 
     .. # noqa: DAR402 exception raised in private method
     """
-    return asyncio.run(
-        async_generate_faucet_wallet(client, wallet, debug, faucet_host, usage_context)
-    )
+    return await async_generate_faucet_wallet(client, wallet, debug, faucet_host, usage_context)


### PR DESCRIPTION
## High Level Overview of Change

Multiple instances of asyncio.run is replaced with async and await

### Context of Change

asyncio.run causes issues when run inside of async functions. Replacing this with await and marking the function as async solves this issue.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Did you update CHANGELOG.md?

- [x] No, this change does not impact library users

## Test Plan

Ensure existing tests are passing
