### PR TITLE
[auth] Add custom HTTP header support to clients (API key / payment)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add support for Batch (XLS-56) `BatchV1_1` signing.
+- Support for custom HTTP headers (e.g. API keys, Dhali payment-claims) on the base `Client`, `JsonRpcBase`, and `WebsocketBase` clients, plus `XRPLAuthenticationException` for 401/402/403 responses.
 
 ### Removed
 

--- a/tests/unit/asyn/clients/test_json_rpc_base.py
+++ b/tests/unit/asyn/clients/test_json_rpc_base.py
@@ -1,0 +1,95 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import Response
+
+from xrpl.asyncio.clients.exceptions import XRPLAuthenticationException
+from xrpl.asyncio.clients.json_rpc_base import JsonRpcBase
+from xrpl.models.requests import ServerInfo
+
+
+@pytest.mark.asyncio
+async def test_global_headers_are_sent():
+    client = JsonRpcBase(
+        "https://xrpl.fake", headers={"Authorization": "Bearer testtoken"}
+    )
+
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = Response(
+            status_code=200,
+            json={"result": {"status": "success"}, "id": 1},
+        )
+
+        await client._request_impl(ServerInfo())
+
+        headers_sent = mock_post.call_args.kwargs["headers"]
+        assert headers_sent["Authorization"] == "Bearer testtoken"
+        assert headers_sent["Content-Type"] == "application/json"
+
+
+@pytest.mark.asyncio
+async def test_per_request_headers_override_global():
+    client = JsonRpcBase(
+        "https://xrpl.fake", headers={"Authorization": "Bearer default"}
+    )
+
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = Response(
+            status_code=200,
+            json={"result": {"status": "success"}, "id": 1},
+        )
+
+        await client._request_impl(
+            ServerInfo(), headers={"Authorization": "Bearer override"}
+        )
+
+        headers_sent = mock_post.call_args.kwargs["headers"]
+        assert headers_sent["Authorization"] == "Bearer override"
+        assert headers_sent["Content-Type"] == "application/json"
+
+
+@pytest.mark.asyncio
+async def test_no_headers_does_not_crash():
+    client = JsonRpcBase("https://xrpl.fake")
+
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = Response(
+            status_code=200,
+            json={"result": {"status": "success"}, "id": 1},
+        )
+
+        await client._request_impl(ServerInfo())
+
+        headers_sent = mock_post.call_args.kwargs["headers"]
+        assert headers_sent["Content-Type"] == "application/json"
+
+
+@pytest.mark.asyncio
+async def test_content_type_cannot_be_overridden():
+    client = JsonRpcBase("https://xrpl.fake", headers={"Content-Type": "text/plain"})
+
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = Response(
+            status_code=200,
+            json={"result": {"status": "success"}, "id": 1},
+        )
+
+        await client._request_impl(ServerInfo(), headers={"Content-Type": "text/xml"})
+
+        headers_sent = mock_post.call_args.kwargs["headers"]
+        assert headers_sent["Content-Type"] == "application/json"
+
+
+@pytest.mark.asyncio
+async def test_raises_on_auth_or_payment_required():
+    client = JsonRpcBase("https://xrpl.fake")
+
+    for code in [401, 402, 403]:
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = Response(status_code=code, text="Rejected")
+
+            with pytest.raises(
+                XRPLAuthenticationException,
+                match="Authentication or payment required",
+            ):
+                await client._request_impl(ServerInfo())

--- a/tests/unit/asyn/clients/test_websocket_base.py
+++ b/tests/unit/asyn/clients/test_websocket_base.py
@@ -7,7 +7,9 @@ import json
 from contextlib import redirect_stdout
 from typing import List
 from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
 
+from xrpl.asyncio.clients import websocket_base
 from xrpl.asyncio.clients.async_websocket_client import AsyncWebsocketClient
 
 
@@ -85,3 +87,41 @@ class TestHandlerMalformedJson(IsolatedAsyncioTestCase):
         self.assertIn("malformed", output.lower())
         self.assertNotIn("req_1", output)
         self.assertNotIn("req_2", output)
+
+
+class TestWebsocketHeaders(IsolatedAsyncioTestCase):
+    """Custom header forwarding on the WebSocket handshake."""
+
+    async def test_forwards_headers_on_connect(self) -> None:
+        client = AsyncWebsocketClient(
+            "ws://test", headers={"Authorization": "Bearer testtoken"}
+        )
+
+        with patch.object(
+            websocket_base.websocket_client, "connect", new_callable=AsyncMock
+        ) as mock_connect:
+            mock_connect.return_value = _FakeWebSocket([])
+
+            await client._do_open()
+
+            self.assertEqual(
+                mock_connect.call_args.kwargs["additional_headers"],
+                {"Authorization": "Bearer testtoken"},
+            )
+
+            # _do_open spawned a handler task over the (empty) connection
+            client._handler_task.cancel()
+
+    async def test_no_headers_passes_none(self) -> None:
+        client = AsyncWebsocketClient("ws://test")
+
+        with patch.object(
+            websocket_base.websocket_client, "connect", new_callable=AsyncMock
+        ) as mock_connect:
+            mock_connect.return_value = _FakeWebSocket([])
+
+            await client._do_open()
+
+            self.assertIsNone(mock_connect.call_args.kwargs["additional_headers"])
+
+            client._handler_task.cancel()

