### PR TITLE
fix: add `MPTAmount` support in `Issue` model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [[Unreleased]]
 
+### Fixed
+
+- add `MPTAmount` support in `Issue` (rippled internal type)
+
 ## [4.1.0] - 2025-2-13
 
 ### Added

--- a/tests/unit/core/binarycodec/types/test_issue.py
+++ b/tests/unit/core/binarycodec/types/test_issue.py
@@ -1,0 +1,69 @@
+from unittest import TestCase
+
+from xrpl.core.binarycodec import XRPLBinaryCodecException
+from xrpl.core.binarycodec.binary_wrappers.binary_parser import BinaryParser
+from xrpl.core.binarycodec.types.issue import Issue
+
+
+class TestIssue(TestCase):
+    def test_from_value_xrp(self):
+        issue_obj = Issue.from_value({"currency": "XRP"})
+        self.assertEqual(issue_obj.to_json(), {"currency": "XRP"})
+
+    def test_from_value_issued_currency(self):
+        test_input = {"currency": "USD", "issuer": "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn"}
+        issue_obj = Issue.from_value(test_input)
+        expected = {"currency": "USD", "issuer": "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn"}
+        self.assertEqual(issue_obj.to_json(), expected)
+
+    def test_from_parser_xrp(self):
+        # Test round-trip: serialize an XRP Issue and then parse it back.
+        test_input = {"currency": "XRP"}
+        issue_obj = Issue.from_value(test_input)
+        # For non-MPT cases, use the hex representation as input to the parser.
+        parser = BinaryParser(issue_obj.to_hex())
+        issue_from_parser = Issue.from_parser(parser)
+        self.assertEqual(issue_from_parser.to_json(), {"currency": "XRP"})
+
+    def test_from_parser_issued_currency(self):
+        # Test round-trip: serialize an issued currency Issue and then parse it back.
+        test_input = {"currency": "EUR", "issuer": "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD"}
+        issue_obj = Issue.from_value(test_input)
+        parser = BinaryParser(issue_obj.to_hex())
+        issue_from_parser = Issue.from_parser(parser)
+        expected = {"currency": "EUR", "issuer": "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD"}
+        self.assertEqual(issue_from_parser.to_json(), expected)
+
+    def test_from_value_mpt(self):
+        # Test Issue creation for an MPT amount.
+        # Use a valid 48-character hex string (24 bytes) for mpt_issuance_id.
+        test_input = {
+            "value": "100",  # MPT amounts must be an integer string (no decimal point)
+            "mpt_issuance_id": "BAADF00DBAADF00DBAADF00DBAADF00DBAADF00DBAADF00D",
+        }
+        issue_obj = Issue.from_value(test_input)
+        expected = {
+            "mpt_issuance_id": "BAADF00DBAADF00DBAADF00DBAADF00DBAADF00DBAADF00D"
+        }
+        self.assertEqual(issue_obj.to_json(), expected)
+
+    def test_from_parser_mpt(self):
+        # Test round-trip: serialize an MPT Issue and then parse it back.
+        test_input = {
+            "value": "100",
+            "mpt_issuance_id": "BAADF00DBAADF00DBAADF00DBAADF00DBAADF00DBAADF00D",
+        }
+        issue_obj = Issue.from_value(test_input)
+        # Use the hex representation and pass the fixed length_hint (24 bytes for
+        # Hash192)
+        parser = BinaryParser(issue_obj.to_hex())
+        issue_from_parser = Issue.from_parser(parser, length_hint=24)
+        expected = {
+            "mpt_issuance_id": "BAADF00DBAADF00DBAADF00DBAADF00DBAADF00DBAADF00D"
+        }
+        self.assertEqual(issue_from_parser.to_json(), expected)
+
+    def test_raises_invalid_value_type(self):
+        # Test that providing an invalid input type raises an XRPLBinaryCodecException.
+        invalid_value = 1
+        self.assertRaises(XRPLBinaryCodecException, Issue.from_value, invalid_value)

--- a/xrpl/core/binarycodec/types/issue.py
+++ b/xrpl/core/binarycodec/types/issue.py
@@ -10,7 +10,9 @@ from xrpl.core.binarycodec.binary_wrappers.binary_parser import BinaryParser
 from xrpl.core.binarycodec.exceptions import XRPLBinaryCodecException
 from xrpl.core.binarycodec.types.account_id import AccountID
 from xrpl.core.binarycodec.types.currency import Currency
+from xrpl.core.binarycodec.types.hash192 import Hash192
 from xrpl.core.binarycodec.types.serialized_type import SerializedType
+from xrpl.models.amounts.mpt_amount import MPTAmount
 from xrpl.models.currencies import XRP as XRPModel
 from xrpl.models.currencies import IssuedCurrency as IssuedCurrencyModel
 
@@ -52,6 +54,13 @@ class Issue(SerializedType):
             issuer_bytes = bytes(AccountID.from_value(value["issuer"]))
             return cls(currency_bytes + issuer_bytes)
 
+        if MPTAmount.is_dict_of_model(value):
+            mpt_issuance_id_bytes = bytearray()
+            Hash192.from_value(value["mpt_issuance_id"]).to_byte_sink(
+                mpt_issuance_id_bytes
+            )
+            return cls(bytes(mpt_issuance_id_bytes))
+
         raise XRPLBinaryCodecException(
             "Invalid type to construct an Issue: expected str or dict,"
             f" received {value.__class__.__name__}."
@@ -69,10 +78,16 @@ class Issue(SerializedType):
         Args:
             parser: The parser to construct the Issue object from.
             length_hint: The number of bytes to consume from the parser.
+                For an MPT amount, pass 24 (the fixed length for Hash192).
 
         Returns:
             The Issue object constructed from a parser.
         """
+        if length_hint is not None and length_hint == 24:
+            mpt_bytes = parser.read(24)
+            return cls(mpt_bytes)
+
+        # Otherwise, follow the regular path
         currency = Currency.from_parser(parser)
         if currency.to_json() == "XRP":
             return cls(bytes(currency))
@@ -87,7 +102,11 @@ class Issue(SerializedType):
         Returns:
             The JSON representation of an Issue.
         """
-        parser = BinaryParser(str(self))
+        # If the buffer is exactly 24 bytes, treat it as an MPT amount.
+        if len(self.buffer) == 24:
+            return {"mpt_issuance_id": self.to_hex().upper()}
+
+        parser = BinaryParser(self.to_hex())
         currency: Union[str, Dict[Any, Any]] = Currency.from_parser(parser).to_json()
         if currency == "XRP":
             return {"currency": currency}


### PR DESCRIPTION
## High Level Overview of Change

Adds `MPTAmount` support in `Issue` model and adds missing test module for `Issue`

### Context of Change

rippled internal type `Issue` now supports `MPTAmount` which was missing.

Historically, the Issue type accounted for `XRP` and `IssuedCurrency` types only. This was implemented in Dec 2024 -- [rippled/include/xrpl/protocol/Asset.h at 33e1c42599857336d792effc753795911bdb13f0 · XRPLF/rippled](https://github.com/XRPLF/rippled/blob/33e1c42599857336d792effc753795911bdb13f0/include/xrpl/protocol/Asset.h#L40) 

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update CHANGELOG.md?

- [x] Yes
- [ ] No, this change does not impact library users

## Test Plan

Adds a missing test module for `Issue`.
