### PR TITLE
feat: Batch (XLS-56) V1_1 signing support

### DIFF
--- a/.ci-config/xrpld.cfg
+++ b/.ci-config/xrpld.cfg
@@ -202,7 +202,7 @@ SingleAssetVault
 fixFrozenLPTokenTransfer
 fixInvalidTxFlags
 PermissionedDEX
-Batch
+BatchV1_1
 TokenEscrow
 LendingProtocol
 PermissionDelegationV1_1

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -26,9 +26,6 @@ jobs:
     name: Integration test
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    permissions:
-      contents: read
-      packages: read
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -45,13 +42,6 @@ jobs:
         with:
           path: /home/runner/.local
           key: dotlocal-${{ env.POETRY_VERSION }}
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run docker in background
         run: |

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -2,7 +2,10 @@ name: Integration test
 
 env:
   POETRY_VERSION: 2.1.1
-  XRPLD_DOCKER_IMAGE: rippleci/xrpld:develop
+  # Standalone rippled with the XLS-56 BatchV1_1 amendment, built from the amd64
+  # binary artifact of https://github.com/XRPLF/rippled/pull/6446 and pushed to
+  # GHCR. Revert to rippleci/xrpld:develop once BatchV1_1 lands in develop.
+  XRPLD_DOCKER_IMAGE: ghcr.io/ckeshava/xrpld-batch-v1_1:latest
 
 on:
   push:
