### PR TITLE
Add missing Vault and Loan/LoanBroker types to NON_DELEGABLE_TRANSACTIONS

### DIFF
--- a/tests/unit/models/transactions/test_delegate_set.py
+++ b/tests/unit/models/transactions/test_delegate_set.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from xrpl.models.exceptions import XRPLModelException
 from xrpl.models.transactions import DelegateSet
 from xrpl.models.transactions.delegate_set import (
+    NON_DELEGABLE_TRANSACTIONS,
     PERMISSIONS_MAX_LENGTH,
     GranularPermission,
     Permission,
@@ -112,3 +113,29 @@ class TestDelegateSet(TestCase):
             "{'permissions': \"Non-delegable transactions found in `permissions` "
             "list: {<TransactionType.ACCOUNT_DELETE: 'AccountDelete'>}.\"}",
         )
+
+    def test_non_delegable_transactions_vault_and_loan_family(self):
+        for transaction_type in [
+            TransactionType.VAULT_CREATE,
+            TransactionType.VAULT_SET,
+            TransactionType.VAULT_DELETE,
+            TransactionType.VAULT_DEPOSIT,
+            TransactionType.VAULT_WITHDRAW,
+            TransactionType.VAULT_CLAWBACK,
+            TransactionType.LOAN_BROKER_SET,
+            TransactionType.LOAN_BROKER_DELETE,
+            TransactionType.LOAN_BROKER_COVER_DEPOSIT,
+            TransactionType.LOAN_BROKER_COVER_WITHDRAW,
+            TransactionType.LOAN_BROKER_COVER_CLAWBACK,
+            TransactionType.LOAN_SET,
+            TransactionType.LOAN_DELETE,
+            TransactionType.LOAN_MANAGE,
+            TransactionType.LOAN_PAY,
+        ]:
+            self.assertIn(transaction_type, NON_DELEGABLE_TRANSACTIONS)
+            with self.assertRaises(XRPLModelException):
+                DelegateSet(
+                    account=_ACCOUNT,
+                    authorize=_DELEGATED_ACCOUNT,
+                    permissions=[Permission(permission_value=transaction_type)],
+                )

--- a/xrpl/models/transactions/delegate_set.py
+++ b/xrpl/models/transactions/delegate_set.py
@@ -23,6 +23,21 @@ NON_DELEGABLE_TRANSACTIONS = {
     TransactionType.ACCOUNT_DELETE,
     TransactionType.BATCH,
     TransactionType.SPONSORSHIP_TRANSFER,
+    TransactionType.VAULT_CREATE,
+    TransactionType.VAULT_SET,
+    TransactionType.VAULT_DELETE,
+    TransactionType.VAULT_DEPOSIT,
+    TransactionType.VAULT_WITHDRAW,
+    TransactionType.VAULT_CLAWBACK,
+    TransactionType.LOAN_BROKER_SET,
+    TransactionType.LOAN_BROKER_DELETE,
+    TransactionType.LOAN_BROKER_COVER_DEPOSIT,
+    TransactionType.LOAN_BROKER_COVER_WITHDRAW,
+    TransactionType.LOAN_BROKER_COVER_CLAWBACK,
+    TransactionType.LOAN_SET,
+    TransactionType.LOAN_DELETE,
+    TransactionType.LOAN_MANAGE,
+    TransactionType.LOAN_PAY,
 }
 
 


### PR DESCRIPTION
## Summary
- rippled develop marks the entire Vault (XLS-65) and Loan/LoanBroker transaction families as NotDelegable, but xrpl-py's `NON_DELEGABLE_TRANSACTIONS` set was missing all 15 of these types.
- Added the 15 missing `TransactionType` entries (6 Vault, 9 Loan/LoanBroker) to `NON_DELEGABLE_TRANSACTIONS` in `delegate_set.py`.
