### PR TITLE
ci: add Python 3.14

### DIFF
--- a/.github/workflows/faucet_test.yml
+++ b/.github/workflows/faucet_test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## High Level Overview of Change

This PR adds support for Python 3.14 to CI, to ensure that everything works as expected.

### Context of Change

3.14 [just came out](https://endoflife.date/python)

### Type of Change

- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

### Did you update CHANGELOG.md?

- [ ] Yes
- [x] No, this change does not impact library users

## Test Plan

CI passes.
