### PR TITLE
fix(wallet): infer signing algorithm from seed prefix in Wallet.from_seed / Wallet.from_secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Dropped support for Python 3.8 (EOL October 2024) and Python 3.9 (EOL October 2025). The minimum supported Python version is now 3.10.
 - Ensure consistent use of ED25519 as the default cryptographic algorithm in `Wallet.from_secret_numbers` method. This change ensures consistency across the entire Wallet class, where ED25519 is used as the default Cryptographic signing algorithm.
+- `Wallet.from_seed` and `Wallet.from_secret` no longer default to `ED25519` when `algorithm` is omitted. The algorithm is now inferred from the seed prefix: `sEd...` seeds derive an ED25519 keypair, all other family seeds (`s...`) derive a SECP256K1 keypair. This fixes the long-standing case where ingesting a secp256k1 family seed without an explicit algorithm silently produced an ED25519 keypair for an unrelated account. Callers that previously relied on the ED25519 default being applied to an `s...` family seed must now pass `algorithm=CryptoAlgorithm.ED25519` explicitly to keep deriving the same keypair. Callers that pass an explicit `algorithm` are unaffected. `Wallet.create`, `Wallet.from_entropy`, and `Wallet.from_secret_numbers` continue to default to ED25519 (they generate a fresh seed rather than ingesting one, so there is no prefix to infer from).
 
 ### Fixed
 

--- a/tests/unit/asyn/wallet/test_main.py
+++ b/tests/unit/asyn/wallet/test_main.py
@@ -177,10 +177,21 @@ class TestWalletMain(TestCase):
 
         _test_wallet_types(self, wallet, "secp256k1")
 
-    def test_from_seed_using_default_algorithm(self):
+    def test_from_seed_infers_secp256k1_from_s_prefix(self):
+        # constants["seed"]["seed"] is an `s...` family seed; with no explicit
+        # algorithm the result should be inferred as secp256k1.
         wallet = Wallet.from_seed(constants["seed"]["seed"])
 
