### PR TITLE
expect tecNO_DELEGATE_PERMISSION error code instead of tecNO_PERMISSION

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
-      max-parallel: 1
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
+      max-parallel: 1
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 

--- a/.github/workflows/snippet_test.yml
+++ b/.github/workflows/snippet_test.yml
@@ -14,7 +14,6 @@ jobs:
     name: Snippet test
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 

--- a/.github/workflows/snippet_test.yml
+++ b/.github/workflows/snippet_test.yml
@@ -14,6 +14,7 @@ jobs:
     name: Snippet test
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 

--- a/tests/integration/sugar/test_wallet.py
+++ b/tests/integration/sugar/test_wallet.py
@@ -1,5 +1,8 @@
 import asyncio
+import time
 from threading import Thread
+
+import httpx
 
 from tests.integration.integration_test_case import IntegrationTestCase
 from tests.integration.it_utils import submit_transaction_async
@@ -12,11 +15,50 @@ from xrpl.models.transactions import Payment
 from xrpl.wallet import generate_faucet_wallet as sync_generate_faucet_wallet
 from xrpl.wallet.main import Wallet
 
+# Add retry logic for wallet funding to handle newly introduced faucet rate limiting.
+MAX_RETRY_DURATION = 600  # 10 minutes
+INITIAL_BACKOFF = 1  # 1 second
+MAX_BACKOFF = 30  # max wait between retries
+
+
+async def generate_faucet_wallet_with_retry(*args, **kwargs):
+    start_time = time.monotonic()
+    backoff = INITIAL_BACKOFF
+
+    while True:
+        try:
+            return await generate_faucet_wallet(*args, **kwargs)
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code != 503 or e.response.status_code != 429:
+                raise
+            elapsed = time.monotonic() - start_time
+            if elapsed > MAX_RETRY_DURATION:
+                raise TimeoutError("Faucet funding failed after 10 minutes.") from e
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, MAX_BACKOFF)
+
+
+def sync_generate_faucet_wallet_with_retry(*args, **kwargs):
+    start_time = time.monotonic()
+    backoff = INITIAL_BACKOFF
+
+    while True:
+        try:
+            return sync_generate_faucet_wallet(*args, **kwargs)
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code != 503 or e.response.status_code != 429:
+                raise
+            elapsed = time.monotonic() - start_time
+            if elapsed > MAX_RETRY_DURATION:
+                raise TimeoutError("Faucet funding failed after 10 minutes.") from e
+            time.sleep(backoff)
+            backoff = min(backoff * 2, MAX_BACKOFF)
+
 
 def sync_generate_faucet_wallet_and_fund_again(
     self, client, faucet_host=None, usage_context="integration_test"
 ):
