### PR TITLE
Fix: default flags field for transaction frozen class should be None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add `MPTCurrency` support in `Issue` (rippled internal type)
 - Fixed the implementation error in get_latest_open_ledger_sequence method. The change uses the "current" ledger for extracting sequence number.
 - Increase default maximum payload size for websocket client
+- Fixed the default behavior of flags field when preparing transactions. By default, flags are not part of the transaction if not explicitly provided.
 
 ### Added
 - Improved validation for models to also check param types

--- a/tests/unit/models/test_base_model.py
+++ b/tests/unit/models/test_base_model.py
@@ -124,7 +124,8 @@ class TestBaseModel(TestCase):
                 {
                     "flags": (
                         "flags is <class 'str'>, expected "
-                        "typing.Union[typing.Dict[str, bool], int, typing.List[int]]"
+                        "typing.Union[typing.Dict[str, bool], "
+                        "int, typing.List[int], NoneType]"
                     ),
                     "destination": (
                         "An XRP payment transaction cannot have the same "
@@ -169,7 +170,6 @@ class TestFromDict(TestCase):
         expected_dict = {
             **check_create_dict,
             "transaction_type": "CheckCreate",
-            "flags": 0,
             "signing_pub_key": "",
         }
         self.assertEqual(expected_dict, check_create.to_dict())
@@ -231,7 +231,6 @@ class TestFromDict(TestCase):
             "account": "rpqBNcDpWaqZC2Rksayf8UyG66Fyv2JTQy",
             "fee": "10",
             "sequence": 16175710,
-            "flags": 0,
             "signer_quorum": 1,
             "signer_entries": [
                 {
@@ -246,7 +245,6 @@ class TestFromDict(TestCase):
             account="rpqBNcDpWaqZC2Rksayf8UyG66Fyv2JTQy",
             fee="10",
             sequence=16175710,
-            flags=0,
             signer_quorum=1,
             signer_entries=[
                 SignerEntry(
@@ -366,7 +364,6 @@ class TestFromDict(TestCase):
             "account": "rpqBNcDpWaqZC2Rksayf8UyG66Fyv2JTQy",
             "fee": "10",
             "sequence": 16175710,
-            "flags": 0,
             "signer_quorum": 1,
             "signer_entries": {
                 "signer_entry": {
@@ -701,7 +698,6 @@ class TestFromXrpl(TestCase):
             "Account": "rweYz56rfmQ98cAdRaeTxQS9wVMGnrdsFp",
             "TransactionType": "Payment",
             "Sequence": 290,
-            "Flags": 0,
             "SigningPubKey": "",
             "Amount": {
                 "currency": "USD",
@@ -745,7 +741,6 @@ class TestFromXrpl(TestCase):
             "Account": "rweYz56rfmQ98cAdRaeTxQS9wVMGnrdsFp",
             "TransactionType": "SignerListSet",
             "Sequence": 290,
-            "Flags": 0,
             "SigningPubKey": "",
             "SignerQuorum": 1,
             "SignerEntries": [
@@ -824,7 +819,6 @@ class TestFromXrpl(TestCase):
             ],
             "TransactionType": "AMMBid",
             "SigningPubKey": "",
-            "Flags": 0,
         }
         self.assertEqual(tx.to_xrpl(), expected)
 
@@ -840,7 +834,6 @@ class TestFromXrpl(TestCase):
             },
             "Destination": destination,
             "TransactionType": "XChainClaim",
-            "Flags": 0,
             "SigningPubKey": "",
             "XChainClaimID": 1,
         }

--- a/tests/unit/models/transactions/test_payment.py
+++ b/tests/unit/models/transactions/test_payment.py
@@ -189,3 +189,59 @@ class TestPayment(TestCase):
         }
         tx = Payment(**transaction_dict)
         self.assertTrue(tx.is_valid())
+
+    def test_simple_payment_with_zero_flag(self):
+        payment_tx_json = {
+            "Account": _ACCOUNT,
+            "Destination": _DESTINATION,
+            "TransactionType": "Payment",
+            "Amount": _XRP_AMOUNT,
+            "Fee": _FEE,
+            "Flags": 0,
+            "Sequence": _SEQUENCE,
+        }
+        payment_txn = Payment.from_xrpl(payment_tx_json)
+        payment = payment_txn.to_xrpl()
+
+        self.assertTrue("Flags" in payment)
+
+    def test_simple_payment_with_zero_flag_direct(self):
+        payment_txn = Payment(
+            account=_ACCOUNT,
+            destination=_DESTINATION,
+            amount=_XRP_AMOUNT,
+            fee=_FEE,
+            flags=0,
+            sequence=_SEQUENCE,
+        )
+        payment = payment_txn.to_xrpl()
+
+        self.assertTrue("Flags" in payment)
+
+    def test_simple_payment_with_no_flag_direct(self):
+        payment_txn = Payment(
+            account=_ACCOUNT,
+            destination=_DESTINATION,
+            amount=_XRP_AMOUNT,
+            fee=_FEE,
+            sequence=_SEQUENCE,
+        )
+        payment = payment_txn.to_xrpl()
+
+        self.assertFalse("Flags" in payment)
+
+    def test_simple_payment_with_nonzero_flag(self):
+        payment_tx_json = {
+            "Account": _ACCOUNT,
+            "Destination": _DESTINATION,
+            "TransactionType": "Payment",
+            "Amount": _XRP_AMOUNT,
+            "Fee": _FEE,
+            "Flags": 2147483648,
+            "Sequence": _SEQUENCE,
+        }
+
+        payment_txn = Payment.from_xrpl(payment_tx_json)
+        payment = payment_txn.to_xrpl()
+
+        self.assertTrue("Flags" in payment)

--- a/tests/unit/models/transactions/test_pseudo_transactions.py
+++ b/tests/unit/models/transactions/test_pseudo_transactions.py
@@ -34,7 +34,7 @@ class TestPseudoTransactions(TestCase):
         )
         actual = PseudoTransaction.from_xrpl(amendment_dict)
         self.assertEqual(actual, expected)
-        full_dict = {**amendment_dict, "Flags": 0, "TxnSignature": ""}
+        full_dict = {**amendment_dict, "TxnSignature": ""}
         self.assertEqual(actual.to_xrpl(), full_dict)
 
     def test_from_xrpl_set_fee_pre_amendment(self):
@@ -61,7 +61,7 @@ class TestPseudoTransactions(TestCase):
         )
         actual = Transaction.from_xrpl(set_fee_dict)
         self.assertEqual(actual, expected)
-        full_dict = {**set_fee_dict, "Flags": 0, "TxnSignature": ""}
+        full_dict = {**set_fee_dict, "TxnSignature": ""}
         self.assertEqual(actual.to_xrpl(), full_dict)
 
     def test_from_xrpl_set_fee_post_amendment(self):
@@ -85,7 +85,7 @@ class TestPseudoTransactions(TestCase):
         )
         actual = Transaction.from_xrpl(set_fee_dict)
         self.assertEqual(actual, expected)
-        full_dict = {**set_fee_dict, "Flags": 0, "TxnSignature": ""}
+        full_dict = {**set_fee_dict, "TxnSignature": ""}
         self.assertEqual(actual.to_xrpl(), full_dict)
 
     def test_from_xrpl_unl_modify(self):
@@ -108,5 +108,5 @@ class TestPseudoTransactions(TestCase):
         )
         actual = PseudoTransaction.from_xrpl(unl_modify_dict)
         self.assertEqual(actual, expected)
-        full_dict = {**unl_modify_dict, "Flags": 0, "TxnSignature": ""}
+        full_dict = {**unl_modify_dict, "TxnSignature": ""}
         self.assertEqual(actual.to_xrpl(), full_dict)

--- a/xrpl/models/transactions/pseudo_transactions/enable_amendment.py
+++ b/xrpl/models/transactions/pseudo_transactions/enable_amendment.py
@@ -101,7 +101,7 @@ class EnableAmendment(PseudoTransaction):
         init=False,
     )
 
