### PR TITLE
Fix failing Integration Test workflow

### DIFF
--- a/.ci-config/rippled.cfg
+++ b/.ci-config/rippled.cfg
@@ -113,7 +113,6 @@ validators.txt
 # Devnet amendments as of June 28th, 2023
 NegativeUNL
 fixRemoveNFTokenAutoTrustLine
-NonFungibleTokensV1
 CheckCashMakesTrustLine
 fixRmSmallIncreasedQOffers
 fixSTAmountCanonicalize
@@ -202,7 +201,7 @@ PermissionedDomains
 SingleAssetVault
 fixFrozenLPTokenTransfer
 fixInvalidTxFlags
-PermissionDelegation
+PermissionDelegationV1_1
 PermissionedDEX
 Batch
 TokenEscrow

--- a/tests/integration/transactions/test_delegate_set.py
+++ b/tests/integration/transactions/test_delegate_set.py
@@ -43,8 +43,8 @@ class TestDelegateSet(IntegrationTestCase):
         self.assertEqual(response.status, ResponseStatus.SUCCESS)
 
         # Sending a transaction without a delegate permission results in
-        # tecNO_DELEGATE_PERMISSION
-        self.assertEqual(response.result["engine_result"], "tecNO_DELEGATE_PERMISSION")
+        # terNO_DELEGATE_PERMISSION
+        self.assertEqual(response.result["engine_result"], "terNO_DELEGATE_PERMISSION")
 
     @test_async_and_sync(globals())
     async def test_delegate_set_workflow(self, client):
@@ -100,7 +100,7 @@ class TestDelegateSet(IntegrationTestCase):
             account_set, bob, client, check_fee=False
         )
         self.assertEqual(response.status, ResponseStatus.SUCCESS)
-        self.assertEqual(response.result["engine_result"], "tecNO_DELEGATE_PERMISSION")
+        self.assertEqual(response.result["engine_result"], "terNO_DELEGATE_PERMISSION")
 
         # test ledger entry
         ledger_entry_response = await client.request(


### PR DESCRIPTION


## High Level Overview of Change
The title of the erstwhile `PermissionDelegation` amendment has been updated in the latest version of the rippled code. [Here is the source](https://github.com/XRPLF/rippled/blob/098eadca0af3bdf543dd83c642ec8264cc05ba6a/include/xrpl/protocol/detail/features.macro#L14).

A corresponding change has been made in the xrpl-py integration tests as well.`terNO_DELEGATE_PERMISSION` error code is used instead of `tecNO_DELEGATE_PERMISSION`.

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->


<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update CHANGELOG.md?

- [ ] Yes
- [x] No, this change does not impact library users

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

The existing integ tests have been updated to accomodate the new behavior of rippled.

<!--
## Future Tasks
For future tasks related to PR.
-->