-    wallet = sync_generate_faucet_wallet(
+    wallet = sync_generate_faucet_wallet_with_retry(
         client, faucet_host=faucet_host, usage_context=usage_context
     )
     result = client.request(
@@ -27,7 +69,7 @@ def sync_generate_faucet_wallet_and_fund_again(
     balance = int(result.result["account_data"]["Balance"])
     self.assertTrue(balance > 0)
 
-    new_wallet = sync_generate_faucet_wallet(
+    new_wallet = sync_generate_faucet_wallet_with_retry(
         client, wallet, faucet_host=faucet_host, usage_context="integration_test"
     )
     new_result = client.request(
@@ -42,7 +84,7 @@ def sync_generate_faucet_wallet_and_fund_again(
 async def generate_faucet_wallet_and_fund_again(
     self, client, faucet_host=None, usage_context="integration_test"
 ):
-    wallet = await generate_faucet_wallet(
+    wallet = await generate_faucet_wallet_with_retry(
         client, faucet_host=faucet_host, usage_context=usage_context
     )
     result = await client.request(
@@ -53,7 +95,7 @@ async def generate_faucet_wallet_and_fund_again(
     balance = int(result.result["account_data"]["Balance"])
     self.assertTrue(balance > 0)
 
-    new_wallet = await generate_faucet_wallet(
+    new_wallet = await generate_faucet_wallet_with_retry(
         client, wallet, faucet_host=faucet_host, usage_context=usage_context
     )
     new_result = await client.request(

--- a/tests/integration/sugar/test_wallet.py
+++ b/tests/integration/sugar/test_wallet.py
@@ -29,7 +29,7 @@ async def generate_faucet_wallet_with_retry(*args, **kwargs):
         try:
             return await generate_faucet_wallet(*args, **kwargs)
         except httpx.HTTPStatusError as e:
-            if e.response.status_code != 503 or e.response.status_code != 429:
+            if e.response.status_code not in (503, 429):
                 raise
             elapsed = time.monotonic() - start_time
             if elapsed > MAX_RETRY_DURATION:
@@ -46,7 +46,7 @@ def sync_generate_faucet_wallet_with_retry(*args, **kwargs):
         try:
             return sync_generate_faucet_wallet(*args, **kwargs)
         except httpx.HTTPStatusError as e:
-            if e.response.status_code != 503 or e.response.status_code != 429:
+            if e.response.status_code not in (503, 429):
                 raise
             elapsed = time.monotonic() - start_time
             if elapsed > MAX_RETRY_DURATION:

--- a/tests/integration/transactions/test_delegate_set.py
+++ b/tests/integration/transactions/test_delegate_set.py
@@ -42,8 +42,9 @@ class TestDelegateSet(IntegrationTestCase):
         )
         self.assertEqual(response.status, ResponseStatus.SUCCESS)
 
-        # The lack of AccountPermissionSet transaction will result in a tecNO_PERMISSION
-        self.assertEqual(response.result["engine_result"], "tecNO_PERMISSION")
+        # Sending a transaction without a delegate permission results in
+        # tecNO_DELEGATE_PERMISSION
+        self.assertEqual(response.result["engine_result"], "tecNO_DELEGATE_PERMISSION")
 
     @test_async_and_sync(globals())
     async def test_delegate_set_workflow(self, client):
@@ -99,7 +100,7 @@ class TestDelegateSet(IntegrationTestCase):
             account_set, bob, client, check_fee=False
         )
         self.assertEqual(response.status, ResponseStatus.SUCCESS)
-        self.assertEqual(response.result["engine_result"], "tecNO_PERMISSION")
+        self.assertEqual(response.result["engine_result"], "tecNO_DELEGATE_PERMISSION")
 
         # test ledger entry
         ledger_entry_response = await client.request(

--- a/xrpl/asyncio/wallet/wallet_generation.py
+++ b/xrpl/asyncio/wallet/wallet_generation.py
@@ -216,30 +216,13 @@ async def _request_funding(
     usage_context: Optional[str] = None,
     user_agent: Optional[str] = None,
 ) -> None:
-    max_backoff_time = 600  # 10 minutes
-    backoff = 5  # Initial backoff in seconds
-
-    async def make_request() -> httpx.Response:
-        async with httpx.AsyncClient() as http_client:
-            json_body = {"destination": address, "userAgent": user_agent}
-            if usage_context is not None:
-                json_body["usageContext"] = usage_context
-            return await http_client.post(url=url, json=json_body)
-
-    while True:
-        response = await make_request()
-        if response.status_code == httpx.codes.OK:
-            return
-
-        if response.status_code >= 500:
-            if backoff > max_backoff_time:
-                break
-            await asyncio.sleep(backoff)
-            backoff *= 2
-        else:
-            response.raise_for_status()
-
-    response.raise_for_status()
+    async with httpx.AsyncClient() as http_client:
+        json_body = {"destination": address, "userAgent": user_agent}
+        if usage_context is not None:
+            json_body["usageContext"] = usage_context
+        response = await http_client.post(url=url, json=json_body)
+    if not response.status_code == httpx.codes.OK:
+        response.raise_for_status()
 
 
 async def _try_to_get_next_seq(address: str, client: Client) -> Optional[int]:

--- a/xrpl/asyncio/wallet/wallet_generation.py
+++ b/xrpl/asyncio/wallet/wallet_generation.py
@@ -216,13 +216,31 @@ async def _request_funding(
     usage_context: Optional[str] = None,
     user_agent: Optional[str] = None,
 ) -> None:
-    async with httpx.AsyncClient() as http_client:
-        json_body = {"destination": address, "userAgent": user_agent}
-        if usage_context is not None:
-            json_body["usageContext"] = usage_context
-        response = await http_client.post(url=url, json=json_body)
-    if not response.status_code == httpx.codes.OK:
-        response.raise_for_status()
+    max_backoff_time = 300  # 5 minutes
+    backoff = 5  # Initial backoff in seconds
+
+    async def make_request() -> httpx.Response:
+        async with httpx.AsyncClient() as http_client:
+            json_body = {"destination": address, "userAgent": user_agent}
+            if usage_context is not None:
+                json_body["usageContext"] = usage_context
+            return await http_client.post(url=url, json=json_body)
+
+    while True:
+        response = await make_request()
+        if response.status_code == httpx.codes.OK:
+            return
+
+        if response.status_code >= 500:
+            if backoff > max_backoff_time:
+                break
+            await asyncio.sleep(backoff)
+            backoff *= 2
+        else:
+            response.raise_for_status()
+
+    # Final attempt failed after backoff
+    response.raise_for_status()
 
 
 async def _try_to_get_next_seq(address: str, client: Client) -> Optional[int]:

--- a/xrpl/asyncio/wallet/wallet_generation.py
+++ b/xrpl/asyncio/wallet/wallet_generation.py
@@ -216,31 +216,13 @@ async def _request_funding(
     usage_context: Optional[str] = None,
     user_agent: Optional[str] = None,
 ) -> None:
-    max_backoff_time = 300  # 5 minutes
-    backoff = 5  # Initial backoff in seconds
-
-    async def make_request() -> httpx.Response:
-        async with httpx.AsyncClient() as http_client:
-            json_body = {"destination": address, "userAgent": user_agent}
-            if usage_context is not None:
-                json_body["usageContext"] = usage_context
-            return await http_client.post(url=url, json=json_body)
-
-    while True:
-        response = await make_request()
-        if response.status_code == httpx.codes.OK:
-            return
-
-        if response.status_code >= 500:
-            if backoff > max_backoff_time:
-                break
-            await asyncio.sleep(backoff)
-            backoff *= 2
-        else:
-            response.raise_for_status()
-
-    # Final attempt failed after backoff
-    response.raise_for_status()
+    async with httpx.AsyncClient() as http_client:
+        json_body = {"destination": address, "userAgent": user_agent}
+        if usage_context is not None:
+            json_body["usageContext"] = usage_context
+        response = await http_client.post(url=url, json=json_body)
+    if not response.status_code == httpx.codes.OK:
+        response.raise_for_status()
 
 
 async def _try_to_get_next_seq(address: str, client: Client) -> Optional[int]:

--- a/xrpl/core/binarycodec/definitions/definitions.json
+++ b/xrpl/core/binarycodec/definitions/definitions.json
@@ -941,6 +941,16 @@
       }
     ],
     [
+      "LockedAmount",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 29,
+        "type": "UInt64"
+      }
+    ],
+    [
       "EmailHash",
       {
         "isSerialized": true,
@@ -1267,6 +1277,26 @@
         "isSigningField": true,
         "isVLEncoded": false,
         "nth": 34,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "VaultID",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 35,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "ParentBatchID",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 36,
         "type": "Hash256"
       }
     ],
@@ -2061,6 +2091,46 @@
       }
     ],
     [
+      "AssetsAvailable",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 2,
+        "type": "Number"
+      }
+    ],
+    [
+      "AssetsMaximum",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 3,
+        "type": "Number"
+      }
+    ],
+    [
+      "AssetsTotal",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 4,
+        "type": "Number"
+      }
+    ],
+    [
+      "LossUnrealized",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 5,
+        "type": "Number"
+      }
+    ],
+    [
       "TransactionMetaData",
       {
         "isSerialized": true,
@@ -2371,6 +2441,36 @@
       }
     ],
     [
+      "RawTransaction",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 34,
+        "type": "STObject"
+      }
+    ],
+    [
+      "BatchSigner",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 35,
+        "type": "STObject"
+      }
+    ],
+    [
+      "Book",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 36,
+        "type": "STObject"
+      }
+    ],
+    [
       "Signers",
       {
         "isSerialized": true,
@@ -2467,6 +2567,16 @@
         "isSigningField": true,
         "isVLEncoded": false,
         "nth": 12,
+        "type": "STArray"
+      }
+    ],
+    [
+      "AdditionalBooks",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 13,
         "type": "STArray"
       }
     ],
