### PR TITLE
fix: rectify `STIssue` codec (`MPTCurrency` case only)

### DIFF
--- a/tests/unit/core/binarycodec/types/test_account_id.py
+++ b/tests/unit/core/binarycodec/types/test_account_id.py
@@ -22,3 +22,25 @@ class TestAccountID(TestCase):
     def test_raises_invalid_value_type(self):
         invalid_value = 30
         self.assertRaises(XRPLBinaryCodecException, AccountID.from_value, invalid_value)
+
+    def test_special_account_ACCOUNT_ONE(self):
+        self.assertEqual(
+            AccountID.from_value("0000000000000000000000000000000000000001").to_json(),
+            "rrrrrrrrrrrrrrrrrrrrBZbvji",
+        )
+
+        self.assertEqual(
+            AccountID.from_value("rrrrrrrrrrrrrrrrrrrrBZbvji").to_hex(),
+            AccountID.from_value("0000000000000000000000000000000000000001").to_hex(),
+        )
+
+    def test_special_account_ACCOUNT_ZERO(self):
+        self.assertEqual(
+            AccountID.from_value("0000000000000000000000000000000000000000").to_json(),
+            "rrrrrrrrrrrrrrrrrrrrrhoLvTp",
+        )
+
+        self.assertEqual(
+            AccountID.from_value("rrrrrrrrrrrrrrrrrrrrrhoLvTp").to_hex(),
+            AccountID.from_value("0000000000000000000000000000000000000000").to_hex(),
+        )

--- a/xrpl/core/binarycodec/types/issue.py
+++ b/xrpl/core/binarycodec/types/issue.py
@@ -10,8 +10,9 @@ from xrpl.core.binarycodec.binary_wrappers.binary_parser import BinaryParser
 from xrpl.core.binarycodec.exceptions import XRPLBinaryCodecException
 from xrpl.core.binarycodec.types.account_id import AccountID
 from xrpl.core.binarycodec.types.currency import Currency
-from xrpl.core.binarycodec.types.hash192 import HASH192_BYTES, Hash192
+from xrpl.core.binarycodec.types.hash192 import Hash192
 from xrpl.core.binarycodec.types.serialized_type import SerializedType
+from xrpl.core.binarycodec.types.uint32 import UInt32
 from xrpl.models.currencies import XRP as XRPModel
 from xrpl.models.currencies import IssuedCurrency as IssuedCurrencyModel
 from xrpl.models.currencies import MPTCurrency as MPTCurrencyModel
@@ -19,6 +20,10 @@ from xrpl.models.currencies import MPTCurrency as MPTCurrencyModel
 
 class Issue(SerializedType):
     """Codec for serializing and deserializing issued currency fields."""
+
+    BLACK_HOLED_ACCOUNT_ID = AccountID.from_value(
+        "0000000000000000000000000000000000000001"
+    )
 
     def __init__(self: Self, buffer: bytes) -> None:
         """
@@ -54,9 +59,26 @@ class Issue(SerializedType):
             issuer_bytes = bytes(AccountID.from_value(value["issuer"]))
             return cls(currency_bytes + issuer_bytes)
 
+        # MPT is serialized as:
+        # - 160 bits MPT issuer account (20 bytes)
+        # - 160 bits black hole account (20 bytes)
+        # - 32 bits sequence (4 bytes)
+        # Please look at STIssue.cpp inside rippled implementation for more details.
+
         if MPTCurrencyModel.is_dict_of_model(value):
+            if len(value["mpt_issuance_id"]) != 48:
+                raise XRPLBinaryCodecException(
+                    "Invalid mpt_issuance_id length: expected 48 characters, "
+                    f"received {len(value['mpt_issuance_id'])} characters."
+                )
             mpt_issuance_id_bytes = bytes(Hash192.from_value(value["mpt_issuance_id"]))
-            return cls(bytes(mpt_issuance_id_bytes))
+            return cls(
+                bytes(
+                    mpt_issuance_id_bytes[:20]
+                    + bytes(cls.BLACK_HOLED_ACCOUNT_ID)
+                    + bytes(mpt_issuance_id_bytes[20:])
+                )
+            )
 
         raise XRPLBinaryCodecException(
             "Invalid type to construct an Issue: expected XRP, IssuedCurrency or "
@@ -80,17 +102,26 @@ class Issue(SerializedType):
         Returns:
             The Issue object constructed from a parser.
         """
-        # Check if it's an MPTIssue by checking mpt_issuance_id byte size
-        if length_hint == HASH192_BYTES:
-            mpt_bytes = parser.read(HASH192_BYTES)
-            return cls(mpt_bytes)
+        currency_or_account = Currency.from_parser(parser)
+        if currency_or_account.to_json() == "XRP":
+            return cls(bytes(currency_or_account))
 
-        currency = Currency.from_parser(parser)
-        if currency.to_json() == "XRP":
-            return cls(bytes(currency))
+        # check if this is an instance of MPTIssuanceID
+        issuer_account_id = AccountID.from_parser(parser)
+        if issuer_account_id.to_json() == cls.BLACK_HOLED_ACCOUNT_ID.to_json():
+            sequence = UInt32.from_parser(parser)
+            return cls(
+                bytes(currency_or_account)
+                + bytes(cls.BLACK_HOLED_ACCOUNT_ID)
+                + bytes(sequence)
+            )
 
-        issuer = parser.read(20)  # the length in bytes of an account ID
-        return cls(bytes(currency) + issuer)
+        return cls(bytes(currency_or_account) + bytes(issuer_account_id))
+
+    @classmethod
+    def _print_buffer(self: Self, buffer: bytes) -> None:
+        print("DEBUG: Inside Issue._print_buffer(), buffer: ", buffer.hex().upper())
+        print("DEBUG: Inside Issue._print_buffer(), buffer length: ", len(buffer))
 
     def to_json(self: Self) -> Union[str, Dict[Any, Any]]:
         """
@@ -99,9 +130,16 @@ class Issue(SerializedType):
         Returns:
             The JSON representation of an Issue.
         """
-        # If the buffer is exactly 24 bytes, treat it as an MPT amount.
-        if len(self.buffer) == HASH192_BYTES:
-            return {"mpt_issuance_id": self.to_hex().upper()}
+        # If the buffer's length is 44 bytes (issuer-account + black-hole-account-id +
+        # sequence), treat it as a MPTCurrency.
+        # Note: hexadecimal representation of the buffer's length is doubled because 1
+        # byte is represented by 2 characters in hex.
+        if len(self.buffer) == 20 + 20 + 4:
+            serialized_mpt_in_hex = self.to_hex().upper()
+            return {
+                "mpt_issuance_id": serialized_mpt_in_hex[:40]
+                + serialized_mpt_in_hex[80:]
+            }
 
         parser = BinaryParser(self.to_hex())
         currency: Union[str, Dict[Any, Any]] = Currency.from_parser(parser).to_json()


### PR DESCRIPTION
## High Level Overview of Change

This PR aims to fix this issue: https://github.com/XRPLF/xrpl-py/issues/869 

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
The `MPTCurrency` type is not being serialized correctly. The present serialized version of the field is not compatible with the XRPL Binary Format standards, hence it is un-parsable by rippled.
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update CHANGELOG.md?

- [ ] Yes
- [x] Not yet. I'll update the CL once I address a round of reviews.

## Test Plan
Additional unit tests have been added to the binary-codec module.

The unit tests for the AccountID rippled internal type have been enhanced to identify special accounts (`ACCOUNT_ZERO` and `ACCOUNT_ONE`)
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