@@ -23,6 +26,9 @@ jobs:
     name: Integration test
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: read
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -39,6 +45,13 @@ jobs:
         with:
           path: /home/runner/.local
           key: dotlocal-${{ env.POETRY_VERSION }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run docker in background
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [[Unreleased]]
 
+### BREAKING CHANGE
+
+- Updated Batch (XLS-56) signing to the V1_1 payload from [rippled #6446](https://github.com/XRPLF/rippled/pull/6446). `encode_for_signing_batch` now binds the outer `Account` and `Sequence` (or `TicketSequence`), the `BatchSigner` account, and — for multi-signed batch signers — the inner signer account into the signed data, preventing signature replay across outer accounts/sequences. Batch signatures produced by older xrpl-py versions are no longer valid; re-sign with this version against a `BatchV1_1`-enabled network.
+
+### Added
+
+- `sign_multiaccount_batch` accepts a `batch_account` argument (sign on behalf of an account when the signing key differs, e.g. a regular key) and a string `multisign` value (multi-sign as a specific account). The counterparty of an inner transaction now counts as an involved account.
+
+### Fixed
+
+- `combine_batch_signers` now rejects fragments that disagree on the outer account, sequence value, flags, or inner transaction IDs (previously only flags and `RawTransactions` were checked) and de-duplicates `BatchSigners` by account so the combined array is strictly ascending and unique.
+
 ## [[5.0.0]]
 
 ### BREAKING CHANGE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [[Unreleased]]
 
-### BREAKING CHANGE
-
-- Updated Batch (XLS-56) signing to the V1_1 payload from [rippled #6446](https://github.com/XRPLF/rippled/pull/6446). `encode_for_signing_batch` now binds the outer `Account` and `Sequence` (or `TicketSequence`), the `BatchSigner` account, and — for multi-signed batch signers — the inner signer account into the signed data, preventing signature replay across outer accounts/sequences. Batch signatures produced by older xrpl-py versions are no longer valid; re-sign with this version against a `BatchV1_1`-enabled network.
-
 ### Added
 
 - `sign_multiaccount_batch` accepts a `batch_account` argument (sign on behalf of an account when the signing key differs, e.g. a regular key) and a string `multisign` value (multi-sign as a specific account). The counterparty of an inner transaction now counts as an involved account.
 
 ### Fixed
 
+- Updated Batch (XLS-56) signing to the V1_1 payload from [rippled #6446](https://github.com/XRPLF/rippled/pull/6446). `encode_for_signing_batch` now binds the outer `Account` and `Sequence` (or `TicketSequence`), the `BatchSigner` account, and — for multi-signed batch signers — the inner signer account into the signed data, preventing signature replay across outer accounts/sequences. (Batch is still in active development and not live on any network, so no existing signatures are affected.)
 - `combine_batch_signers` now rejects fragments that disagree on the outer account, sequence value, flags, or inner transaction IDs (previously only flags and `RawTransactions` were checked) and de-duplicates `BatchSigners` by account so the combined array is strictly ascending and unique.
 
 ## [[5.0.0]]

--- a/tests/integration/transactions/test_batch.py
+++ b/tests/integration/transactions/test_batch.py
@@ -1,18 +1,24 @@
 from tests.integration.integration_test_case import IntegrationTestCase
 from tests.integration.it_utils import (
+    fund_wallet_async,
     sign_and_reliable_submission_async,
     test_async_and_sync,
 )
 from tests.integration.reusable_values import DESTINATION, WALLET
 from xrpl.asyncio.transaction import autofill
-from xrpl.models import Batch, BatchFlag, Payment
+from xrpl.models import Batch, BatchFlag, Payment, TicketCreate
+from xrpl.models.requests.account_objects import AccountObjects, AccountObjectType
 from xrpl.models.response import ResponseStatus
-from xrpl.transaction.batch_signers import sign_multiaccount_batch
+from xrpl.transaction.batch_signers import (
+    combine_batch_signers,
+    sign_multiaccount_batch,
+)
+from xrpl.wallet import Wallet
 
 
 class TestBatch(IntegrationTestCase):
     @test_async_and_sync(globals())
-    async def test_basic_functionality(self, client):
+    async def test_all_or_nothing(self, client):
         payment = Payment(
             account=WALLET.address,
             amount="1",
@@ -27,8 +33,24 @@ class TestBatch(IntegrationTestCase):
         self.assertEqual(response.status, ResponseStatus.SUCCESS)
         self.assertEqual(response.result["engine_result"], "tesSUCCESS")
 
+    @test_async_and_sync(globals())
+    async def test_independent(self, client):
+        payment = Payment(
+            account=WALLET.address,
+            amount="1",
+            destination=DESTINATION.address,
+        )
+        batch = Batch(
+            account=WALLET.address,
+            flags=BatchFlag.TF_INDEPENDENT,
+            raw_transactions=[payment, payment],
+        )
+        response = await sign_and_reliable_submission_async(batch, WALLET, client)
+        self.assertEqual(response.status, ResponseStatus.SUCCESS)
+        self.assertEqual(response.result["engine_result"], "tesSUCCESS")
+
     @test_async_and_sync(globals(), ["xrpl.transaction.autofill"])
-    async def test_multisign(self, client):
+    async def test_multi_account_single_sign(self, client):
         payment = Payment(
             account=WALLET.address,
             amount="1",
@@ -43,6 +65,77 @@ class TestBatch(IntegrationTestCase):
             account=WALLET.address,
             flags=BatchFlag.TF_ALL_OR_NOTHING,
             raw_transactions=[payment, payment2],
+        )
+        autofilled = await autofill(batch, client, 1)
+        signed = sign_multiaccount_batch(DESTINATION, autofilled)
+        response = await sign_and_reliable_submission_async(signed, WALLET, client)
+        self.assertEqual(response.status, ResponseStatus.SUCCESS)
+        self.assertEqual(response.result["engine_result"], "tesSUCCESS")
+
+    @test_async_and_sync(globals(), ["xrpl.transaction.autofill"])
+    async def test_combine_batch_signers(self, client):
+        signer = Wallet.create()
+        await fund_wallet_async(signer)
+        batch = Batch(
+            account=WALLET.address,
+            flags=BatchFlag.TF_ALL_OR_NOTHING,
+            raw_transactions=[
+                Payment(
+                    account=WALLET.address,
+                    amount="1",
+                    destination=DESTINATION.address,
+                ),
+                Payment(
+                    account=DESTINATION.address,
+                    amount="1",
+                    destination=WALLET.address,
+                ),
+                Payment(
+                    account=signer.address,
+                    amount="1",
+                    destination=WALLET.address,
+                ),
+            ],
+        )
+        autofilled = await autofill(batch, client, 2)
+        signed_dest = sign_multiaccount_batch(DESTINATION, autofilled)
+        signed_signer = sign_multiaccount_batch(signer, autofilled)
+        combined = Batch.from_blob(combine_batch_signers([signed_dest, signed_signer]))
+        response = await sign_and_reliable_submission_async(combined, WALLET, client)
+        self.assertEqual(response.status, ResponseStatus.SUCCESS)
+        self.assertEqual(response.result["engine_result"], "tesSUCCESS")
+
+    @test_async_and_sync(globals(), ["xrpl.transaction.autofill"])
+    async def test_ticket_sequence(self, client):
+        # The V1_1 signing payload binds the outer sequence value, which is the
+        # TicketSequence when a ticket is used. This exercises that path.
+        await sign_and_reliable_submission_async(
+            TicketCreate(account=WALLET.address, ticket_count=1), WALLET, client
+        )
+        ticket_objects = await client.request(
+            AccountObjects(account=WALLET.address, type=AccountObjectType.TICKET)
+        )
+        ticket_sequence = max(
+            obj["TicketSequence"] for obj in ticket_objects.result["account_objects"]
+        )
+
+        batch = Batch(
+            account=WALLET.address,
+            flags=BatchFlag.TF_ALL_OR_NOTHING,
+            sequence=0,
+            ticket_sequence=ticket_sequence,
+            raw_transactions=[
+                Payment(
+                    account=WALLET.address,
+                    amount="1",
+                    destination=DESTINATION.address,
+                ),
+                Payment(
+                    account=DESTINATION.address,
+                    amount="1",
+                    destination=WALLET.address,
+                ),
+            ],
         )
         autofilled = await autofill(batch, client, 1)
         signed = sign_multiaccount_batch(DESTINATION, autofilled)

--- a/tests/unit/core/binarycodec/test_main.py
+++ b/tests/unit/core/binarycodec/test_main.py
@@ -402,20 +402,28 @@ class TestMainSigning(TestCase):
         )
         self.assertEqual(encode_for_signing_claim(json), expected)
 
-    def test_batch(self):
-        flags = 1
-        transaction_ids = [
-            "ABE4871E9083DF66727045D49DEEDD3A6F166EB7F8D1E92FE868F02E76B2C5CA",
-            "795AAC88B59E95C3497609749127E69F12958BC016C600C770AEEB1474C840B4",
-        ]
-
-        json = {"flags": flags, "transaction_ids": transaction_ids}
+    def test_batch_single_signed(self):
+        json = {
+            "account": "rNCFjv8Ek5oDrNiMJ3pw6eLLFtMjZLJnf2",
+            "sequence": 5,
+            "flags": 1,
+            "transaction_ids": [
+                "ABE4871E9083DF66727045D49DEEDD3A6F166EB7F8D1E92FE868F02E76B2C5CA",
+                "795AAC88B59E95C3497609749127E69F12958BC016C600C770AEEB1474C840B4",
+            ],
+            # The BatchSigner.Account the signature is bound to (XLS-56 V1_1).
+            "batch_account": "rJCxK2hX9tDMzbnn3cg1GU2g19Kfmhzxkp",
+        }
         actual = encode_for_signing_batch(json)
         self.assertEqual(
             actual,
             (
                 # hash prefix
                 "42434800"
+                # outer account
+                "95F14B0E44F78A264E41713C64B5F89242540EE2"
+                # outer sequence
+                "00000005"
                 # flags
                 "00000001"
                 # transaction_ids length
@@ -423,6 +431,46 @@ class TestMainSigning(TestCase):
                 # transaction_ids
                 "ABE4871E9083DF66727045D49DEEDD3A6F166EB7F8D1E92FE868F02E76B2C5CA"
                 "795AAC88B59E95C3497609749127E69F12958BC016C600C770AEEB1474C840B4"
+                # batch signer account
+                "C1D81FB31C42392BA1570431F1CBCBEEBBEF50E1"
+            ),
+        )
+
+    def test_batch_multi_signed(self):
+        json = {
+            "account": "rNCFjv8Ek5oDrNiMJ3pw6eLLFtMjZLJnf2",
+            "sequence": 5,
+            "flags": 1,
+            "transaction_ids": [
+                "ABE4871E9083DF66727045D49DEEDD3A6F166EB7F8D1E92FE868F02E76B2C5CA",
+                "795AAC88B59E95C3497609749127E69F12958BC016C600C770AEEB1474C840B4",
+            ],
+            # The BatchSigner.Account the signature is bound to.
+            "batch_account": "rJCxK2hX9tDMzbnn3cg1GU2g19Kfmhzxkp",
+            # The inner Signers entry account for a multi-signed BatchSigner.
+            "signer_account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        }
+        actual = encode_for_signing_batch(json)
+        self.assertEqual(
+            actual,
+            (
+                # hash prefix
+                "42434800"
+                # outer account
+                "95F14B0E44F78A264E41713C64B5F89242540EE2"
+                # outer sequence
+                "00000005"
+                # flags
+                "00000001"
+                # transaction_ids length
+                "00000002"
+                # transaction_ids
+                "ABE4871E9083DF66727045D49DEEDD3A6F166EB7F8D1E92FE868F02E76B2C5CA"
+                "795AAC88B59E95C3497609749127E69F12958BC016C600C770AEEB1474C840B4"
+                # batch signer account
+                "C1D81FB31C42392BA1570431F1CBCBEEBBEF50E1"
+                # inner signer account
+                "B5F762798A53D543A014CAF8B297CFF8F2F937E8"
             ),
         )
 

--- a/tests/unit/transaction/test_batch_signers.py
+++ b/tests/unit/transaction/test_batch_signers.py
@@ -2,9 +2,10 @@ from unittest import TestCase
 
 from xrpl.constants import CryptoAlgorithm, XRPLException
 from xrpl.core.binarycodec.main import decode
-from xrpl.models.transactions import Batch, Signer
+from xrpl.models.transactions import Batch, BatchFlag, Signer
 from xrpl.models.transactions.batch import BatchSigner
 from xrpl.models.transactions.transaction import Transaction
+from xrpl.transaction import sign
 from xrpl.transaction.batch_signers import (
     combine_batch_signers,
     sign_multiaccount_batch,
@@ -265,3 +266,39 @@ class TestCombineBatchSigners(TestCase):
             "BatchSigners", []
         )
         self.assertEqual(decode(result)["BatchSigners"], expected_valid)
+
+    def test_dedup_shared_signer(self):
+        # Combining fragments that share a signer keeps a single, unique signer.
+        result = combine_batch_signers([self.tx1, self.tx1])
+        self.assertEqual(
+            decode(result)["BatchSigners"], self.tx1.to_xrpl()["BatchSigners"]
+        )
+
+    def test_no_transactions(self):
+        with self.assertRaises(XRPLException):
+            combine_batch_signers([])
+
+    def test_signed_batch_rejected(self):
+        # A fully signed outer Batch cannot be combined.
+        signed_blob = sign(self.tx1, secp_wallet).blob()
+        with self.assertRaises(XRPLException):
+            combine_batch_signers([signed_blob, self.tx2])
+
+    def _signed_with_field(self, **overrides):
+        bad_dict = {**self.batch_tx.to_xrpl(), **overrides}
+        return sign_multiaccount_batch(secp_wallet, Batch.from_xrpl(bad_dict))
+
+    def test_different_flags(self):
+        bad_tx = self._signed_with_field(Flags=int(BatchFlag.TF_INDEPENDENT))
+        with self.assertRaises(XRPLException):
+            combine_batch_signers([self.tx1, bad_tx])
+
+    def test_different_account(self):
+        bad_tx = self._signed_with_field(Account="rJy554HmWFFJQGnRfZuoo8nV97XSMq77h7")
+        with self.assertRaises(XRPLException):
+            combine_batch_signers([self.tx1, bad_tx])
+
+    def test_different_sequence(self):
+        bad_tx = self._signed_with_field(Sequence=216)
+        with self.assertRaises(XRPLException):
+            combine_batch_signers([self.tx1, bad_tx])

--- a/tests/unit/transaction/test_batch_signers.py
+++ b/tests/unit/transaction/test_batch_signers.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 from xrpl.constants import CryptoAlgorithm, XRPLException
 from xrpl.core.binarycodec.main import decode
-from xrpl.models.transactions import Batch
+from xrpl.models.transactions import Batch, Signer
 from xrpl.models.transactions.batch import BatchSigner
 from xrpl.models.transactions.transaction import Transaction
 from xrpl.transaction.batch_signers import (
@@ -23,7 +23,13 @@ submit_wallet = Wallet.from_seed(
     "sEd7HmQFsoyj5TAm6d98gytM9LJA1MF",
     algorithm=CryptoAlgorithm.ED25519,
 )
+regkey_wallet = Wallet.from_seed(
+    "sEdStM1pngFcLQqVfH3RQcg2Qr6ov9e",
+    algorithm=CryptoAlgorithm.ED25519,
+)
 other_wallet = Wallet.create()
+
+REGKEY_PUBLIC_KEY = "ED37D3F048B7F1E680B0A97F70C7843160B9F25D6398D07E68B9A2C83AA8E1B156"
 
 
 class TestSignMultiAccountBatch(TestCase):
@@ -39,8 +45,7 @@ class TestSignMultiAccountBatch(TestCase):
                         "Amount": "5000000",
                         "Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
                         "Fee": "0",
-                        "NetworkID": 21336,
-                        "Sequence": 0,
+                        "Sequence": 215,
                         "SigningPubKey": "",
                         "TransactionType": "Payment",
                     },
@@ -52,8 +57,7 @@ class TestSignMultiAccountBatch(TestCase):
                         "Flags": 1073741824,
                         "Destination": "rJCxK2hX9tDMzbnn3cg1GU2g19Kfmhzxkp",
                         "Fee": "0",
-                        "NetworkID": 21336,
-                        "Sequence": 0,
+                        "Sequence": 470,
                         "SigningPubKey": "",
                         "TransactionType": "Payment",
                     },
@@ -73,9 +77,9 @@ class TestSignMultiAccountBatch(TestCase):
                     "8F3AFC006E3FE"
                 ),
                 txn_signature=(
-                    "3045022100EAE8F20550F414DE2EC5501544D17500EFAE6B4B66C36B05BBF59CA"
-                    "FDA2C72A502201C9D5C8BEEB6AAC63DC6FB9FEF3E5F008638D36B488E6D98D084"
-                    "AC5813E9342A"
+                    "304502210098890858AA57D6515D7C523FE076FA97BFA87DA666A87B4A7CF44249"
+                    "181DC1DC02201B90E513FE2F45D41FB31850F463C0ECBA8F5126B1AF431B67C400"
+                    "4CA0DD8042"
                 ),
             )
         ]
@@ -93,13 +97,83 @@ class TestSignMultiAccountBatch(TestCase):
                     "6A6E9E62BA638"
                 ),
                 txn_signature=(
-                    "640D96D68C061EF61C5D72460E2254CA74D1CCE75FFC9FF327FC1072419AF474D2"
-                    "5A8A01E17AE0BCE71D96B5C5CB87D890D86058A909FB8918DAA046B67EA30C"
+                    "27B496F0C1F2C4789A0E6CF25265069980190C786053CF5D6C066C07E21D632A6E"
+                    "B87C56275109A8542EEDE782FDC5591EA51FAF28C3FCFCF35BCE960F1D8601"
                 ),
             )
         ]
 
         self.assertIsNotNone(result.batch_signers)
