### PR TITLE
feat: add support for Permissioned DEX (XLS-81)

### DIFF
--- a/.ci-config/rippled.cfg
+++ b/.ci-config/rippled.cfg
@@ -202,9 +202,8 @@ PermissionedDomains
 SingleAssetVault
 fixFrozenLPTokenTransfer
 fixInvalidTxFlags
-
-# 2.5.0 Amendments
 PermissionDelegation
+PermissionedDEX
 Batch
 TokenEscrow
 

--- a/tests/unit/models/transactions/test_offer_create.py
+++ b/tests/unit/models/transactions/test_offer_create.py
@@ -1,0 +1,58 @@
+from unittest import TestCase
+
+from xrpl.models.exceptions import XRPLModelException
+from xrpl.models.transactions.offer_create import OfferCreate, OfferCreateFlag
+
+_ACCOUNT = "r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ"
+_TAKER_GETS = {
+    "currency": "USD",
+    "issuer": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+    "value": "100",
+}
+_TAKER_PAYS = {
+    "currency": "EUR",
+    "issuer": "rJ4EpEPTDR88GpXvix3Y1djATCsDn41ixp",
+    "value": "90",
+}
+
+
+class TestOfferCreate(TestCase):
+    def test_offer_create_valid(self):
+        tx = OfferCreate(
+            account=_ACCOUNT,
+            taker_gets=_TAKER_GETS,
+            taker_pays=_TAKER_PAYS,
+        )
+        self.assertTrue(tx.is_valid())
+
+    def test_offer_create_hybrid_flag_without_domain_id(self):
+        """
+        A hybrid offer (tfHybrid flag set) should require domain_id.
+        If domain_id is missing, is_valid() should be False and an error should be
+        present.
+        """
+        with self.assertRaises(XRPLModelException) as error:
+            OfferCreate(
+                account=_ACCOUNT,
+                taker_gets=_TAKER_GETS,
+                taker_pays=_TAKER_PAYS,
+                flags=OfferCreateFlag.TF_HYBRID,
+                domain_id=None,
+            )
+        self.assertEqual(
+            error.exception.args[0],
+            "{'domain_id': 'Hybrid offer (tfHybrid flag) requires domain_id to be set.'"
+            "}",
+        )
+
+    def test_offer_create_hybrid_flag_with_domain_id(self):
+        """
+        A hybrid offer (tfHybrid flag set) with domain_id should pass validation.
+        """
+        OfferCreate(
+            account=_ACCOUNT,
+            taker_gets=_TAKER_GETS,
+            taker_pays=_TAKER_PAYS,
+            flags=OfferCreateFlag.TF_HYBRID,
+            domain_id="ABCDEF1234567890",
+        )


### PR DESCRIPTION
## High Level Overview of Change

Adds support for Permissioned DEX (XLS-81).

### Context of Change

[Spec](https://github.com/XRPLF/XRPL-Standards/blob/56ba122be9f127c940fd37d433faaa2de91a4eb6/XLS-0081d-permissioned-dex/README.md)

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update CHANGELOG.md?

- [x] Yes
- [ ] No, this change does not impact library users

## Test Plan

Adds unit and integ tests.
