### PR TITLE
fix: make Directory.dir_root and Directory.owner optional in LedgerEntry

### DIFF
--- a/tests/unit/models/requests/test_ledger_entry.py
+++ b/tests/unit/models/requests/test_ledger_entry.py
@@ -4,6 +4,7 @@ from xrpl.models import XRP, LedgerEntry, XChainBridge
 from xrpl.models.exceptions import XRPLModelException
 from xrpl.models.requests.ledger_entry import (
     Credential,
+    Directory,
     MPToken,
     Oracle,
     PermissionedDomain,
@@ -46,6 +47,32 @@ class TestLedgerEntry(TestCase):
             directory="hello",
         )
         self.assertTrue(req.is_valid())
+
+    def test_directory_with_owner_only_is_valid(self):
+        # Regression test for https://github.com/XRPLF/xrpl-py/issues/885
+        # dir_root should be optional when owner is provided
+        req = LedgerEntry(
+            directory=Directory(
+                owner="rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe",
+                sub_index=0,
+            ),
+            ledger_index="validated",
+        )
+        self.assertTrue(req.is_valid())
+
+    def test_directory_with_dir_root_only_is_valid(self):
+        # owner should also be optional when dir_root is provided
+        req = LedgerEntry(
+            directory=Directory(
+                dir_root="1BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB0",
+            ),
+        )
+        self.assertTrue(req.is_valid())
+
+    def test_directory_with_neither_owner_nor_dir_root_is_invalid(self):
+        # Must provide at least one of owner or dir_root
+        with self.assertRaises(XRPLModelException):
+            Directory(sub_index=0)
 
     def test_has_only_offer_is_valid(self):
         req = LedgerEntry(

--- a/xrpl/models/requests/ledger_entry.py
+++ b/xrpl/models/requests/ledger_entry.py
@@ -114,23 +114,25 @@ class DepositPreauth(BaseModel):
 class Directory(BaseModel):
     """
     Required fields for requesting a DirectoryNode if not querying by
-    object ID.
+    object ID. Either ``owner`` or ``dir_root`` must be provided, but not
+    necessarily both.
     """
 
-    owner: str = REQUIRED
-    """
-    This field is required.
+    owner: Optional[str] = None
+    """The owner of the directory. Required if ``dir_root`` is not provided."""
 
-    :meta hide-value:
+    dir_root: Optional[str] = None
+    """
+    The root of the directory. Required if ``owner`` is not provided.
     """
 
-    dir_root: str = REQUIRED
-    """
-    This field is required.
-
-    :meta hide-value:
-    """
     sub_index: Optional[int] = None
+
+    def _get_errors(self: Self) -> Dict[str, str]:
+        errors = super()._get_errors()
+        if self.owner is None and self.dir_root is None:
+            errors["Directory"] = "Must provide either `owner` or `dir_root`."
+        return errors
 
 
 @dataclass(frozen=True, kw_only=True)


### PR DESCRIPTION
## Description

Fixes #885.

Both `dir_root` and `owner` were marked as `REQUIRED` in the `Directory` model used by `LedgerEntry`, but the [XRPL `ledger_entry` docs](https://xrpl.org/ledger_entry.html#directory) specify that only one of the two is needed — you can look up a DirectoryNode by `owner` alone or by `dir_root` alone.

This caused a spurious `XRPLModelException: {'dir_root': 'dir_root is not set'}` when constructing a valid `Directory` with only `owner` provided, even though the same query works correctly when passed as a raw dict.

## Changes

**`xrpl/models/requests/ledger_entry.py`**
- `Directory.owner`: `str = REQUIRED` → `Optional[str] = None`
- `Directory.dir_root`: `str = REQUIRED` → `Optional[str] = None`
- Added `Directory._get_errors()` to enforce that at least one of `owner` or `dir_root` is provided

**`tests/unit/models/requests/test_ledger_entry.py`**
- Added `Directory` to imports
- Added `test_directory_with_owner_only_is_valid` — regression test for #885
- Added `test_directory_with_dir_root_only_is_valid` — confirms dir_root-only is also valid
- Added `test_directory_with_neither_owner_nor_dir_root_is_invalid` — confirms validation catches missing fields

## Test plan

- [x] `test_directory_with_owner_only_is_valid` — the exact case from issue #885 now passes
- [x] `test_directory_with_dir_root_only_is_valid` — dir_root-only lookup is valid
- [x] `test_directory_with_neither_owner_nor_dir_root_is_invalid` — raises XRPLModelException as expected
- [x] All existing `TestLedgerEntry` tests continue to pass