--- a/xrpl/asyncio/clients/client.py
+++ b/xrpl/asyncio/clients/client.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Dict, Optional
 
 from typing_extensions import Final, Self
 
@@ -24,14 +24,26 @@ class Client(ABC):
     :meta private:
     """
 
-    def __init__(self: Self, url: str) -> None:
+    def __init__(
+        self: Self,
+        url: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> None:
         """
         Initializes a client.
 
         Arguments:
-            url: The url to which this client will connect
+            url: The URL to which this client will connect.
+            headers: Optional dictionary of default headers to include with
+                each request. These can be used to authenticate with private
+                XRPL nodes or pass custom metadata, such as
+                {"Authorization": "Bearer <token>"}.
         """
         self.url = url
+        # store an owned copy so later external mutation of the caller's dict
+        # cannot silently change the headers used for subsequent requests
+        self.headers = dict(headers) if headers else {}
         self.network_id: Optional[int] = None
         self.build_version: Optional[str] = None
 

--- a/xrpl/asyncio/clients/exceptions.py
+++ b/xrpl/asyncio/clients/exceptions.py
@@ -36,3 +36,13 @@ class XRPLWebsocketException(XRPLException):
     """
 
     pass
+
+
+class XRPLAuthenticationException(XRPLRequestFailureException):
+    """
+    Raised when the XRPL node rejects a request before processing it because
+    of missing or invalid credentials or payment: HTTP 401 (Unauthorized),
+    402 (Payment Required), or 403 (Forbidden).
+    """
+
+    pass

--- a/xrpl/asyncio/clients/json_rpc_base.py
+++ b/xrpl/asyncio/clients/json_rpc_base.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 from json import JSONDecodeError
+from typing import Dict, Optional
 
 from httpx import AsyncClient
 from typing_extensions import Self
 
 from xrpl.asyncio.clients.client import REQUEST_TIMEOUT, Client
-from xrpl.asyncio.clients.exceptions import XRPLRequestFailureException
+from xrpl.asyncio.clients.exceptions import (
+    XRPLAuthenticationException,
+    XRPLRequestFailureException,
+)
 from xrpl.asyncio.clients.utils import json_to_response, request_to_json_rpc
 from xrpl.models.requests.request import Request
 from xrpl.models.response import Response
@@ -21,8 +25,28 @@ class JsonRpcBase(Client):
     :meta private:
     """
 
+    def __init__(
+        self: Self,
+        url: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """
+        Initializes a new JsonRpcBase client.
+
+        Arguments:
+            url: The URL of the XRPL node to connect to.
+            headers: Optional default headers for all requests (e.g. an API key
+                or Dhali payment-claim).
+        """
+        super().__init__(url, headers=headers)
+
     async def _request_impl(
-        self: Self, request: Request, *, timeout: float = REQUEST_TIMEOUT
+        self: Self,
+        request: Request,
+        *,
+        timeout: float = REQUEST_TIMEOUT,
+        headers: Optional[Dict[str, str]] = None,
     ) -> Response:
         """
         Base ``_request_impl`` implementation for JSON RPC.
@@ -30,21 +54,42 @@ class JsonRpcBase(Client):
         Arguments:
             request: An object representing information about a rippled request.
             timeout: The duration within which we expect to hear a response from the
-            rippled validator.
+                rippled server.
+            headers: Optional additional headers to include for this request.
 
         Returns:
             The response from the server, as a Response object.
 
         Raises:
+            XRPLAuthenticationException: if the server responds with 401, 402,
+                or 403.
             XRPLRequestFailureException: if response can't be JSON decoded.
 
         :meta private:
         """
+        # Merge global and per-request headers. Content-Type is applied last
+        # so it cannot be overridden: the JSON-RPC body is always JSON.
+        merged_headers = {
+            **self.headers,
+            **(headers or {}),
+            "Content-Type": "application/json",
+        }
+
         async with AsyncClient(timeout=timeout) as http_client:
             response = await http_client.post(
                 self.url,
                 json=request_to_json_rpc(request),
+                headers=merged_headers,
             )
+            if response.status_code in (401, 402, 403):
+                raise XRPLAuthenticationException(
+                    {
+                        "error": response.status_code,
+                        "error_message": (
+                            f"Authentication or payment required: {response.text}"
+                        ),
+                    }
+                )
             try:
                 return json_to_response(response.json())
             except JSONDecodeError:
@@ -53,4 +98,4 @@ class JsonRpcBase(Client):
                         "error": response.status_code,
                         "error_message": response.text,
                     }
-                )
+                ) from None

--- a/xrpl/asyncio/clients/websocket_base.py
+++ b/xrpl/asyncio/clients/websocket_base.py
@@ -61,12 +61,19 @@ class WebsocketBase(Client):
     :meta private:
     """
 
