### PR TITLE
fix(transaction): guard version parsing against short version strings

### DIFF
--- a/xrpl/asyncio/transaction/main.py
+++ b/xrpl/asyncio/transaction/main.py
@@ -343,6 +343,8 @@ def _is_not_later_rippled_version(source: str, target: str) -> bool:
         return True
     source_decomp = source.split(".")
     target_decomp = target.split(".")
+    if len(source_decomp) < 3 or len(target_decomp) < 3:
+        return False
     source_major, source_minor = int(source_decomp[0]), int(source_decomp[1])
     target_major, target_minor = int(target_decomp[0]), int(target_decomp[1])
 


### PR DESCRIPTION
## Bug

`_is_not_later_rippled_version()` splits the version on `.` and directly accesses indices `[0]`, `[1]`, `[2]`. A 2-part version string (e.g. `"1.11"`) from a buggy or compromised server causes an `IndexError`.

## Fix

Check that both decomposed version strings have at least 3 parts before accessing them. If not, return `False` (treat as unknown version).

Closes #975