### PR TITLE
Revised PR 763 - Add API key support for JSON-RPC requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for  `PermissionedDomains` (XLS-80)
 - Support `AMMClawback` amendment (XLS-73d)
 - Support for the `simulate` RPC ([XLS-69](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0069d-simulate))
+- Support for custom HTTP headers in `JsonRpcBase` via the `headers` parameter. This enables connections to XRPL nodes that require API key authentication or Dhali payment-claim headers. Headers can be set at initialization and/or per request. ([#763](https://github.com/XRPLF/xrpl-py/pull/763))
 
 ### Fixed
 - `Sign`, `SignFor`, and `SignAndSubmit` methods now properly handle WebSocket clients


### PR DESCRIPTION
Revised PR 763
https://github.com/XRPLF/xrpl-py/pull/763

This change allows `JsonRpcBase` to include custom HTTP headers when connecting to XRPL nodes that require authentication or metadata. The `__init__` method now accepts a headers argument, which is stored as an attribute and merged with any per-request headers passed to `_request_impl`.
	•	Updated the _request_impl method to merge default and request-specific headers.
	•	Added a headers parameter to the `__init__` method for flexible instantiation.
	•	This change was tested by connecting to a private XRPL server that required authentication using a custom header.

## High Level Overview of Change

This PR introduces support for custom header injection in the `JsonRpcBase` class. An optional headers parameter has been added to the `__init__` method, allowing users to specify HTTP headers to include in each `JSON-RPC` request. The `_request_impl` method also accepts an optional headers argument to override or add headers on a per-request basis.

This makes it easier to integrate `xrpl-py` with private infrastructure providers and secure environments, while maintaining full backward compatibility.

### Context of Change

This change is driven by the increasing use of XRPL infrastructure that relies on API key or header-based authentication—such as rate-limited services or internal infrastructure. Previously, `JsonRpcBase` did not support adding HTTP headers, limiting its usefulness in many production environments.

By making this update in the shared `json_rpc_base.py` layer, all inheriting classes benefit from the new feature. It allows for greater flexibility without impacting users who do not require any headers. Additionally, the per-request header support allows for advanced use cases like dynamic tokens, session headers, or monetized access.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### Did you update CHANGELOG.md?

- [x] Yes
- [ ] No, this change does not impact library users

## Test Plan

The change can be tested by:
	•	Connecting to a private XRPL server that requires authentication using a custom header and verifying that requests are processed successfully.
	•	Ensuring compatibility with public nodes by omitting the headers parameter, confirming that no issues arise when using unauthenticated connections.
	•	Passing request-specific headers to `_request_impl` and verifying that they are correctly merged with any global headers.
	•	Confirming that all existing requests function identically when headers are not used.

## Future Tasks
Future tasks related to this PR could include:
	•	Elevating header support to the top-level `Client` class to ensure WebSocket clients can also benefit from custom headers.