+        self.assertEqual(result.batch_signers, expected)
+
+    def test_different_account(self):
+        # Sign with a regular key on behalf of an account in the Batch.
+        result = sign_multiaccount_batch(
+            regkey_wallet, self.batch_tx, batch_account=ed_wallet.address
+        )
+        expected = [
+            BatchSigner(
+                account="rJy554HmWFFJQGnRfZuoo8nV97XSMq77h7",
+                signing_pub_key=REGKEY_PUBLIC_KEY,
+                txn_signature=(
+                    "046315C731DF089E08EB6662251F12B22938ED462F66BC561A847A87DF6B3C9AC8"
+                    "11D9EC5971EDEC2BA96C959BDE883CD838B7EF6460A47AD9B71518F1A2A00B"
+                ),
+            )
+        ]
+
+        self.assertEqual(result.batch_signers, expected)
+
+    def test_multisign(self):
+        result = sign_multiaccount_batch(
+            regkey_wallet,
+            self.batch_tx,
+            multisign=True,
+            batch_account=ed_wallet.address,
+        )
+        expected = [
+            BatchSigner(
+                account="rJy554HmWFFJQGnRfZuoo8nV97XSMq77h7",
+                signers=[
+                    Signer(
+                        account="rwRNeznwHzdfYeKWpevYmax2NSDioyeEtT",
+                        signing_pub_key=REGKEY_PUBLIC_KEY,
+                        txn_signature=(
+                            "8FCA6C1056C2146DC13F4D10BA297335A82F562D837FA3C65D75DCDC87"
+                            "540F61428B7370FCC1DE4D83B6FA1A00A18CD9283E7B08089091ED84CC"
+                            "3E4A8B43F00F"
+                        ),
+                    )
+                ],
+            )
+        ]
+
+        self.assertEqual(result.batch_signers, expected)
+
+    def test_multisign_with_regular_key(self):
+        result = sign_multiaccount_batch(
+            regkey_wallet,
+            self.batch_tx,
+            multisign=submit_wallet.address,
+            batch_account=ed_wallet.address,
+        )
+        expected = [
+            BatchSigner(
+                account="rJy554HmWFFJQGnRfZuoo8nV97XSMq77h7",
+                signers=[
+                    Signer(
+                        account="rJCxK2hX9tDMzbnn3cg1GU2g19Kfmhzxkp",
+                        signing_pub_key=REGKEY_PUBLIC_KEY,
+                        txn_signature=(
+                            "D80D4195BF67D5CB12CA225D04DA4D00AC77250803671E09DF61F1695A"
+                            "831FAD6BF820F335DD2D8CFE16DA55CFC2E64AEC8A1429524E6CDB6C36"
+                            "B7AEA717C700"
+                        ),
+                    )
+                ],
+            )
+        ]
+
         self.assertEqual(result.batch_signers, expected)
 
     def test_not_included_account(self):