-    flags: Union[Dict[str, bool], int, List[int]] = 0
+    flags: Optional[Union[Dict[str, bool], int, List[int]]] = None
     """
     The Flags value of the EnableAmendment pseudo-transaction indicates the status
     of the amendment at the time of the ledger including the pseudo-transaction.

--- a/xrpl/models/transactions/pseudo_transactions/unl_modify.py
+++ b/xrpl/models/transactions/pseudo_transactions/unl_modify.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Dict, List, Optional, Union
 
 from typing_extensions import Self
 
@@ -55,7 +55,7 @@ class UNLModify(PseudoTransaction):
         init=False,
     )
 
-    flags: int = 0
+    flags: Optional[Union[Dict[str, bool], int, List[int]]] = None
     """
     The Flags value of the EnableAmendment pseudo-transaction indicates the status
     of the amendment at the time of the ledger including the pseudo-transaction.

--- a/xrpl/models/transactions/transaction.py
+++ b/xrpl/models/transactions/transaction.py
@@ -200,7 +200,7 @@ class Transaction(BaseModel):
     details.
     """
 
-    flags: Union[Dict[str, bool], int, List[int]] = 0
+    flags: Optional[Union[Dict[str, bool], int, List[int]]] = None
     """
     A List of flags, or a bitwise map of flags, modifying this transaction's
     behavior. See `Flags Field
@@ -275,11 +275,14 @@ class Transaction(BaseModel):
         """
         # we need to override this because transaction_type is using ``field``
         # which will not include the value in the objects __dict__
-        return {
+        prepared_dict = {
             **super().to_dict(),
             "transaction_type": self.transaction_type.value,
-            "flags": self._flags_to_int(),
         }
+        flags = self._flags_to_int()
+        if flags is not None:
+            prepared_dict["flags"] = flags
+        return prepared_dict
 
     def _iter_to_int(
         self: Self,
@@ -291,7 +294,9 @@ class Transaction(BaseModel):
             accumulator |= flag
         return accumulator
 
-    def _flags_to_int(self: Self) -> int:
+    def _flags_to_int(self: Self) -> int | None:
+        if self.flags is None:
+            return None
         if isinstance(self.flags, int):
             return self.flags
         check_false_flag_definition(tx_type=self.transaction_type, tx_flags=self.flags)
@@ -372,6 +377,8 @@ class Transaction(BaseModel):
         Raises:
             XRPLModelException: if `self.flags` is invalid.
         """
+        if self.flags is None:
+            return False
         if isinstance(self.flags, int):
             return self.flags & flag != 0
         elif isinstance(self.flags, dict):
@@ -488,7 +495,6 @@ class Transaction(BaseModel):
                                 amount and deliver_max fields
         """
         processed_value = cls._process_xrpl_json(value)
-
         # handle the deliver_max alias in Payment transactions
         if (
             "transaction_type" in processed_value


### PR DESCRIPTION
## High Level Overview of Change

By default flags field in transaction frozen class should be None rather than 0

### Context of Change

When creating transactions using the frozen classes, the flags should not be 

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Did you update CHANGELOG.md?

- [ ] Yes
- [x] No, this change does not impact library users

## Test Plan

Current tests 

## Future Tasks

No future tasks
