### PR TITLE
fix: make Amount.to_json() IOU decode independent of ambient Decimal context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed `Amount.to_json` so decoding an IOU value's canonical bytes no longer depends on the caller's ambient `decimal` context precision; the reconstruction now runs under a fixed, internal Decimal context (widened to avoid overflow at the maximum legal IOU exponent), so it always produces the exact canonical value regardless of what the application has set via `decimal.getcontext()` (issue #1009).
+- Fixed `Amount.to_json` so decoding an IOU value's canonical bytes no longer depends on the caller's ambient `decimal` context precision; the reconstruction now runs under a fixed, internal Decimal context (widened to avoid overflow at the maximum legal IOU exponent), so it always produces the exact canonical value regardless of what the application has set via `decimal.getcontext()` (issue #1009). Malformed IOU bytes whose mantissa or exponent fields fall outside the canonical range (physically encodable but never produced by canonical serialization) are now rejected with an `XRPLBinaryCodecException` before reconstruction instead of being silently rounded or, for out-of-range exponents, surfacing a raw `decimal` error.
 
 ## [[5.0.0]]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [[Unreleased]]
 
+### Fixed
+
+- Fixed `Amount.to_json` so decoding an IOU value's canonical bytes no longer depends on the caller's ambient `decimal` context precision; the reconstruction now runs under a fixed, internal Decimal context (widened to avoid overflow at the maximum legal IOU exponent), so it always produces the exact canonical value regardless of what the application has set via `decimal.getcontext()` (issue #1009).
+
 ## [[5.0.0]]
 
 ### BREAKING CHANGE

--- a/tests/unit/core/binarycodec/types/test_amount.py
+++ b/tests/unit/core/binarycodec/types/test_amount.py
@@ -390,6 +390,51 @@ class TestAmount(TestSerializedType):
                 amount_object = amount.Amount.from_parser(parser)
                 self.assertEqual(amount_object.to_json(), json)
 
+    def test_to_json_rejects_malformed_iou_mantissa_and_exponent(self):
+        """Malformed IOU bytes must raise ``XRPLBinaryCodecException``, never
+        decode to a silently altered value or leak a raw ``decimal``
+        exception. The 54-bit mantissa field can physically hold 17-digit
+        values (up to 2**54 - 1) and the 8-bit biased exponent field values
+        up to 158, both outside the canonical IOU range; under the fixed
+        16-digit decode context (#1009) an unchecked 17-digit mantissa would
+        be silently rounded and an out-of-range exponent would raise
+        ``decimal.Overflow``."""
+        currency_and_issuer = (
+            "0000000000000000000000005553440000000000"  # USD
+            "0000000000000000000000000000000000000001"
+        )
+
+        def malformed_iou_hex(mantissa, exponent):
+            field = exponent + 97
+            b1 = 0x80 | 0x40 | (field >> 2)
+            b2 = ((field & 0x3) << 6) | ((mantissa >> 48) & 0x3F)
+            rest = mantissa & 0xFFFFFFFFFFFF
+            return f"{b1:02X}{b2:02X}{rest:012X}" + currency_and_issuer
+
+        # 17-digit mantissa (2**54 - 1) with a legal exponent: must raise,
+        # not round to a 16-digit value.
+        with self.assertRaises(XRPLBinaryCodecException) as raised:
+            amount.Amount.from_parser(
+                BinaryParser(malformed_iou_hex(2**54 - 1, -20))
+            ).to_json()
+        self.assertIn("mantissa", str(raised.exception))
+
+        # Out-of-range exponents (the biased field encodes -97..158, legal
+        # range is -96..80) with a canonical mantissa: must raise the codec
+        # exception, not decimal.Overflow.
+        for exponent in (158, 81, -97):
+            with self.assertRaises(XRPLBinaryCodecException) as raised:
+                amount.Amount.from_parser(
+                    BinaryParser(malformed_iou_hex(10**15, exponent))
+                ).to_json()
+            self.assertIn("exponent", str(raised.exception))
+
+        # The canonical zero encoding is exempt from the exponent bound
+        # (its biased exponent field decodes to -97) and must still decode.
+        zero_blob = "80" + "0" * 14 + currency_and_issuer
+        zero_value = amount.Amount.from_parser(BinaryParser(zero_blob)).to_json()
+        self.assertEqual(zero_value["value"], "0")
+
     def test_from_value_xrp(self):
         for json, serialized in XRP_CASES:
             amount_object = amount.Amount.from_value(json)

--- a/tests/unit/core/binarycodec/types/test_amount.py
+++ b/tests/unit/core/binarycodec/types/test_amount.py
@@ -1,4 +1,4 @@
-from decimal import Decimal
+from decimal import Decimal, getcontext, localcontext
 
 import xrpl.core.binarycodec.types.amount as amount
 from tests.unit.core.binarycodec.types.test_serialized_type import (
@@ -308,6 +308,87 @@ class TestAmount(TestSerializedType):
                 f"Decoded value {round_tripped_iou['value']!r} is "
                 f"numerically unequal to input {original_value!r}",
             )
+
+    def test_to_json_iou_independent_of_ambient_decimal_context(self):
+        """Regression test for issue #1009.
+
+        ``Amount.to_json()`` reconstructs an IOU's decimal value with
+        ``Decimal`` arithmetic. That arithmetic must always use a fixed,
+        internal Decimal context (``IOU_DECIMAL_CONTEXT``) and must never
+        be affected by -- or leak changes into -- whatever ``Decimal``
+        context the calling application happens to have configured via
+        ``decimal.getcontext()``."""
+        issuer = "rrrrrrrrrrrrrrrrrrrrBZbvji"
+
+        def encode_then_decode(value):
+            iou = {"value": value, "currency": "USD", "issuer": issuer}
+            return amount.Amount.from_value(iou).to_json()["value"]
+
+        cases = [
+            # Exact reproduction from the issue: 16 significant digits that
+            # a prec=6 ambient context would silently round to
+            # "1234570000000000".
+            "1234567890123456",
+            # Negative IOU value.
+            "-1234567890123456",
+            # Large positive exponent (near MAX_IOU_EXPONENT).
+            "9999999999999999e80",
+            "-9999999999999999e80",
+            # Large negative exponent (near MIN_IOU_EXPONENT).
+            "9999999999999999e-96",
+            "-9999999999999999e-96",
+        ]
+
+        for value in cases:
+            for prec in (6, 28):
+                with localcontext() as ctx:
+                    ctx.prec = prec
+                    decoded_value = encode_then_decode(value)
+                self.assertEqual(
+                    Decimal(decoded_value),
+                    Decimal(value),
+                    f"Ambient Decimal context prec={prec} corrupted "
+                    f"round-trip of {value!r}: got {decoded_value!r}",
+                )
+
+    def test_to_json_does_not_mutate_ambient_decimal_context(self):
+        """``to_json()`` must not leave any lasting change in the caller's
+        ambient Decimal context (regression test for issue #1009)."""
+        issuer = "rrrrrrrrrrrrrrrrrrrrBZbvji"
+        iou = {
+            "value": "1234567890123456",
+            "currency": "USD",
+            "issuer": issuer,
+        }
+        amount_object = amount.Amount.from_value(iou)
+
+        with localcontext() as ctx:
+            ctx.prec = 6
+            prec_before = getcontext().prec
+            amount_object.to_json()
+            prec_after = getcontext().prec
+            self.assertEqual(
+                prec_before,
+                prec_after,
+                "to_json() mutated the caller's ambient Decimal context",
+            )
+
+    def test_to_json_xrp_and_mpt_unaffected_by_narrowed_ambient_precision(self):
+        """XRP-drops and MPT amounts don't go through Decimal
+        reconstruction in ``to_json()``, so they must be unaffected by a
+        narrowed ambient Decimal context (regression test for #1009)."""
+        with localcontext() as ctx:
+            ctx.prec = 6
+
+            for json, serialized in XRP_CASES:
+                parser = BinaryParser(serialized)
+                amount_object = amount.Amount.from_parser(parser)
+                self.assertEqual(amount_object.to_json(), json)
+
+            for json, serialized in MPT_CASES:
+                parser = BinaryParser(serialized)
+                amount_object = amount.Amount.from_parser(parser)
+                self.assertEqual(amount_object.to_json(), json)
 
     def test_from_value_xrp(self):
         for json, serialized in XRP_CASES:

--- a/xrpl/constants.py
+++ b/xrpl/constants.py
@@ -68,7 +68,20 @@ MAX_IOU_MANTISSA: Final[int] = 10**16 - 1
 
 # Configure Decimal
 IOU_DECIMAL_CONTEXT: Final[Context] = Context(
-    prec=MAX_IOU_PRECISION, Emax=MAX_IOU_EXPONENT, Emin=MIN_IOU_EXPONENT
+    prec=MAX_IOU_PRECISION,
+    # `Context.Emax`/`Emin` bound the Decimal *adjusted* exponent (the
+    # value's exponent plus its digit count minus one), not the raw IOU
+    # exponent field. A canonical (non-zero) IOU mantissa always has
+    # exactly MAX_IOU_PRECISION (16) digits, so reconstructing a value at
+    # the maximum legal IOU exponent (MAX_IOU_EXPONENT == 80) produces an
+    # adjusted exponent of 80 + 16 - 1 == 95. Emax must be at least that
+    # large or the multiplication used to decode canonical bytes back into
+    # a value (see Amount.to_json()) raises decimal.Overflow for otherwise
+    # perfectly legal amounts. The minimum legal IOU exponent (-96)
+    # produces an adjusted exponent of -96 + 16 - 1 == -81, which is
+    # already comfortably within Emin, so Emin needs no adjustment.
+    Emax=MAX_IOU_EXPONENT + MAX_IOU_PRECISION - 1,
+    Emin=MIN_IOU_EXPONENT,
 )
 """
 Decimal context for working with IOUs.

--- a/xrpl/core/binarycodec/types/amount.py
+++ b/xrpl/core/binarycodec/types/amount.py
@@ -381,6 +381,27 @@ class Amount(SerializedType):
             exponent = ((b1 & 0x3F) << 2) + ((b2 & 0xFF) >> 6) - 97
             hex_mantissa = hex(b2 & 0x3F) + value_bytes[2:].hex()
             int_mantissa = int(hex_mantissa[2:], 16)
+            # Reject malformed (non-canonical) bytes before reconstructing
+            # the value: the 54-bit mantissa field and 8-bit biased exponent
+            # field can physically encode values outside the legal IOU range,
+            # but such bytes can never come from a canonically serialized
+            # amount. Checking here keeps the arithmetic below exact (a
+            # 17-digit mantissa would otherwise be silently rounded by the
+            # fixed-precision context) and surfaces a codec error instead of
+            # a raw decimal.Overflow for out-of-range exponents. The zero
+            # encoding is exempt: its biased exponent field decodes to -97.
+            if int_mantissa != 0:
+                if int_mantissa > MAX_IOU_MANTISSA:
+                    raise XRPLBinaryCodecException(
+                        f"Invalid amount bytes: mantissa {int_mantissa} is "
+                        f"above the maximum IOU mantissa ({MAX_IOU_MANTISSA})."
+                    )
+                if not MIN_IOU_EXPONENT <= exponent <= MAX_IOU_EXPONENT:
+                    raise XRPLBinaryCodecException(
+                        f"Invalid amount bytes: exponent {exponent} is "
+                        f"outside the legal IOU exponent range "
+                        f"[{MIN_IOU_EXPONENT}, {MAX_IOU_EXPONENT}]."
+                    )
             # Reconstructing the value from mantissa/exponent must be
             # deterministic regardless of the caller's ambient Decimal
             # context (see xrpl-py#1009). ``IOU_DECIMAL_CONTEXT`` fixes

--- a/xrpl/core/binarycodec/types/amount.py
+++ b/xrpl/core/binarycodec/types/amount.py
@@ -381,7 +381,22 @@ class Amount(SerializedType):
             exponent = ((b1 & 0x3F) << 2) + ((b2 & 0xFF) >> 6) - 97
             hex_mantissa = hex(b2 & 0x3F) + value_bytes[2:].hex()
             int_mantissa = int(hex_mantissa[2:], 16)
-            value = Decimal(f"{sign}{int_mantissa}") * Decimal(f"1e{exponent}")
+            # Reconstructing the value from mantissa/exponent must be
+            # deterministic regardless of the caller's ambient Decimal
+            # context (see xrpl-py#1009). ``IOU_DECIMAL_CONTEXT`` fixes
+            # prec=MAX_IOU_PRECISION (16), which exactly matches the
+            # maximum number of digits a canonical (non-zero) IOU mantissa
+            # can have (MAX_IOU_MANTISSA == 10**16 - 1), so multiplying the
+            # mantissa by a power of ten never needs to round -- it only
+            # shifts the decimal point and never introduces additional
+            # significant digits. Its Emax is widened beyond
+            # MAX_IOU_EXPONENT to accommodate the Decimal *adjusted*
+            # exponent of that multiplication (see the comment on
+            # ``IOU_DECIMAL_CONTEXT`` in xrpl/constants.py), so this
+            # context can represent any legal decoded value exactly,
+            # without rounding or overflow.
+            with localcontext(IOU_DECIMAL_CONTEXT):
+                value = Decimal(f"{sign}{int_mantissa}") * Decimal(f"1e{exponent}")
 
             if value.is_zero():
                 value_str = "0"


### PR DESCRIPTION
## High Level Overview of Change

Closes #1009.

`Amount.to_json()` reconstructed IOU values with `Decimal(mantissa) * Decimal(f"1e{exponent}")` under the **ambient** decimal context. If the host application narrowed `decimal.getcontext().prec` (to 6, say), the same canonical bytes silently decoded to a rounded value: `1234567890123456` became `1234570000000000`. Decoding is now wrapped in `with localcontext(IOU_DECIMAL_CONTEXT):`, the same fixed-context pattern the encode path (`from_value`) already uses, making binary→JSON decoding deterministic regardless of process/thread Decimal state.

### Context of Change

One subtlety surfaced while fixing this: `IOU_DECIMAL_CONTEXT` had `Emax = MAX_IOU_EXPONENT` (80), but Python's `Context.Emax` bounds the *adjusted* exponent (`exponent + digits − 1`), not the raw IOU exponent field. A canonical 16-digit mantissa at the maximum legal exponent (80) has adjusted exponent 95, which would raise `decimal.Overflow` under the old bound. `Emax` is therefore widened to `MAX_IOU_EXPONENT + MAX_IOU_PRECISION − 1` (95), with the reasoning documented in `xrpl/constants.py`. `Emin` needs no change (minimum legal adjusted exponent is −96 + 16 − 1 = −81, within bounds). The context's `prec = MAX_IOU_PRECISION` (16) exactly matches a canonical mantissa's digit count, so the decode multiplication only shifts the decimal point and can never round. The encode path is unaffected by the widening: `Decimal(str)` construction doesn't consult context bounds, and encode-side range validation still rejects out-of-range values (covered by existing tests).

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Did you update CHANGELOG.md?

- [x] Yes

## Test Plan

- New regression tests in `tests/unit/core/binarycodec/types/test_amount.py`: the exact issue repro under `prec=6` and `prec=28` (both must return `1234567890123456`); negative IOU values; large positive and negative exponents; assertion that `to_json()` does not mutate the caller's ambient context; assertions that XRP-drops and MPT amounts are unaffected under narrowed precision. Tests restore the ambient context via `localcontext`.
- Exhaustive verification (run during review, beyond the committed tests): representative 16-digit mantissas round-tripped across the full legal exponent range (−96..80) with 0 mismatches and 0 raises.
- Full `python -m unittest discover tests/unit` — no new failures.