--- a/xrpl/core/binarycodec/main.py
+++ b/xrpl/core/binarycodec/main.py
@@ -5,7 +5,7 @@ decoding them.
 
 from typing import Any, Dict, List, Optional, TypedDict, cast
 
-from typing_extensions import Final
+from typing_extensions import Final, NotRequired
 
 from xrpl.core.binarycodec.binary_wrappers.binary_parser import BinaryParser
 from xrpl.core.binarycodec.types import AccountID, Hash256, STObject, UInt32, UInt64
@@ -73,32 +73,56 @@ def encode_for_signing_claim(json: Dict[str, Any]) -> str:
 
 class BatchSigningDict(TypedDict):
     """
-    A TypedDict for the JSON representation of a Batch transaction that is
-    intended to be signed.
+    A TypedDict describing the data of a Batch transaction that is intended to be
+    signed by a ``BatchSigner`` (XLS-56 ``Batch`` V1_1).
     """
 
+    account: str
+    sequence: int
     flags: int
     transaction_ids: List[str]
+    batch_account: str
+    signer_account: NotRequired[str]
 
 
 def encode_for_signing_batch(json: BatchSigningDict) -> str:
     """
-    Encode a Batch transaction's data to be signed.
+    Encode a Batch transaction's data to be signed by a ``BatchSigner``.
+
+    Serializes the XLS-56 Batch V1_1 signing payload::
+
+        BATCH_PREFIX | Account | Sequence | Flags | len(transaction_ids)
+            | transaction_ids[] | batch_account [ | signer_account ]
+
+    The outer ``account`` and ``sequence`` bind the signature to a specific Batch,
+    preventing it from being replayed under a different outer account or sequence.
 
     Args:
-        json: A JSON-like dictionary representation of Batch data.
+        json: A dictionary describing the Batch signing data. Requires the outer
+            Batch ``account``, its ``sequence`` value (the ``Sequence``, or the
+            ``TicketSequence`` value when a ticket is used), ``flags``, the list of
+            inner ``transaction_ids``, and the ``batch_account`` (the
+            ``BatchSigner.Account`` the signature binds to). ``signer_account`` is the
+            inner ``Signers`` entry account for a multi-signed ``BatchSigner``.
 
     Returns:
-        The binary-encoded Batch data, ready to be signed.
+        The binary-encoded Batch signing data, as an uppercase hex string.
     """
