### PR TITLE
fix: docker path for integration test

### DIFF
--- a/.claude/skills/batch-deps-upgrade/SKILL.md
+++ b/.claude/skills/batch-deps-upgrade/SKILL.md
@@ -87,7 +87,7 @@ For each Python version, run the following in order:
        --detach \
        --publish 5005:5005 \
        --publish 6006:6006 \
-       --volume "$PWD/.ci-config/:/etc/opt/xrpld/" \
+       --volume "$PWD/.ci-config/:/etc/xrpld/" \
        --name xrpld-service \
        rippleci/xrpld:develop --standalone
      ```

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -46,7 +46,7 @@ jobs:
             --detach \
             --publish 5005:5005 \
             --publish 6006:6006 \
-            --volume "${{ github.workspace }}/.ci-config/":"/etc/opt/xrpld/" \
+            --volume "${{ github.workspace }}/.ci-config/":"/etc/xrpld/" \
             --name xrpld-service \
             ${{ env.XRPLD_DOCKER_IMAGE }} --standalone
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ docker run \
   --detach \
   --publish 5005:5005 \
   --publish 6006:6006 \
-  --volume "$PWD/.ci-config/:/etc/opt/xrpld/" \
+  --volume "$PWD/.ci-config/:/etc/xrpld/" \
   --name xrpld-service \
   rippleci/xrpld:develop --standalone
 ```
@@ -103,7 +103,7 @@ Breaking down the command:
 
 - `--detach` — run in background
 - `--publish 5005:5005 --publish 6006:6006` — expose JSON-RPC and WebSocket ports
-- `--volume "$PWD/.ci-config/:/etc/opt/xrpld/"` — mount local config into the container
+- `--volume "$PWD/.ci-config/:/etc/xrpld/"` — mount local config into the container
 - `--name xrpld-service` — name the container
 - `rippleci/xrpld:develop` — latest `develop` branch build of xrpld
 - `--standalone` — start xrpld in standalone mode


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->
The `rippleci/xrpld:develop` image now reads its config from `/etc/xrpld/`, not `/etc/opt/xrpld/`.
Update both the CI workflow and the CONTRIBUTING.md instructions.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update CHANGELOG.md?

- [ ] Yes
- [x] No, this change does not impact library users

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

CI passes.