@@ -2601,6 +2711,26 @@
       }
     ],
     [
+      "RawTransactions",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 30,
+        "type": "STArray"
+      }
+    ],
+    [
+      "BatchSigners",
+      {
+        "isSerialized": true,
+        "isSigningField": false,
+        "isVLEncoded": false,
+        "nth": 31,
+        "type": "STArray"
+      }
+    ],
+    [
       "CloseResolution",
       {
         "isSerialized": true,
@@ -2687,6 +2817,16 @@
         "isSigningField": true,
         "isVLEncoded": false,
         "nth": 19,
+        "type": "UInt8"
+      }
+    ],
+    [
+      "WithdrawalPolicy",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 20,
         "type": "UInt8"
       }
     ],
@@ -2797,6 +2937,16 @@
         "isSigningField": true,
         "isVLEncoded": false,
         "nth": 1,
+        "type": "Hash192"
+      }
+    ],
+    [
+      "ShareMPTID",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 2,
         "type": "Hash192"
       }
     ],
@@ -2938,6 +3088,7 @@
     "RippleState": 114,
     "SignerList": 83,
     "Ticket": 84,
+    "Vault": 132,
     "XChainOwnedClaimID": 113,
     "XChainOwnedCreateAccountClaimID": 116
   },
@@ -2974,6 +3125,7 @@
     "tecINVALID_UPDATE_TIME": 188,
     "tecINVARIANT_FAILED": 147,
     "tecKILLED": 150,