-    prefix = _BATCH_PREFIX
-    flags = UInt32.from_value(json["flags"])
     transaction_ids = json["transaction_ids"]
-    len_transaction_ids = UInt32.from_value(len(transaction_ids))
 
-    buffer = prefix + bytes(flags) + bytes(len_transaction_ids)
+    buffer = _BATCH_PREFIX
+    buffer += bytes(AccountID.from_value(json["account"]))
+    buffer += bytes(UInt32.from_value(json["sequence"]))
+    buffer += bytes(UInt32.from_value(json["flags"]))
+    buffer += bytes(UInt32.from_value(len(transaction_ids)))
     for tx in transaction_ids:
         buffer += bytes(Hash256.from_value(tx))
+
+    buffer += bytes(AccountID.from_value(json["batch_account"]))
+    # The inner signer account is only present for a multi-signed BatchSigner.
+    signer_account = json.get("signer_account")
+    if signer_account is not None:
+        buffer += bytes(AccountID.from_value(signer_account))
 
     return buffer.hex().upper()
 

--- a/xrpl/transaction/batch_signers.py
+++ b/xrpl/transaction/batch_signers.py
@@ -1,6 +1,6 @@
 """Helper functions for signing multi-account Batch transactions."""
 
-from typing import List, Union, cast
+from typing import List, Optional, Union, cast
 
 from xrpl.constants import XRPLException
 from xrpl.core.addresscodec.codec import decode_classic_address
