### PR TITLE
Update default algorithm in`Wallet` class (breaking change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### BREAKING CHANGE
 
 - Dropped support for Python 3.8 (EOL October 2024) and Python 3.9 (EOL October 2025). The minimum supported Python version is now 3.10.
-- Ensure consistent use of ED25519 as the default cryptographic algorithm in `Wallet.from_secret_numbers` method and `Wallet` class constructor. This change ensures consistency across the entire Wallet class, where ED25519 is used as the default Cryptographic signing algorithm.
+- Ensure consistent use of ED25519 as the default cryptographic algorithm in `Wallet.from_secret_numbers` method. This change ensures consistency across the entire Wallet class, where ED25519 is used as the default Cryptographic signing algorithm.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### BREAKING CHANGE
 
 - Dropped support for Python 3.8 (EOL October 2024) and Python 3.9 (EOL October 2025). The minimum supported Python version is now 3.10.
+- Ensure consistent use of ED25519 as the default cryptographic algorithm in `Wallet.from_secret_numbers` method and `Wallet` class constructor. This change ensures consistency across the entire Wallet class, where ED25519 is used as the default Cryptographic signing algorithm.
 
 ### Fixed
 

--- a/tests/unit/asyn/wallet/test_main.py
+++ b/tests/unit/asyn/wallet/test_main.py
@@ -131,14 +131,26 @@ def _test_wallet_types(self, wallet, algorithm):
 
 
 class TestWalletMain(TestCase):
-    def test_constructor(self):
+    def test_constructor_with_secp256_algorithm(self):
         wallet = Wallet(
             constants["seed"]["secp256k1"]["public_key"],
             constants["seed"]["secp256k1"]["private_key"],
             seed=constants["seed"]["seed"],
+            algorithm="secp256k1",
         )
 
         _test_wallet_values(self, wallet, "seed", "secp256k1")
+        self.assertEqual(wallet.algorithm, "secp256k1")
+
+    def test_constructor_with_default_algorithm(self):
+        wallet = Wallet(
+            constants["seed"]["ed25519"]["public_key"],
+            constants["seed"]["ed25519"]["private_key"],
+            seed=constants["seed"]["seed"],
+        )
+
+        _test_wallet_values(self, wallet, "seed", "ed25519")
+        self.assertEqual(wallet.algorithm, "ed25519")
 
     def test_wallet_contructor_throws_with_invalid_seed(self):
         with self.assertRaises(XRPLAddressCodecException):
@@ -148,15 +160,28 @@ class TestWalletMain(TestCase):
                 seed="abc",
             )
 
-    def test_constructor_using_regular_key_pair(self):
+    def test_constructor_using_regular_key_pair_secp256_algorithm(self):
         wallet = Wallet(
             constants["regular_key_pair"]["secp256k1"]["public_key"],
             constants["regular_key_pair"]["secp256k1"]["private_key"],
             master_address=constants["regular_key_pair"]["master_address"],
             seed=constants["regular_key_pair"]["seed"],
+            algorithm="secp256k1",
         )
 
         _test_wallet_values(self, wallet, "regular_key_pair", "secp256k1")
+        self.assertEqual(wallet.algorithm, "secp256k1")
+
+    def test_constructor_using_regular_key_pair_default_algorithm(self):
+        wallet = Wallet(
+            constants["regular_key_pair"]["ed25519"]["public_key"],
+            constants["regular_key_pair"]["ed25519"]["private_key"],
+            master_address=constants["regular_key_pair"]["master_address"],
+            seed=constants["regular_key_pair"]["seed"],
+        )
+
+        _test_wallet_values(self, wallet, "regular_key_pair", "ed25519")
+        self.assertEqual(wallet.algorithm, "ed25519")
 
     def test_create_using_default_algorithm(self):
         wallet = Wallet.create()
@@ -317,12 +342,12 @@ class TestWalletMain(TestCase):
     def test_from_secret_numbers_string_using_default_algorithm(self):
         wallet = Wallet.from_secret_numbers(constants["secret_numbers"]["string"])
 
-        _test_wallet_values(self, wallet, "secret_numbers", "secp256k1")
+        _test_wallet_values(self, wallet, "secret_numbers", "ed25519")
 
     def test_from_secret_numbers_array_using_default_algorithm(self):
         wallet = Wallet.from_secret_numbers(constants["secret_numbers"]["array"])
 