+    "tecLIMIT_EXCEEDED": 195,
     "tecLOCKED": 192,
     "tecMAX_SEQUENCE_REACHED": 154,
     "tecNEED_MASTER_KEY": 142,
@@ -2981,6 +3133,7 @@
     "tecNFTOKEN_OFFER_TYPE_MISMATCH": 157,
     "tecNO_ALTERNATIVE_KEY": 130,
     "tecNO_AUTH": 134,
+    "tecNO_DELEGATE_PERMISSION": 198,
     "tecNO_DST": 124,
     "tecNO_DST_INSUF_XRP": 125,
     "tecNO_ENTRY": 140,
@@ -2997,6 +3150,8 @@
     "tecOWNERS": 132,
     "tecPATH_DRY": 128,
     "tecPATH_PARTIAL": 101,
+    "tecPRECISION_LOSS": 197,
+    "tecPSEUDO_ACCOUNT": 196,
     "tecTOKEN_PAIR_NOT_FOUND": 189,
     "tecTOO_SOON": 152,
     "tecUNFUNDED": 129,
@@ -3004,6 +3159,7 @@
     "tecUNFUNDED_AMM": 162,
     "tecUNFUNDED_OFFER": 103,
     "tecUNFUNDED_PAYMENT": 104,
+    "tecWRONG_ASSET": 194,
     "tecXCHAIN_ACCOUNT_CREATE_PAST": 181,
     "tecXCHAIN_ACCOUNT_CREATE_TOO_MANY": 182,
     "tecXCHAIN_BAD_CLAIM_ID": 172,
@@ -3100,6 +3256,7 @@
     "temINVALID_ACCOUNT_ID": -268,
     "temINVALID_COUNT": -266,
     "temINVALID_FLAG": -276,
+    "temINVALID_INNER_BATCH": -250,
     "temMALFORMED": -299,
     "temREDUNDANT": -275,
     "temRIPPLE_EMPTY": -274,
@@ -3113,6 +3270,7 @@
     "temXCHAIN_BRIDGE_NONDOOR_OWNER": -257,
     "temXCHAIN_EQUAL_DOOR_ACCOUNTS": -260,
 
+    "terADDRESS_COLLISION": -86,
     "terFUNDS_SPENT": -98,
     "terINSUF_FEE_B": -97,
     "terLAST": -91,
@@ -3139,6 +3297,7 @@
     "AMMWithdraw": 37,
     "AccountDelete": 21,
     "AccountSet": 3,
+    "Batch": 71,
     "CheckCancel": 18,
     "CheckCash": 17,
     "CheckCreate": 16,
@@ -3182,6 +3341,12 @@
     "TicketCreate": 10,
     "TrustSet": 20,
     "UNLModify": 102,
+    "VaultClawback": 70,
+    "VaultCreate": 65,
+    "VaultDelete": 67,
+    "VaultDeposit": 68,
+    "VaultSet": 66,
+    "VaultWithdraw": 69,
     "XChainAccountCreateCommit": 44,
     "XChainAddAccountCreateAttestation": 46,
     "XChainAddClaimAttestation": 45,


### PR DESCRIPTION
## High Level Overview of Change

1. tecNO_DELEGATE_PERMISSION is returned instead of tecNO_PERMISSION when a transaction is executed by B on behalf of A without having A delegated permissions to B.

2. Add backoff retry logic to `test_wallet` IT that timeouts after 10 minutes to account errors due to new introduced rate limiting on testnet faucet.

3. Execute integration tests and snippets jobs one at a time.

4. Execute snippets only on merge to `main` branch.

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

To account for failing integration tests due to stricter rate limiting on testnet faucet.

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update CHANGELOG.md?

- [ ] Yes
- [ ] No, this change does not impact library users

## Test Plan
Fixed the integration tests.
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
