### PR TITLE
feat(binarycodec): add DefinitionsRegistry with contextvars support

### DIFF
--- a/tests/unit/core/binarycodec/test_definition_service.py
+++ b/tests/unit/core/binarycodec/test_definition_service.py
@@ -8,24 +8,23 @@ class TestDefinitionService(TestCase):
         self.test_field_name = "Sequence"
 
     def test_load_definitions(self):
+        loaded = definitions.load_definitions()
         expected_keys = ["TYPES", "FIELDS", "TRANSACTION_RESULTS", "TRANSACTION_TYPES"]
         for key in expected_keys:
-            self.assertIn(key, definitions._DEFINITIONS)
+            self.assertIn(key, loaded)
 
     def test_inverse_transaction_type_map(self):
         transaction_type_code = 8
         expected_transaction_type = "OfferCancel"
-        transaction_type = definitions._TRANSACTION_TYPE_CODE_TO_STR_MAP[
-            transaction_type_code
-        ]
+        transaction_type = definitions.get_transaction_type_name(transaction_type_code)
         self.assertEqual(expected_transaction_type, transaction_type)
 
     def test_inverse_transaction_result_map(self):
         transaction_result_code = 0
         expected_transaction_result = "tesSUCCESS"
-        transaction_result = definitions._TRANSACTION_RESULTS_CODE_TO_STR_MAP[
+        transaction_result = definitions.get_transaction_result_name(
             transaction_result_code
-        ]
+        )
         self.assertEqual(expected_transaction_result, transaction_result)
 
     def test_get_field_type_name(self):

--- a/xrpl/core/binarycodec/definitions/__init__.py
+++ b/xrpl/core/binarycodec/definitions/__init__.py
@@ -1,6 +1,8 @@
 """Handles the XRPL type and definition specifics."""
 
 from xrpl.core.binarycodec.definitions.definitions import (
+    DEFAULT_GRANULAR_PERMISSIONS,
+    DefinitionsRegistry,
     get_field_header_from_name,
     get_field_instance,
     get_field_name_from_header,
@@ -13,21 +15,29 @@ from xrpl.core.binarycodec.definitions.definitions import (
     get_transaction_type_code,
     get_transaction_type_name,
     load_definitions,
-    update_definitions,
+    set_default_registry,
+    using_definitions,
 )
 from xrpl.core.binarycodec.definitions.field_header import FieldHeader
 from xrpl.core.binarycodec.definitions.field_info import FieldInfo
 from xrpl.core.binarycodec.definitions.field_instance import FieldInstance
 
 __all__ = [
+    # Classes
+    "DefinitionsRegistry",
     "FieldHeader",
     "FieldInfo",
     "FieldInstance",
+    # Registry management
     "load_definitions",
-    "update_definitions",
+    "set_default_registry",
+    "using_definitions",
+    "DEFAULT_GRANULAR_PERMISSIONS",
+    # Field lookups
     "get_field_header_from_name",
     "get_field_name_from_header",
     "get_field_instance",
+    # Type lookups
     "get_ledger_entry_type_code",
     "get_ledger_entry_type_name",
     "get_transaction_result_code",


### PR DESCRIPTION
## Summary

Two commits introducing configurable definitions for the binary codec:

### Commit 1: Simple monkey-patching
- `update_definitions(source)` - reload all module-level maps from a file path or dict
- Quick and dirty, not thread-safe, affects global state

### Commit 2: Registry pattern with contextvars (recommended)
- `DefinitionsRegistry` class encapsulating all lookup tables
- `using_definitions()` context manager for scoped, thread/async-safe switching
- `set_default_registry()` for changing the global default
- Backwards compatible - existing functions delegate to current registry
- Removes legacy private `_DEFINITIONS`, `_FIELD_INFO_MAP` etc. (tests updated to use public API)

## Use Cases

- Custom networks (Xahau, sidechains) with different transaction types/fields
- Testing with mock definitions
- Concurrent operations with different definitions (via contextvars)

## Recommended Usage

```python
from xrpl.core.binarycodec.definitions import (
    DefinitionsRegistry,
    using_definitions,
    set_default_registry,
)

# Scoped (thread/async safe) - RECOMMENDED
with using_definitions("/path/to/xahau_definitions.json"):
    encode(tx)  # Uses Xahau definitions
# Back to default automatically

# Global switch
set_default_registry(DefinitionsRegistry.from_path("/path/to/defs.json"))

# Or work with registry directly
registry = DefinitionsRegistry.from_path("/path/to/defs.json")
registry.get_transaction_type_code("Payment")
```

## Test plan

- [x] All existing binarycodec tests pass (39 tests)
- [x] Context manager properly scopes definitions
- [x] Tests updated to use public API instead of private `_VARS`