-    def __init__(self: Self, url: str) -> None:
+    def __init__(
+        self: Self,
+        url: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> None:
         """
         Initializes a websocket client.
 
         Arguments:
             url: The URL of the rippled node to submit requests to.
+            headers: Optional default headers to include with the connection
+                handshake (e.g. an API key or Dhali payment-claim).
         """
         self._open_requests: _REQUESTS_TYPE = {}
         self._websocket: Optional[websocket_client.ClientConnection] = None
@@ -76,7 +83,7 @@ class WebsocketBase(Client):
         # will initialize a new event loop when it opens the connection, so for
         # that client the initializer cannot create the queue
         self._messages: Optional[_MESSAGES_TYPE] = None
-        super().__init__(url)
+        super().__init__(url, headers=headers)
 
     def is_open(self: Self) -> bool:
         """
@@ -96,7 +103,10 @@ class WebsocketBase(Client):
         """Connects the client to the Web Socket API at its URL."""
         # open the connection
         self._websocket = await websocket_client.connect(
-            self.url, max_size=_PAYLOAD_MAX_SIZE
+            self.url,
+            max_size=_PAYLOAD_MAX_SIZE,
+            # pass None when no headers were supplied to preserve default behavior
+            additional_headers=self.headers or None,
         )
 
         # make a message queue

--- a/xrpl/clients/websocket_client.py
+++ b/xrpl/clients/websocket_client.py
@@ -69,7 +69,11 @@ class WebsocketClient(SyncClient, WebsocketBase):
     """
 
     def __init__(
-        self: Self, url: str, timeout: Optional[Union[int, float]] = None
+        self: Self,
+        url: str,
+        timeout: Optional[Union[int, float]] = None,
+        *,
+        headers: Optional[Dict[str, str]] = None,
     ) -> None:
         """
         Constructs a WebsocketClient.
@@ -79,11 +83,13 @@ class WebsocketClient(SyncClient, WebsocketBase):
             timeout: Maximum seconds to wait for a new message when
                 iterating. A value of 0 or None will result in no limit.
                 If this limit is met, iteration will stop.
+            headers: Optional default headers to include with the connection
+                handshake (e.g. an API key or Dhali payment-claim).
         """
         self.timeout = timeout
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._thread: Optional[Thread] = None
-        super().__init__(url)
+        super().__init__(url, headers=headers)
 
     def is_open(self: Self) -> bool:
         """


### PR DESCRIPTION
## High Level Overview of Change

Adds support for sending custom HTTP headers (e.g. API keys or [Dhali](https://dhali.io/) payment-claims) when connecting to XRPL nodes that require authentication, payment, or metadata.

- Adds an optional `headers` argument to the base `Client`, `JsonRpcBase`, `WebsocketBase`, and the sync `WebsocketClient`. Headers are applied to all requests and, for JSON-RPC, can be overridden per request via `_request_impl`.
- The base `Client` stores an owned copy of the headers so later mutation of the caller's dict cannot silently change the headers used for subsequent requests.
- WebSocket clients forward the headers via `additional_headers` on the connection handshake.
- Forces `Content-Type: application/json` on JSON-RPC requests so a custom header cannot accidentally break the JSON body.
- Adds `XRPLAuthenticationException`, raised on `401` (Unauthorized), `402` (Payment Required), and `403` (Forbidden) JSON-RPC responses. The exception's `error` field carries the exact status code.

This consolidates work that was previously split across #763, #827, and #829 (all now closed) into this single PR.

### Context of Change

This is a new feature requested by node operators and infrastructure providers who gate access behind authentication or payment. Headers are added at the base `Client` level (rather than only on `JsonRpcBase`) so the same mechanism serves both the HTTP and WebSocket clients and any future client implementations. `402` handling was added so that Dhali's payment-claim rejections surface as a catchable exception.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

### Did you update CHANGELOG.md?

- [x] Yes

## Test Plan

New unit tests were added and all pass locally; `black`, `isort`, `flake8`, and `mypy` are clean.

- `tests/unit/asyn/clients/test_json_rpc_base.py`
  - Global headers are sent with the request, including the default `Content-Type`.
  - Per-request headers override instance-level headers.
  - No headers supplied still works (backward compatible) and keeps the default `Content-Type`.
  - `Content-Type` cannot be overridden by instance- or request-level headers.
  - `401`/`402`/`403` responses raise `XRPLAuthenticationException`.
- `tests/unit/asyn/clients/test_websocket_base.py`
  - The connection handshake forwards `additional_headers` when headers are provided.
  - `additional_headers` is `None` when no headers are provided (default behavior preserved).

Run with:

```
poetry run python -m pytest tests/unit/asyn/clients/
```