@@ -12,8 +12,28 @@ from xrpl.models.transactions.batch import BatchSigner
 from xrpl.wallet import Wallet
 
 
+def _get_batch_seq_value(transaction: Batch) -> int:
+    """
+    Resolve the sequence value bound into a Batch signature: the ``Sequence`` when
+    non-zero, otherwise the ``TicketSequence`` value (or 0).
+
+    Args:
+        transaction: The Batch transaction being signed.
+
+    Returns:
+        The sequence value to bind into the signature.
+    """
+    sequence = transaction.sequence or 0
+    if sequence != 0:
+        return sequence
+    return transaction.ticket_sequence or 0
+
+
 def sign_multiaccount_batch(
-    wallet: Wallet, transaction: Batch, multisign: bool = False
+    wallet: Wallet,
+    transaction: Batch,
+    multisign: Union[bool, str] = False,
+    batch_account: Optional[str] = None,
 ) -> Batch:
     """
     Sign a multi-account Batch transaction.
@@ -21,39 +41,63 @@ def sign_multiaccount_batch(
     Args:
         wallet: Wallet instance.
         transaction: The Batch transaction to sign.
-        multisign: Specify true/false to use multisign. Defaults to False.
+        multisign: Specify ``True`` to multi-sign with ``wallet``'s address, or pass
+            an address string to multi-sign on behalf of that account (e.g. when
+            signing with a regular key). Defaults to ``False`` (single-sign).
+        batch_account: The account included in the Batch on whose behalf this
+            signature is provided. Defaults to ``wallet``'s address. Use this when the
+            signing key differs from the account it signs for (e.g. a regular key).
 
     Raises:
-        XRPLException: If the wallet signing the transaction doesn't have an account in
-            the Batch.
+        XRPLException: If the account signing the transaction doesn't submit (or is
+            the counterparty of) an inner transaction in the Batch.
 
     Returns:
         The Batch transaction with the BatchSigner included.
     """
