### PR TITLE
Fix error in account_objects request type filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [[Unreleased]]
 
+### Fixed
+- Fix [error in the type filter](https://github.com/XRPLF/xrpl-py/issues/888) of the account_objects request.
+
 ## [[4.4.0]] - 2025-12-16
 
 ### Added

--- a/tests/integration/reqs/test_account_objects.py
+++ b/tests/integration/reqs/test_account_objects.py
@@ -13,3 +13,24 @@ class TestAccountObjects(IntegrationTestCase):
             )
         )
         self.assertTrue(response.is_successful())
+
+    @test_async_and_sync(globals())
+    async def test_type_filter(self, client):
+        response = await client.request(
+            AccountObjects(
+                account=WALLET.address,
+                type="Escrow",
+            )
+        )
+        self.assertTrue(response.is_successful())
+        self.assertIsNotNone(response.result["account_objects"])
+
+        # test case-insensitive type filter
+        response = await client.request(
+            AccountObjects(
+                account=WALLET.address,
+                type="mPtOkeNisSuance",
+            )
+        )
+        self.assertTrue(response.is_successful())
+        self.assertIsNotNone(response.result["account_objects"])

--- a/xrpl/models/requests/account_objects.py
+++ b/xrpl/models/requests/account_objects.py
@@ -9,7 +9,7 @@ AccountLinesRequest instead.
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from xrpl.models.requests.request import LookupByLedgerRequest, Request, RequestMethod
 from xrpl.models.required import REQUIRED
@@ -65,7 +65,7 @@ class AccountObjects(Request, LookupByLedgerRequest):
     """
 
     method: RequestMethod = field(default=RequestMethod.ACCOUNT_OBJECTS, init=False)
-    type: Optional[AccountObjectType] = None
+    type: Optional[Union[AccountObjectType, str]] = None
     deletion_blockers_only: bool = False
     limit: Optional[int] = None
     # marker data shape is actually undefined in the spec, up to the


### PR DESCRIPTION


## High Level Overview of Change
fix #888: Allow canonical case-insensitive ledger-object names in type filter. Please refer to the issue description for more context on this issue.

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->



<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update CHANGELOG.md?

- [x] Yes
- [ ] No, this change does not impact library users

## Test Plan

Added a new test with canonical `str` inputs to the type filer in the `account_objects` request.

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