-        _test_wallet_values(self, wallet, "secret_numbers", "secp256k1")
+        _test_wallet_values(self, wallet, "secret_numbers", "ed25519")
 
     def test_from_secret_numbers_string_using_algorithm_ecdsa_secp256k1(self):
         wallet = Wallet.from_secret_numbers(

--- a/tests/unit/asyn/wallet/test_main.py
+++ b/tests/unit/asyn/wallet/test_main.py
@@ -142,16 +142,6 @@ class TestWalletMain(TestCase):
         _test_wallet_values(self, wallet, "seed", "secp256k1")
         self.assertEqual(wallet.algorithm, "secp256k1")
 
-    def test_constructor_with_default_algorithm(self):
-        wallet = Wallet(
-            constants["seed"]["ed25519"]["public_key"],
-            constants["seed"]["ed25519"]["private_key"],
-            seed=constants["seed"]["seed"],
-        )
-
-        _test_wallet_values(self, wallet, "seed", "ed25519")
-        self.assertEqual(wallet.algorithm, "ed25519")
-
     def test_wallet_contructor_throws_with_invalid_seed(self):
         with self.assertRaises(XRPLAddressCodecException):
             Wallet(
@@ -171,17 +161,6 @@ class TestWalletMain(TestCase):
 
         _test_wallet_values(self, wallet, "regular_key_pair", "secp256k1")
         self.assertEqual(wallet.algorithm, "secp256k1")
-
-    def test_constructor_using_regular_key_pair_default_algorithm(self):
-        wallet = Wallet(
-            constants["regular_key_pair"]["ed25519"]["public_key"],
-            constants["regular_key_pair"]["ed25519"]["private_key"],
-            master_address=constants["regular_key_pair"]["master_address"],
-            seed=constants["regular_key_pair"]["seed"],
-        )
-
-        _test_wallet_values(self, wallet, "regular_key_pair", "ed25519")
-        self.assertEqual(wallet.algorithm, "ed25519")
 
     def test_create_using_default_algorithm(self):
         wallet = Wallet.create()

--- a/xrpl/wallet/main.py
+++ b/xrpl/wallet/main.py
@@ -210,8 +210,7 @@ class Wallet:
             master_address: Include if a Wallet uses a Regular Key Pair. It must be
                 the master address of the account. The default is `None`.
             algorithm: The digital signature algorithm to generate an address for.
-                The default is `ED25519
-                https://xrpl.org/docs/concepts/accounts/cryptographic-keys#ed25519-key-derivation`_
+            The default is `ED25519 <https://xrpl.org/docs/concepts/accounts/cryptographic-keys#ed25519-key-derivation>`_.
 
         Returns:
             The wallet that is generated from the given secret numbers.

--- a/xrpl/wallet/main.py
+++ b/xrpl/wallet/main.py
@@ -47,7 +47,7 @@ class Wallet:
         *,
         master_address: Optional[str] = None,
         seed: Optional[str] = None,
-        algorithm: Optional[CryptoAlgorithm] = None,
+        algorithm: CryptoAlgorithm = CryptoAlgorithm.ED25519,
     ) -> None:
         """
         Generate a new Wallet.
@@ -58,16 +58,10 @@ class Wallet:
             master_address: Include if a Wallet uses a Regular Key Pair. This sets the
                 address that this wallet corresponds to. The default is `None`.
             seed: The seed used to derive the account keys. The default is `None`.
-            algorithm: The algorithm used to encode the keys. Inferred from the seed if
-                not included
+            algorithm: The algorithm used to encode the keys. By default ED25519
+            algorithm is used. If the public/private key-pairs were generated using
+            secp256k1, explicitly specify it in the algorithm parameter.
         """
-        if algorithm is None:
-            if seed is not None and seed.startswith("sEd"):
-                wallet_algorithm = CryptoAlgorithm.ED25519
-            else:
-                wallet_algorithm = CryptoAlgorithm.SECP256K1
-        else:
-            wallet_algorithm = algorithm
 
         """
         The core value that is used to derive all other information about
@@ -78,7 +72,7 @@ class Wallet:
             try:
                 # We do not use the outputs of the below function, we are interested in
                 # whether it throws an exception or not
-                addresscodec.decode_seed(seed, wallet_algorithm)
+                addresscodec.decode_seed(seed, algorithm)
             except Exception as e:
                 raise XRPLAddressCodecException(
                     "Attempted to initialize a Wallet with "
@@ -86,14 +80,14 @@ class Wallet:
                     + seed
                     + ". The cryptographic algorithm"
                     + " used is: "
-                    + wallet_algorithm
+                    + algorithm
                     + "\nError message: "
                     + str(e)
                 )
 
         self.seed = seed
 
-        self.algorithm = wallet_algorithm
+        self.algorithm = algorithm
         """
         The algorithm that is used to convert the seed into its public/private keypair.
         """
@@ -205,7 +199,7 @@ class Wallet:
         secret_numbers: List[str] | str,
         *,
         master_address: Optional[str] = None,
-        algorithm: CryptoAlgorithm = CryptoAlgorithm.SECP256K1,
+        algorithm: CryptoAlgorithm = CryptoAlgorithm.ED25519,
     ) -> Self:
         """
         Generates a new Wallet from secret numbers.
@@ -216,9 +210,8 @@ class Wallet:
             master_address: Include if a Wallet uses a Regular Key Pair. It must be
                 the master address of the account. The default is `None`.
             algorithm: The digital signature algorithm to generate an address for.
-                The default is `SECP256K1
-                <https://xrpl.org/cryptographic-keys.html#secp256k1-key-derivation>`_
-                (XUMM standard as of December 2022).
+                The default is `ED25519
+                https://xrpl.org/docs/concepts/accounts/cryptographic-keys#ed25519-key-derivation`_
 
         Returns:
             The wallet that is generated from the given secret numbers.

--- a/xrpl/wallet/main.py
+++ b/xrpl/wallet/main.py
@@ -47,9 +47,10 @@ class Wallet:
         *,
         master_address: Optional[str] = None,
         seed: Optional[str] = None,
-        algorithm: CryptoAlgorithm = CryptoAlgorithm.ED25519,
+        algorithm: Optional[CryptoAlgorithm] = None,
     ) -> None:
-        """Generate a new Wallet.
+        """
+        Generate a new Wallet.
 
         Args:
             public_key: The public key for the account.
@@ -57,18 +58,27 @@ class Wallet:
             master_address: Include if a Wallet uses a Regular Key Pair. This sets the
                 address that this wallet corresponds to. The default is `None`.
             seed: The seed used to derive the account keys. The default is `None`.
-            algorithm: The algorithm used to encode the keys. By default ED25519
-            algorithm is used. If the public/private key-pairs were generated using
-            secp256k1, explicitly specify it in the algorithm parameter.
+            algorithm: The algorithm used to encode the keys. Inferred from the seed if
+                not included
         """
-        # The core value that is used to derive all other information about
-        # this wallet. MUST be kept secret!
+        if algorithm is None:
+            if seed is not None and seed.startswith("sEd"):
+                wallet_algorithm = CryptoAlgorithm.ED25519
+            else:
+                wallet_algorithm = CryptoAlgorithm.SECP256K1
+        else:
+            wallet_algorithm = algorithm
+
+        """
+        The core value that is used to derive all other information about
+        this wallet. MUST be kept secret!
+        """
         # Validate the seed before initialization of Wallet object
         if seed is not None:
             try:
                 # We do not use the outputs of the below function, we are interested in
                 # whether it throws an exception or not
-                addresscodec.decode_seed(seed, algorithm)
+                addresscodec.decode_seed(seed, wallet_algorithm)
             except Exception as e:
                 raise XRPLAddressCodecException(
                     "Attempted to initialize a Wallet with "
@@ -76,14 +86,14 @@ class Wallet:
                     + seed
                     + ". The cryptographic algorithm"
                     + " used is: "
-                    + algorithm
+                    + wallet_algorithm
                     + "\nError message: "
                     + str(e)
                 )
 
         self.seed = seed
 
-        self.algorithm = algorithm
+        self.algorithm = wallet_algorithm
         """
         The algorithm that is used to convert the seed into its public/private keypair.
         """
@@ -206,7 +216,8 @@ class Wallet:
             master_address: Include if a Wallet uses a Regular Key Pair. It must be
                 the master address of the account. The default is `None`.
             algorithm: The digital signature algorithm to generate an address for.
-            The default is `ED25519 <https://xrpl.org/docs/concepts/accounts/cryptographic-keys#ed25519-key-derivation>`_.
+            The default is `ED25519
+            <https://xrpl.org/docs/concepts/accounts/cryptographic-keys#ed25519-key-derivation>`_.
 
         Returns:
             The wallet that is generated from the given secret numbers.

--- a/xrpl/wallet/main.py
+++ b/xrpl/wallet/main.py
@@ -49,8 +49,7 @@ class Wallet:
         seed: Optional[str] = None,
         algorithm: CryptoAlgorithm = CryptoAlgorithm.ED25519,
     ) -> None:
-        """
-        Generate a new Wallet.
+        """Generate a new Wallet.
 
         Args:
             public_key: The public key for the account.
@@ -62,11 +61,8 @@ class Wallet:
             algorithm is used. If the public/private key-pairs were generated using
             secp256k1, explicitly specify it in the algorithm parameter.
         """
-
-        """
-        The core value that is used to derive all other information about
-        this wallet. MUST be kept secret!
-        """
+        # The core value that is used to derive all other information about
+        # this wallet. MUST be kept secret!
         # Validate the seed before initialization of Wallet object
         if seed is not None:
             try:


### PR DESCRIPTION
## High Level Overview of Change

Ensure consistent use of `ED25519` as the default cryptographic algorithm in `Wallet.from_secret_numbers` method. This change ensures consistency across the entire Wallet class, where ED25519 is used as the default Cryptographic signing algorithm.

Note: The `Wallet.__init__()` still uses `SECP256K1` cryptographic signing algorithm. This occurs only when the user does not explicitly specify the algorithm `parameter` AND it is not possible to infer the type of the seed from the prefix (i.e. non-existence of `sEd...`). However, this behavior has been retained. Otherwise, we run the risk of erroneously categorizing a seed as ED25519, when it was in-fact created using SECP256K1 algorithm *silently*.


<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

This work was originally completed ~10 months ago. However, it was reverted because this PR requires a major version upgrade. Please read the following PRs for more context: https://github.com/XRPLF/xrpl-py/pull/770/changes, 

Sister PR in javascript: https://github.com/XRPLF/xrpl.js/pull/2658

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update CHANGELOG.md?

- [x] Yes
- [ ] No, this change does not impact library users

## Test Plan

New tests have been added. Existing tests also verify that the old behavior works correctly when the `secp256k1` algorithm is explicitly specified.

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