+    signing_account = batch_account if batch_account is not None else wallet.address
+
+    multisign_address: Union[bool, str] = False
+    if isinstance(multisign, str):
+        multisign_address = multisign
+    elif multisign:
+        multisign_address = wallet.address
+
+    # An account must sign the Batch if it submits an inner transaction or is the
+    # `Counterparty` of one.
     involved_accounts = set(tx.account for tx in transaction.raw_transactions)
-    if wallet.address not in involved_accounts:
+    for tx in transaction.raw_transactions:
+        counterparty = getattr(tx, "counterparty", None)
+        if isinstance(counterparty, str):
+            involved_accounts.add(counterparty)
+    if signing_account not in involved_accounts:
         raise XRPLException("Must be signing for an address included in the Batch.")
 
     fields_to_sign: BatchSigningDict = {
+        "account": transaction.account,
+        "sequence": _get_batch_seq_value(transaction),
         "flags": transaction._flags_to_int() or 0,
         "transaction_ids": [tx.get_hash() for tx in transaction.raw_transactions],
+        "batch_account": signing_account,
     }
-    if multisign:
+    if multisign_address:
+        # Multi-signed batch signers also bind the inner signer account.
+        fields_to_sign["signer_account"] = multisign_address
+
+    signature = sign(encode_for_signing_batch(fields_to_sign), wallet.private_key)
+
+    if multisign_address:
         signer = Signer(
-            account=wallet.address,
+            account=multisign_address,
             signing_pub_key=wallet.public_key,
-            txn_signature=sign(
-                encode_for_signing_batch(fields_to_sign), wallet.private_key
-            ),
+            txn_signature=signature,
         )
-        batch_signer = BatchSigner(account=wallet.address, signers=[signer])
+        batch_signer = BatchSigner(account=signing_account, signers=[signer])
     else:
         batch_signer = BatchSigner(
-            account=wallet.address,
+            account=signing_account,
             signing_pub_key=wallet.public_key,
-            txn_signature=sign(
-                encode_for_signing_batch(fields_to_sign), wallet.private_key
-            ),
+            txn_signature=signature,
         )
 
     transaction_dict = transaction.to_dict()

--- a/xrpl/transaction/batch_signers.py
+++ b/xrpl/transaction/batch_signers.py
@@ -1,6 +1,6 @@
 """Helper functions for signing multi-account Batch transactions."""
 
-from typing import List, Optional, Union, cast
+from typing import List, Optional, Tuple, Union, cast
 
 from xrpl.constants import XRPLException
 from xrpl.core.addresscodec.codec import decode_classic_address
