### PR TITLE
fix: make 160-bit Currency decoding robust and non-raising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [[Unreleased]]
 
+### Fixed
+
+- Fixed `Currency` decoder to classify a 160-bit currency code as a standard ISO code only when it has the exact standard layout (12 leading zero bytes, 3 ASCII code bytes, 5 trailing zero bytes); malformed codes such as `0000000000000000000000005553440000000001` now render as their raw 40-char hex instead of being misclassified as `USD`, matching rippled and xrpl.js (issue #1006).
+- Fixed `Currency` decoder so decoding a 160-bit code never raises: non-ASCII code bytes no longer raise `UnicodeDecodeError`, and bytes spelling `XRP` in the code position render as raw hex instead of raising `XRPLBinaryCodecException`. Every 20-byte buffer now decodes to `XRP`, a 3-char ISO code, or the raw 40-char hex, matching rippled and xrpl.js (issue #1007).
+
 ## [[5.0.0]]
 
 ### BREAKING CHANGE

--- a/tests/unit/core/binarycodec/types/test_currency.py
+++ b/tests/unit/core/binarycodec/types/test_currency.py
@@ -4,10 +4,19 @@ import xrpl.core.binarycodec.types.currency as currency
 from xrpl.core.binarycodec.exceptions import XRPLBinaryCodecException
 
 XRP_HEX_CODE = "0000000000000000000000000000000000000000"
-ILLEGAL_XRP_HEX_CODE = "0000000000000000000000005852500000000000"
+# 'XRP' (0x585250) in the standard code position: renders as raw hex on decode
+# (only 20 zero bytes mean XRP), matching rippled and xrpl.js.
+XRP_IN_STANDARD_POSITION_HEX_CODE = "0000000000000000000000005852500000000000"
 USD_HEX_CODE = "0000000000000000000000005553440000000000"
 NONSTANDARD_HEX_CODE = "015841551A748AD2C1F76FF6ECB0CCCD00000000"
 NOT_RECOMMENDED_HEX_CODE = "0000000000414C6F676F30330000000000000000"
+# Standard layout but a non-ASCII code byte (0x80): raw hex, no raise (#1007).
+NON_ASCII_CODE_HEX = "0000000000000000000000008000000000000000"
+# Standard layout but a non-ASCII code byte (0xFF) between ASCII bytes (#1007).
+MIXED_NON_ASCII_CODE_HEX = "00000000000000000000000041FF420000000000"
+# ASCII 'USD' code but a non-zero trailing reserved byte: raw hex, not "USD"
+# (#1006 -- must not be misclassified as the canonical USD code).
+MALFORMED_USD_TRAILING_HEX = "0000000000000000000000005553440000000001"
 XRP_ISO = "XRP"
 USD_ISO = "USD"
 
@@ -81,7 +90,78 @@ class TestCurrency(TestCase):
             XRPLBinaryCodecException, currency.Currency.from_value, invalid_value
         )
 
-    def test_raises_invalid_xrp_encoding(self):
+    def test_raises_unsupported_representation(self):
+        # Encode-side validation is unchanged: a string that is neither a
+        # 3-char ISO code nor a 40-char hex string is still rejected.
+        for disallowed in ("INVALID", "XR", "12345", "GG"):
+            self.assertRaises(
+                XRPLBinaryCodecException,
+                currency.Currency.from_value,
+                disallowed,
+            )
+
+    def test_raises_invalid_hex_length(self):
+        # A hex string of the wrong length remains an encode-side error.
         self.assertRaises(
-            XRPLBinaryCodecException, currency.Currency.from_value, ILLEGAL_XRP_HEX_CODE
+            XRPLBinaryCodecException,
+            currency.Currency.from_value,
+            "00000000000000000000000055534400000000",  # 38 chars
         )
+
+    def test_decode_never_raises_and_renders_hex(self):
+        # #1006 / #1007: decoding any 20-byte buffer must never raise and must
+        # render as raw uppercase hex when it is not XRP or a valid ISO code.
+        for hex_code in (
+            XRP_IN_STANDARD_POSITION_HEX_CODE,
+            NON_ASCII_CODE_HEX,
+            MIXED_NON_ASCII_CODE_HEX,
+            MALFORMED_USD_TRAILING_HEX,
+        ):
+            currency_object = currency.Currency.from_value(hex_code)
+            self.assertEqual(currency_object.to_json(), hex_code.upper())
+
+    def test_xrp_in_standard_position_decodes_to_hex(self):
+        # Bytes spelling 'XRP' in the code position render as raw hex on decode
+        # (matching rippled and xrpl.js), rather than raising (#1007).
+        currency_object = currency.Currency.from_value(
+            XRP_IN_STANDARD_POSITION_HEX_CODE
+        )
+        self.assertEqual(currency_object.to_json(), XRP_IN_STANDARD_POSITION_HEX_CODE)
+
+    def test_malformed_usd_is_not_iso(self):
+        # #1006: a standard 'USD' code with a non-zero trailing reserved byte
+        # must not be misclassified as the canonical USD ISO code.
+        currency_object = currency.Currency.from_value(MALFORMED_USD_TRAILING_HEX)
+        self.assertEqual(currency_object.to_json(), MALFORMED_USD_TRAILING_HEX)
+        self.assertNotEqual(currency_object.to_json(), USD_ISO)
+
+    def test_canonical_codes_still_decode_to_iso(self):
+        # Canonical USD and all-zero XRP still resolve to their ISO codes.
+        self.assertEqual(currency.Currency.from_value(USD_HEX_CODE).to_json(), USD_ISO)
+        self.assertEqual(currency.Currency.from_value(XRP_HEX_CODE).to_json(), XRP_ISO)
+
+    def test_decode_round_trip(self):
+        # #1006 / #1007: for every malformed case, the bytes survive
+        # Currency(bytes) -> to_json() -> Currency.from_value(hex).
+        for hex_code in (
+            XRP_HEX_CODE,
+            USD_HEX_CODE,
+            XRP_IN_STANDARD_POSITION_HEX_CODE,
+            NON_ASCII_CODE_HEX,
+            MIXED_NON_ASCII_CODE_HEX,
+            MALFORMED_USD_TRAILING_HEX,
+            NONSTANDARD_HEX_CODE,
+            NOT_RECOMMENDED_HEX_CODE,
+        ):
+            original = currency.Currency.from_value(hex_code)
+            round_tripped = currency.Currency.from_value(original.to_json())
+            self.assertEqual(round_tripped.buffer, original.buffer)
+            self.assertEqual(round_tripped.buffer.hex().upper(), hex_code.upper())
+
+    def test_iso_code_from_hex_never_raises(self):
+        # Direct unit check: non-ASCII and 'XRP' code bytes yield None, never
+        # a UnicodeDecodeError or XRPLBinaryCodecException (#1007).
+        self.assertIsNone(currency._iso_code_from_hex(b"\x80\x00\x00"))
+        self.assertIsNone(currency._iso_code_from_hex(b"\x41\xff\x42"))
+        self.assertIsNone(currency._iso_code_from_hex(b"XRP"))
+        self.assertEqual(currency._iso_code_from_hex(b"USD"), "USD")

--- a/xrpl/core/binarycodec/types/currency.py
+++ b/xrpl/core/binarycodec/types/currency.py
@@ -19,12 +19,23 @@ def _is_iso_code(value: str) -> bool:
 
 
 def _iso_code_from_hex(value: bytes) -> Optional[str]:
-    candidate_iso = value.decode("ascii")
+    """
+    Decode the 3 ASCII bytes of a standard-format currency code to an ISO code.
+
+    Returns ``None`` (so the caller renders the raw hex) rather than raising
+    when the bytes are not ASCII, spell the reserved code ``XRP``, or are not a
+    valid ISO code. This mirrors rippled and xrpl.js, which never raise while
+    decoding a 160-bit currency and fall back to the raw hex representation.
+    """
+    try:
+        candidate_iso = value.decode("ascii")
+    except UnicodeDecodeError:
+        # Non-ASCII bytes in the code position are not a standard ISO code.
+        return None
     if candidate_iso == "XRP":
-        raise XRPLBinaryCodecException(
-            "Disallowed currency code: to indicate the currency "
-            "XRP you must use 20 bytes of 0s"
-        )
+        # 'XRP' in the standard code position is not a valid ISO code; on
+        # decode it is rendered as raw hex (only 20 zero bytes mean XRP).
+        return None
     if _is_iso_code(candidate_iso):
         return candidate_iso
     return None
@@ -33,6 +44,23 @@ def _iso_code_from_hex(value: bytes) -> Optional[str]:
 def _is_hex(value: str) -> bool:
     """Tests if value is a valid 40-char hex string."""
     return bool(HEX_CURRENCY_REGEX.fullmatch(value))
+
+
+def _is_standard_code(buffer: bytes) -> bool:
+    """
+    Tests if a 20-byte buffer is in the standard currency-code format.
+
+    A standard code is 12 leading zero bytes, 3 ASCII bytes holding the code,
+    then 5 trailing zero bytes. Any other layout (a non-zero type/reserved
+    byte, non-ASCII code bytes, or non-zero trailing bytes) is a non-standard
+    code and is rendered as raw hex. This matches the ``STANDARD_FORMAT`` check
+    in rippled and xrpl.js.
+    """
+    return (
+        buffer[0:12] == bytes(12)
+        and buffer[15:20] == bytes(5)
+        and all(byte <= 0x7F for byte in buffer[12:15])
+    )
 
 
 def _iso_to_bytes(iso: str) -> bytes:
@@ -81,17 +109,18 @@ class Currency(Hash160):
         else:
             super().__init__(bytes(self.LENGTH))
 
-        code_bytes = self.buffer[12:15]
         # Determine whether this currency code is in standard or nonstandard format:
         # https://xrpl.org/currency-formats.html#nonstandard-currency-codes
-        if self.buffer[0] != 0:
-            # non-standard currency
-            self._iso = None
-        elif self.buffer.hex() == "0" * 40:  # all 0s
+        # Decoding never raises: any 20-byte buffer resolves to "XRP", a 3-char
+        # ISO code, or (via to_json) the raw 40-char hex string.
+        if self.buffer == bytes(self.LENGTH):  # all 0s
             # the special case for literal XRP
             self._iso = "XRP"
+        elif _is_standard_code(self.buffer):
+            self._iso = _iso_code_from_hex(self.buffer[12:15])
         else:
-            self._iso = _iso_code_from_hex(code_bytes)
+            # non-standard currency, rendered as raw hex by to_json
+            self._iso = None
 
     @classmethod
     def from_value(cls: Type[Self], value: str) -> Self:


### PR DESCRIPTION
## High Level Overview of Change

Fixes #1006. Fixes #1007.

Two related defects in `xrpl/core/binarycodec/types/currency.py`'s decode path:

1. **Misclassification (#1006):** the decoder decided "standard ISO code" by checking only `buffer[0] != 0`, so a malformed 160-bit code like `0000000000000000000000005553440000000001` (non-zero trailing reserved byte) decoded to `"USD"` — indistinguishable from canonical USD. rippled and xrpl.js render it as the raw 40-char hex.
2. **Crash (#1007):** `_iso_code_from_hex` called `value.decode("ascii")` unguarded, so non-ASCII bytes in positions 12–14 (e.g. `0x80`, `0xFF`) raised an uncaught `UnicodeDecodeError` (not an `XRPLBinaryCodecException`, so typed handlers miss it). Bytes spelling `"XRP"` in the code position also raised on **decode**, where rippled and xrpl.js render raw hex.

The fix introduces `_is_standard_code(buffer)`, which requires the exact standard layout (12 leading zero bytes, 3 ASCII code bytes each ≤ `0x7F`, 5 trailing zero bytes), and guards the ASCII decode. Decoding any 20-byte buffer now never raises and always yields `"XRP"`, a 3-char ISO code, or the raw 40-char uppercase hex — matching rippled and xrpl.js (verified against `ripple-binary-codec`'s `currency.ts` and its "dodgy XRP" decode tests).

### Context of Change

The classification bug predates MPT/newer work — it's the original single-byte check. Encode-side validation (`from_value` / `_iso_to_bytes`) is intentionally unchanged for genuinely unsupported inputs (wrong type, non-hex/non-ISO strings, wrong-length hex all still raise `XRPLBinaryCodecException`, now pinned by tests). One deliberate behavior change on the encode side: `from_value("0000000000000000000000005852500000000000")` (hex spelling "XRP" in the code region) no longer raises, because the decode path must emit exactly that hex for such buffers and decode→encode round-trips must reproduce identical bytes — this matches xrpl.js, whose codec also accepts it.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Did you update CHANGELOG.md?

- [x] Yes

## Test Plan

- New/extended tests in `tests/unit/core/binarycodec/types/test_currency.py` (16 tests): canonical USD → `"USD"`; malformed trailing-byte USD → raw hex; `0x80` code byte → raw hex (no raise); `41FF42` → raw hex (no raise); XRP-in-code-position → raw hex (no raise); all-zero → `"XRP"`; decode-never-raises sweep; `Currency(bytes) → to_json() → from_value(hex)` round-trips to identical bytes; encode-side rejections pinned (`test_raises_invalid_value_type`, `test_raises_unsupported_representation`, `test_raises_invalid_hex_length`).
- Full `python -m unittest discover tests/unit` — no new failures.
- Cross-SDK parity verified against xrpl.js `packages/ripple-binary-codec/src/types/currency.ts` for every case above, plus a 20,000-buffer random fuzz of the decode path with zero raises.