### PR TITLE
ci: support private xrpld images via committed config file

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -2,7 +2,6 @@ name: Integration test
 
 env:
   POETRY_VERSION: 2.1.1
-  XRPLD_DOCKER_IMAGE: rippleci/xrpld:develop
 
 on:
   push:
@@ -19,10 +18,74 @@ on:
         default: ""
 
 jobs:
+  resolve_xrpld_image:
+    name: Resolve xrpld image
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    outputs:
+      image: ${{ steps.resolve.outputs.image }}
+      is_private: ${{ steps.resolve.outputs.is_private }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_ref != '' && inputs.git_ref || github.ref }}
+
+      - name: Resolve xrpld image
+        id: resolve
+        env:
+          IMAGE_CONFIG_FILE: .github/xrpld-image.env
+          DEFAULT_IMAGE: rippleci/xrpld:develop
+          PRIVATE_IMAGE_REPO: registry.gitlab.com/ripple/xrpledger/xrpld_package_deploy/xrpld-private
+          GITLAB_REGISTRY_USERNAME: ${{ vars.GITLAB_REGISTRY_USERNAME }}
+          GITLAB_REGISTRY_TOKEN: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Read the requested private version from the committed config file.
+          # The file is never sourced: on fork pull requests its contents are
+          # untrusted, so we only extract the value and validate it strictly.
+          PRIVATE_VERSION=""
+          if [[ -f "${IMAGE_CONFIG_FILE}" ]]; then
+            RAW_LINE="$(grep -E '^[[:space:]]*XRPLD_PRIVATE_VERSION[[:space:]]*=' "${IMAGE_CONFIG_FILE}" | tail -n1 || true)"
+            PRIVATE_VERSION="$(printf '%s' "${RAW_LINE#*=}" | tr -d "[:space:]\"'")"
+          fi
+
+          if [[ -z "${PRIVATE_VERSION}" ]]; then
+            echo "No private xrpld version configured in ${IMAGE_CONFIG_FILE}; using default image ${DEFAULT_IMAGE}."
+            {
+              echo "image=${DEFAULT_IMAGE}"
+              echo "is_private=false"
+            } >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if ! [[ "${PRIVATE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(b|rc)[0-9]+)?$ ]]; then
+            echo "XRPLD_PRIVATE_VERSION in ${IMAGE_CONFIG_FILE} must use X.Y.Z, X.Y.Z-bN, or X.Y.Z-rcN format (got '${PRIVATE_VERSION}')." >&2
+            exit 1
+          fi
+
+          if [[ -z "${GITLAB_REGISTRY_USERNAME}" || -z "${GITLAB_REGISTRY_TOKEN}" ]]; then
+            echo "A private xrpld version (${PRIVATE_VERSION}) is configured but the GITLAB_REGISTRY_USERNAME variable and GITLAB_REGISTRY_TOKEN secret are unavailable. These are not exposed to fork pull requests; run the private build from a branch in this repository, or clear XRPLD_PRIVATE_VERSION to use the default image." >&2
+            exit 1
+          fi
+
+          echo "Using private xrpld image for version ${PRIVATE_VERSION}."
+          {
+            echo "image=${PRIVATE_IMAGE_REPO}:private-${PRIVATE_VERSION}"
+            echo "is_private=true"
+          } >> "${GITHUB_OUTPUT}"
+
   integration-test:
     name: Integration test
+    needs: resolve_xrpld_image
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      XRPLD_DOCKER_IMAGE: ${{ needs.resolve_xrpld_image.outputs.image }}
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -40,6 +103,16 @@ jobs:
           path: /home/runner/.local
           key: dotlocal-${{ env.POETRY_VERSION }}
 
+      - name: Log in to the private GitLab registry
+        if: ${{ needs.resolve_xrpld_image.outputs.is_private == 'true' }}
+        env:
+          GITLAB_REGISTRY_USERNAME: ${{ vars.GITLAB_REGISTRY_USERNAME }}
+          GITLAB_REGISTRY_TOKEN: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
+        run: |
+          printf '%s' "${GITLAB_REGISTRY_TOKEN}" | docker login registry.gitlab.com \
+            --username "${GITLAB_REGISTRY_USERNAME}" \
+            --password-stdin
+
       - name: Run docker in background
         run: |
           docker run \
@@ -48,7 +121,7 @@ jobs:
             --publish 6006:6006 \
             --volume "${{ github.workspace }}/.ci-config/":"/etc/xrpld/" \
             --name xrpld-service \
-            ${{ env.XRPLD_DOCKER_IMAGE }} --standalone
+            "${XRPLD_DOCKER_IMAGE}" --standalone
 
       - name: Install poetry
         if: steps.cache-poetry.outputs.cache-hit != 'true'

--- a/.github/xrpld-image.env
+++ b/.github/xrpld-image.env
@@ -1,0 +1,14 @@
+# xrpld image selection for the integration test workflow.
+#
+# Set XRPLD_PRIVATE_VERSION to a private xrpld release (for example, 3.3.0-rc2
+# or 3.3.0-b1) to run the integration tests against the private image:
+#   registry.gitlab.com/ripple/xrpledger/xrpld_package_deploy/xrpld-private:private-<version>
+#
+# Leave it empty to use the default public image rippleci/xrpld:develop.
+#
+# Private pulls require the repository variable GITLAB_REGISTRY_USERNAME and the
+# repository secret GITLAB_REGISTRY_TOKEN (a GitLab deploy token with
+# read_registry access). These credentials are not exposed to fork pull
+# requests, so a private version must be tested from a branch in this
+# repository; a fork pull request with a private version set will fail fast.
+XRPLD_PRIVATE_VERSION=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,10 @@ Breaking down the command:
 
 When you're done, stop and remove the container with `docker stop xrpld-service && docker rm xrpld-service`.
 
+Maintainers can run the CI integration tests against a private xrpld image by committing a version to `.github/xrpld-image.env`. Set `XRPLD_PRIVATE_VERSION` to the version without the `private-` prefix (for example, `XRPLD_PRIVATE_VERSION=3.3.0-rc2`); every workflow run triggered afterwards — including pull request runs — pulls `registry.gitlab.com/ripple/xrpledger/xrpld_package_deploy/xrpld-private:private-<version>`. Leave the value empty to use the default public image `rippleci/xrpld:develop`.
+
+Private image access requires the repository variable `GITLAB_REGISTRY_USERNAME` and repository secret `GITLAB_REGISTRY_TOKEN`, configured with a GitLab deploy token that has `read_registry` access. These credentials are not exposed to fork pull requests, so a private version must be tested from a branch in this repository; a fork pull request with a private version set will fail fast rather than silently fall back.
+
 Then to actually run the tests, run the command:
 
 ```bash


### PR DESCRIPTION
## High Level Overview of Change

- Drive xrpld image selection from a committed config file, `.github/xrpld-image.env`, so pull-request-triggered CI can run the integration tests against a private xrpld image without manual workflow dispatch.
- Add a `resolve_xrpld_image` job to the Integration test workflow that reads `XRPLD_PRIVATE_VERSION` from the config file: when set, the integration tests use the private GitLab image; when empty, they use the default public image `rippleci/xrpld:develop`.
- Authenticate private pulls with the `GITLAB_REGISTRY_USERNAME` repository variable and read-only `GITLAB_REGISTRY_TOKEN` deploy-token secret.
- Document the config-file workflow and required repository credentials in `CONTRIBUTING.md`.

### Context of Change

Private `xrpl-py` builds need to run integration tests against xrpld images published only to the Ripple GitLab registry. Selecting the image from a committed config file means a branch (including a PR branch in this repository) can opt into a private image simply by setting `XRPLD_PRIVATE_VERSION`, with no manual `workflow_dispatch` step.

The resolver never sources the config file: it extracts the value and validates it against a strict `X.Y.Z`, `X.Y.Z-bN`, or `X.Y.Z-rcN` pattern before constructing `private-<version>`, avoiding arbitrary image references and shell injection. When a private version is configured but the registry credentials are unavailable — as happens on fork pull requests, where GitHub withholds secrets — the job fails fast with a clear message rather than silently falling back.

This mirrors the same mechanism added to `xrpl.js` (XRPLF/xrpl.js#3416) so both libraries select the CI xrpld image the same way.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [x] Documentation Updates
- [ ] Release

### Did you update CHANGELOG.md?

- [ ] Yes
- [x] No, this change does not impact library users

## Test Plan

- Parsed `.github/workflows/integration_test.yml` with a YAML loader.
- Ran the resolver's config-file parsing locally against empty, quoted, whitespace-padded, and commented values.
- Verified the version regex accepts `X.Y.Z`, `X.Y.Z-bN`, and `X.Y.Z-rcN` and rejects malformed versions and shell-injection attempts.
- With `XRPLD_PRIVATE_VERSION` empty (as committed here), `resolve_xrpld_image` resolves to the default `rippleci/xrpld:develop` and the integration tests run unchanged.

> Note: to test the private image, set `XRPLD_PRIVATE_VERSION` on a branch pushed directly to this repository (not a fork), so the `GITLAB_REGISTRY_TOKEN` secret is available.