@@ -150,29 +150,51 @@ def combine_batch_signers(transactions: List[Union[Batch, str]]) -> str:
     return encode(_get_batch_with_all_signers(batch_txs).to_xrpl())
 
 
+def _get_batch_equivalence_key(tx: Batch) -> Tuple[str, int, int, Tuple[str, ...]]:
+    """
+    Build a comparison key over every field bound into a Batch signature
+    (XLS-56 V1_1): the outer account, sequence value, flags, and inner transaction
+    IDs. Fragments that disagree on any of these were signed over different payloads
+    and cannot be combined.
+    """
+    return (
+        tx.account,
+        _get_batch_seq_value(tx),
+        tx._flags_to_int() or 0,
+        tuple(raw_tx.get_hash() for raw_tx in tx.raw_transactions),
+    )
+
+
 def _validate_batch_equivalence(transactions: List[Batch]) -> None:
-    example_tx = transactions[0]
-    for tx in transactions:
-        if (
-            tx.flags != example_tx.flags
-            or tx.raw_transactions != example_tx.raw_transactions
-        ):
+    example_key = _get_batch_equivalence_key(transactions[0])
+    for tx in transactions[1:]:
+        if _get_batch_equivalence_key(tx) != example_key:
             raise XRPLException(
-                "Flags and RawTransactions are not the same for all provided "
-                "transactions."
+                "Account, sequence, flags, and transaction hashes must be the same "
+                "for all provided transactions."
             )
 
 
 def _get_batch_with_all_signers(transactions: List[Batch]) -> Batch:
-    batch_signers = [
-        signer
-        for tx in transactions
-        if tx.batch_signers is not None
-        for signer in tx.batch_signers
-        if signer.account != transactions[0].account
-    ]
-    batch_signers.sort(
-        key=lambda signer: decode_classic_address(signer.account).hex().upper()
+    outer_account = transactions[0].account
+    # A batch signer cannot be the outer account (rippled: temBAD_SIGNER).
+    batch_signers = sorted(
+        (
+            signer
+            for tx in transactions
+            if tx.batch_signers is not None
+            for signer in tx.batch_signers
+            if signer.account != outer_account
+        ),
+        key=lambda signer: decode_classic_address(signer.account).hex().upper(),
     )
+    # BatchSigners must be strictly ascending and unique by account, so
+    # de-duplicate when combining fragments that share a signer.
+    deduped_signers: List[BatchSigner] = []
+    last_account: Optional[str] = None
+    for signer in batch_signers:
+        if signer.account != last_account:
+            deduped_signers.append(signer)
+            last_account = signer.account
     returned_tx_dict = transactions[0].to_dict()
-    return Batch.from_dict({**returned_tx_dict, "batch_signers": batch_signers})
+    return Batch.from_dict({**returned_tx_dict, "batch_signers": deduped_signers})

--- a/xrpl/transaction/batch_signers.py
+++ b/xrpl/transaction/batch_signers.py
@@ -57,7 +57,7 @@ def sign_multiaccount_batch(
     """
     signing_account = batch_account if batch_account is not None else wallet.address
 
-    multisign_address: Union[bool, str] = False
+    multisign_address: Optional[str] = None
     if isinstance(multisign, str):
         multisign_address = multisign
     elif multisign:


### PR DESCRIPTION
Implements XLS-56 Batch **V1_1** signing, matching rippled [#6446](https://github.com/XRPLF/rippled/pull/6446).

- **binarycodec** — `encode_for_signing_batch` now binds the outer `Account`, `Sequence` (or `TicketSequence`), the `BatchSigner` account, and (for multi-signed signers) the inner signer account into the signed payload, preventing signature replay.
- **`sign_multiaccount_batch`** — builds the V1_1 payload; adds `batch_account` and regular-key / string `multisign` support.
- **`combine_batch_signers`** — validates the full payload (account, sequence, flags, tx IDs) and de-duplicates signers.
- **Tests** — byte-level codec vectors, signing/combine unit tests (cross-checked against xrpl.js), and integration tests (all-or-nothing, independent, multi-account, combine, ticket sequence).

**Breaking:** batch signatures from older versions are no longer valid; re-sign against a `BatchV1_1` network.

Depends on rippled#6446 (`BatchV1_1`). CI runs the integration suite against a rippled built from that PR;

🤖 Generated with [Claude Code](https://claude.com/claude-code)