### PR TITLE
Fix Directory ledger entry dir_root validation

### DIFF
--- a/tests/unit/models/requests/test_ledger_entry.py
+++ b/tests/unit/models/requests/test_ledger_entry.py
@@ -4,6 +4,7 @@ from xrpl.models import XRP, LedgerEntry, XChainBridge
 from xrpl.models.exceptions import XRPLModelException
 from xrpl.models.requests.ledger_entry import (
     Credential,
+    Directory,
     MPToken,
     Oracle,
     PermissionedDomain,
@@ -44,6 +45,16 @@ class TestLedgerEntry(TestCase):
     def test_has_only_directory_is_valid(self):
         req = LedgerEntry(
             directory="hello",
+        )
+        self.assertTrue(req.is_valid())
+
+    def test_directory_with_owner_and_sub_index_is_valid(self):
+        req = LedgerEntry(
+            directory=Directory(
+                owner="rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe",
+                sub_index=0,
+            ),
+            ledger_index="validated",
         )
         self.assertTrue(req.is_valid())
 

--- a/xrpl/models/requests/ledger_entry.py
+++ b/xrpl/models/requests/ledger_entry.py
@@ -124,9 +124,9 @@ class Directory(BaseModel):
     :meta hide-value:
     """
 
-    dir_root: str = REQUIRED
+    dir_root: Optional[str] = None
     """
-    This field is required.
+    This field is optional when querying by owner and sub_index.
 
     :meta hide-value:
     """


### PR DESCRIPTION
## High Level Overview
Make `Directory.dir_root` optional in the `ledger_entry` request model so lookups by `owner` + `sub_index` work with the typed Python API.

## Context of Change
Fixes #885. The XRPL server accepts directory lookups without `dir_root`, but xrpl-py rejected them at model validation time.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan
- [x] `poetry run poe test tests/unit/models/requests/test_ledger_entry.py`
- [x] `poetry run poe lint`