-        _test_wallet_values(self, wallet, "seed", "ed25519")
+        _test_wallet_values(self, wallet, "seed", "secp256k1")
+
+    def test_from_seed_infers_ed25519_from_sEd_prefix(self):
+        sed_seed = "sEdVRAkrcTVBt4jKfJyKzQzndPFARgs"
+        inferred = Wallet.from_seed(sed_seed)
+        explicit = Wallet.from_seed(sed_seed, algorithm=CryptoAlgorithm.ED25519)
+
+        self.assertEqual(inferred.public_key, explicit.public_key)
+        self.assertEqual(inferred.private_key, explicit.private_key)
+        self.assertEqual(inferred.algorithm, CryptoAlgorithm.ED25519)
 
     def test_from_seed_using_algorithm_ecdsa_secp256k1(self):
         wallet = Wallet.from_seed(
@@ -196,13 +207,15 @@ class TestWalletMain(TestCase):
 
         _test_wallet_values(self, wallet, "seed", "ed25519")
 
-    def test_from_seed_using_regular_key_pair_using_default_algorithm(self):
+    def test_from_seed_using_regular_key_pair_infers_secp256k1_from_s_prefix(self):
+        # regular_key_pair seed is `sh8i92...`, an `s...` family seed;
+        # inference should pick secp256k1.
         wallet = Wallet.from_seed(
             constants["regular_key_pair"]["seed"],
             master_address=constants["regular_key_pair"]["master_address"],
         )
 
-        _test_wallet_values(self, wallet, "regular_key_pair", "ed25519")
+        _test_wallet_values(self, wallet, "regular_key_pair", "secp256k1")
 
     def test_from_seed_using_regular_key_pair_using_algorithm_ed25519(self):
         wallet = Wallet.from_seed(
@@ -222,10 +235,10 @@ class TestWalletMain(TestCase):
 
         _test_wallet_values(self, wallet, "regular_key_pair", "secp256k1")
 
-    def test_from_secret_using_default_algorithm(self):
+    def test_from_secret_infers_secp256k1_from_s_prefix(self):
         wallet = Wallet.from_secret(constants["seed"]["seed"])
 
-        _test_wallet_values(self, wallet, "seed", "ed25519")
+        _test_wallet_values(self, wallet, "seed", "secp256k1")
 
     def test_from_secret_using_algorithm_ecdsa_secp256k1(self):
         wallet = Wallet.from_secret(
@@ -241,13 +254,13 @@ class TestWalletMain(TestCase):
 
         _test_wallet_values(self, wallet, "seed", "ed25519")
 
-    def test_from_secret_using_regular_key_pair_using_default_algorithm(self):
+    def test_from_secret_using_regular_key_pair_infers_secp256k1_from_s_prefix(self):
         wallet = Wallet.from_secret(
             constants["regular_key_pair"]["seed"],
             master_address=constants["regular_key_pair"]["master_address"],
         )
 
-        _test_wallet_values(self, wallet, "regular_key_pair", "ed25519")
+        _test_wallet_values(self, wallet, "regular_key_pair", "secp256k1")
 
     def test_from_secret_using_regular_key_pair_using_algorithm_ed25519(self):
         wallet = Wallet.from_secret(

--- a/tests/unit/wallet/test_wallet.py
+++ b/tests/unit/wallet/test_wallet.py
@@ -24,17 +24,17 @@ class TestWallet(TestCase):
         self.assertFalse(wallet.seed.startswith("sEd"))
         self.assertTrue(wallet.seed.startswith("s"))
 
-    def test_init_auto_with_default_algorithm(self):
-        wallet = Wallet.from_seed(SED_SEED)
-        self.assertEqual(wallet.seed, SED_SEED)
-        self.assertEqual(wallet.address, SED_ADDRESS)
-        self.assertEqual(wallet.algorithm, CryptoAlgorithm.ED25519)
-
     def test_init_auto_with_sEd_seed(self):
         wallet = Wallet.from_seed(SED_SEED)
         self.assertEqual(wallet.seed, SED_SEED)
         self.assertEqual(wallet.address, SED_ADDRESS)
         self.assertEqual(wallet.algorithm, CryptoAlgorithm.ED25519)
+
+    def test_init_auto_with_s_seed_infers_secp256k1(self):
+        wallet = Wallet.from_seed(SEED)
+        self.assertEqual(wallet.seed, SEED)
+        self.assertEqual(wallet.address, SECP_ADDRESS)
+        self.assertEqual(wallet.algorithm, CryptoAlgorithm.SECP256K1)
 
     def test_init_secp256k1_with_s_seed(self):
         wallet = Wallet.from_seed(SEED, algorithm=CryptoAlgorithm.SECP256K1)

--- a/xrpl/wallet/main.py
+++ b/xrpl/wallet/main.py
@@ -140,7 +140,7 @@ class Wallet:
         seed: str,
         *,
         master_address: Optional[str] = None,
-        algorithm: CryptoAlgorithm = CryptoAlgorithm.ED25519,
+        algorithm: Optional[CryptoAlgorithm] = None,
     ) -> Self:
         """
         Generates a new Wallet from seed (secret).
@@ -149,8 +149,9 @@ class Wallet:
             seed: The seed (secret) used to derive the account keys.
             master_address: Include if a Wallet uses a Regular Key Pair. This sets the
                 address that this wallet corresponds to. The default is `None`.
-            algorithm: The key-generation algorithm to use when generating the seed.
-                The default is `ED25519`.
+            algorithm: The key-generation algorithm to use. When omitted, the algorithm
+                is inferred from the seed prefix: `sEd...` seeds derive an ED25519
+                keypair, all other family seeds (`s...`) derive a SECP256K1 keypair.
 
         Returns:
             The wallet that is generated from the given secret.


### PR DESCRIPTION
## Background

Until now, `Wallet.from_seed(seed)` (and its alias `Wallet.from_secret`) silently coerced `algorithm` to `ED25519` whenever the caller didn't pass one. For `sEd…` family seeds this happened to produce the right account. For an `s…` family seed (secp256k1), it produced a valid keypair on a completely different account — making it look like the user's account "disappeared." This has been one of the most commonly reported migration issues since the 3.x default flip.

Sister work in xrpl.js: https://github.com/XRPLF/xrpl.js/pull/3337

## Change

`Wallet.from_seed` no longer applies a fallback `ED25519` default when `algorithm` is omitted. The `None` value flows through to `xrpl.core.keypairs.derive_keypair`, which already infers the algorithm from the seed prefix via `addresscodec.decode_seed`. `Wallet.__init__` independently re-infers using `seed.startswith("sEd")`, so the two paths agree. Net effect:

- `sEd…` seeds → ED25519 (unchanged result for callers who relied on the previous default)
- `s…` family seeds → SECP256K1 (correct curve; previously returned an unrelated ED25519 account)

`Wallet.create` still passes its algorithm explicitly, so its ED25519 default is preserved.

## Wallet factory defaults after this PR

| Method | Input | Algorithm when `algorithm` is omitted |
|---|---|---|
| `Wallet.create()` | none (random) | `ED25519` |
| `Wallet.from_seed(seed)` | seed string | inferred from prefix: `sEd…` → `ED25519`, otherwise `SECP256K1` |
| `Wallet.from_secret(secret)` | seed string (alias of `from_seed`) | inferred from prefix: `sEd…` → `ED25519`, otherwise `SECP256K1` |
| `Wallet.from_entropy(entropy)` | random bytes | `ED25519` |
| `Wallet.from_secret_numbers(numbers)` | secret numbers | `ED25519` |
| `xrpl.core.keypairs.generate_seed()` | none / entropy | `ED25519` |
| `xrpl.core.keypairs.derive_keypair(seed)` | seed string | inferred from prefix via `decode_seed` |

## Migration

Only `Wallet.from_seed` and `Wallet.from_secret` change behavior. Every other Wallet factory listed above is unaffected by this PR.

| Call site | Before this PR | After this PR | Required action |
|---|---|---|---|
| `Wallet.from_seed(seed)` / `Wallet.from_secret(seed)` where `seed` does not start with `sEd` (i.e. `s…` family seed), `algorithm` omitted | returned an ED25519 keypair for an unrelated account | returns the SECP256K1 keypair for the account the seed was actually issued for | If you intended secp256k1: no action — you now get the correct keypair. If your application has persisted the previously-derived ED25519 keypair and must keep using it: pass `algorithm=CryptoAlgorithm.ED25519` explicitly. |
| `Wallet.from_seed(seed)` / `Wallet.from_secret(seed)` where `seed` starts with `sEd`, `algorithm` omitted | returned an ED25519 keypair | returns an ED25519 keypair (now via prefix inference instead of the hard-coded default) | None — result is identical. Optional: pass `algorithm=CryptoAlgorithm.ED25519` explicitly as defense against future default changes. |
| `Wallet.from_seed` / `Wallet.from_secret` with an explicit `algorithm` (either curve) | honored the explicit value | honors the explicit value | None. |
| `Wallet.create`, `Wallet.from_entropy`, `Wallet.from_secret_numbers`, `xrpl.core.keypairs.generate_seed` | unchanged | unchanged | None. |

## Tests

- The four `…_using_default_algorithm` cases in `tests/unit/asyn/wallet/test_main.py` were locking in the buggy behavior (asserted ED25519 keys for `s…` family fixture seeds `ssL9dv2W5RK8L3tuzQxYY6EaZhSxW` and `sh8i92YRnEjJy3fpFkL8txQSCVo79`). Renamed to `…_infers_secp256k1_from_s_prefix` and updated to assert the correct secp256k1 keys / addresses.
- Added `test_from_seed_infers_ed25519_from_sEd_prefix` to lock in the `sEd…` inference path and assert the inferred result equals an explicit `algorithm=CryptoAlgorithm.ED25519` call.
- In `tests/unit/wallet/test_wallet.py`, replaced the duplicate `test_init_auto_with_default_algorithm` with `test_init_auto_with_s_seed_infers_secp256k1`, which ingests `ssQgsaM2ujhyWoDw3Yb1TNjkZTVT2` (an `s…` seed) and asserts the secp256k1 address `r9o97fQwt54s73b1UzgbhvZTPDHYgSqz7G`.
- Full unit suite: 792 tests pass via `poetry run python3 -m unittest discover tests/unit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)