### PR TITLE
docs: add .ai-review/instructions.md for repo-specific review context

### DIFF
--- a/.ai-review/instructions.md
+++ b/.ai-review/instructions.md
@@ -1,0 +1,110 @@
+# Reviewing xrpl-py
+
+xrpl-py is the canonical **Python SDK for the XRP Ledger** (`xrpl/`: models, binary codec, keypairs,
+address codec, sync + async clients). It is a **financial primitive**: amount, serialization, and
+signing bugs corrupt transactions or break consensus compatibility and surface only against a
+live network. **rippled is the source of truth** — verify fields, types, and flags against it,
+not intuition or a draft spec.
+
+## Amounts & numbers
+- A bare `str` in the `Amount` union is XRP in **drops** (integer string; the codec rejects any
+  decimal point in XRP/MPT strings — don't suggest accepting them). IOU `value` strings may be
+  decimal.
+- Amount **encode** (`Amount.from_value`) and drops conversions wrap Decimal math in
+  `IOU_`/`DROPS_DECIMAL_CONTEXT`; flag new plain-context Decimals there. Decode (`Amount.to_json`)
+  uses the ambient context deliberately — don't flag it.
+- Decimal→string on encode paths must force fixed-point (`f"{value:f}"`) and only `rstrip("0")` when
+  a `.` is present (a 5.0.0 truncation fix). Flag a new full-value `str(Decimal)` or a `rstrip("0")`
+  on an un-split value; a rstrip on an already-separated fractional slice is fine.
+- IOU bounds are protocol-fixed (≤16 significant digits, exponent −96…80); underflow **silently
+  rounds to zero encoding** (matches rippled). MPT values are unsigned 63-bit integer strings (the
+  MSB is spec).
+- The model layer is deliberately lenient (`IssuedCurrencyAmount.value` = `str|int|float`);
+  validation lives in the codec. DO flag IOU values round-tripped through `float` on encode paths.
+
+## Binary serialization & the Number type
+- **Round-trip is the core invariant**: `encode(decode(blob)) == blob`, `decode(encode(json)) ==
+  json`. A new/changed `SerializedType` needs both directions in lockstep plus round-trip tests.
+- Wire order is **ordinal** (`type_code << 16 | nth`, sorted in `STObject.from_value`); unsorted
+  output looks valid but rippled rejects it.
+- The `Number` codec deliberately **ports rippled's C++ Number/STNumber** (sentinel zero, string-built
+  `to_json`). Don't suggest idiomatic-Python numerics; changes need boundary tests.
+- A type named in `definitions.json` needs a `SerializedType` class **imported and in `__all__`** of
+  `binarycodec/types/__init__.py`: resolution raises `KeyError` lazily on first field use
+  (survives CI that never exercises it).
+
+## Generated code (definitions.json & transaction models)
+- `definitions.json` is **machine-generated** from rippled headers (`poe definitions <rippled ref>`;
+  `poe generate` also regenerates models). Hand-edits are lost on regen — a hand-edited
+  definitions.json is itself the finding. Verify changed mappings against rippled's macros (the
+  5.0.0 `sfMutableFlags` mis-mapping).
+- In a definitions.json diff, mass **TER-code renumbering is legitimate** (implicit-increment
+  derivation; check anchors like `tesSUCCESS = 0`), but unexplained **deletions are the red flag** —
+  the generator's regexes silently drop macro lines they fail to parse.
+- Transaction models are **generated once, then hand-maintained**: hand-edits survive regen; a bare
+  new model needing hand-finishing is normal. A `TRANSACTION_TYPES` addition with **no matching
+  model file** usually means the model generator's regex dropped it.
+
+## Transaction models & validation
+- Adding a tx type touches **three sites**: model module; `TransactionType` member whose value
+  **exactly equals the class name**; import **and** `__all__` entry in `transactions/__init__.py`. A
+  missing **import** breaks polymorphic `from_dict` for **every** type (eager `getattr` dispatch); a
+  missing `__all__` entry breaks dict-style flag parsing.
+- Every model subclass declaring fields needs its **own `@dataclass(frozen=True, kw_only=True)`** —
+  not inherited; without it the fields are silently excluded from `__init__`.
+- Flags are name-coupled: `{TxType}Flag(int, Enum)` + `{TxType}FlagInterface` (identical member
+  names), both in `__all__` — a mismatch makes dict-style flags silently resolve to 0.
+- `_get_errors()` overrides must merge `super()._get_errors()`; a fresh dict silently disables all
+  inherited validation. Flag-dependent checks belong here via `self.has_flag(...)`.
+- `field: T = REQUIRED` (an `object()` sentinel) is the required-field idiom
+  (optional = `Optional[T] = None`); `transaction_type: ... = field(..., init=False)` + its
+  `to_dict`/`from_dict` special-casing is the dispatch contract. Don't flag either.
+- Never default `flags` to 0 — omitted `Flags` vs `Flags: 0` changes the signed bytes.
+- Models are **STRICT — the opposite of xrpl.js**: `from_dict` raises on unknown keys (and real
+  rippled responses via `from_xrpl`). Don't suggest ignoring them. When rippled adds a field, the
+  model update must land with it.
+
+## Cryptography & signing
+- Secrets never appear in `__repr__`/`__str__`/exceptions: `_SENSITIVE_FIELDS` + a redacting
+  `__repr__` emit `-HIDDEN-`; new sensitive fields extend it. Seed validation re-raises with
+  `from None` (base58 errors embed seed bytes) — don't flag that; DO flag new interpolation of
+  seeds/keys/entropy into strings.
+- Seed-prefix inference is **load-bearing**: `sEd…` → ED25519, else SECP256K1; explicit `algorithm`
+  wins. Changing inference or defaults silently derives a **different address from the same seed**.
+  Don't suggest an ED25519 default for externally supplied seeds.
+- Signing is XRPL-spec: secp256k1 = `sha512_first_half` prehash + RFC-6979 + `canonical=True` low-S
+  (flag new signing code missing any); ed25519 signs the raw message — the asymmetry is spec.
+- Four prefixes (`STX`/`CLM`/`SMT`/`BCH`) domain-separate single-sign/claim/multisign/Batch
+  payloads; multisigning appends the signer AccountID suffix. Wrong/shared prefix or missing suffix
+  = signature replay. Outer `SigningPubKey` stays `""` when multisigning; signer arrays sort by
+  **decoded AccountID bytes**, not the base58 string; Batch uses `encode_for_signing_batch` only.
+- `isSigningField` changes in definitions.json are signature-compatibility breaks; verify against
+  rippled.
+
+## Sync/async parity (hand-maintained)
+- The async side is the implementation; sync functions in `xrpl/{account,ledger,transaction,wallet}/`
+  are verbatim `asyncio.run(...)` delegates with duplicated signatures/docstrings (the parity
+  contract). There is **no parity check**: flag edits to one side of a paired function without the
+  matching edit — drift fails silently.
+
+## Client & response handling
+- Transports never raise on rippled app errors: non-`success` returns `Response(status=ERROR)`;
+  callers gate on `is_successful()`. DO flag new helpers reading `response.result` without a
+  status check (WS errors put fields at top level).
+- The WebSocket `_handler` must **exception-isolate each frame**: one malformed frame must not kill
+  the handler task and every pending Future. Its internals (double delivery, fire-and-forget sends,
+  wide request IDs) are deliberate — flag removals, not oddity.
+
+## Test conventions (do NOT flag)
+- `snoPBrXtMeMyMHUVTgbuqAfg1SUTb` (and its `rHb9…` address) in `tests/integration/` is rippled's
+  public standalone-mode genesis account, not a leaked secret.
+- `@test_async_and_sync(globals())` **textually rewrites** async test bodies and `exec()`s the sync
+  variant — deliberate harness mechanics, not unsafe exec. Check the contract instead: tests are
+  `async def test_*(self, client)` on an `IntegrationTestCase` subclass, call helpers by their
+  `_async` names, and reuse `reusable_values.py` fixtures.
+
+## Contributor conventions
+- Python floor is **3.10** (CI up to 3.14): flag newer-than-3.10 syntax, and `Self`/`TypeVar(default=)`
+  imported from `typing` instead of `typing_extensions`. Don't request 3.8/3.9 compatibility.
+- `.github/xrpld-image.env` is high-blast-radius CI config: a committed private version redirects
+  the **integration-test** workflow (every PR run) and breaks fork-PR CI. Verify it's intentional and reset.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,28 +1,57 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 language: "en-US"
+
+# Short steer toward useful feedback for open-source contributors; skip style nits (max 250 chars).
+tone_instructions: "Be concise and encouraging to open-source contributors. Flag correctness, security, and API-contract issues; skip style and formatting nits."
+
 reviews:
-  # Set the profile for reviews. Assertive profile yields more feedback, that may be considered nitpicky.
+  # chill = fewer, higher-signal comments (assertive is nitpicky).
   profile: "chill"
-  # Approve the review once CodeRabbit's comments are resolved. Note: In GitLab, all discussions must be resolved.
+  # Keep the bot's review non-blocking; don't gate a contributor's merge on nitpicks.
   request_changes_workflow: false
-  # Generate a high level summary of the changes in the PR/MR description.
+  # Don't let the bot append a summary to the contributor's PR description.
   high_level_summary: false
-  # Generate a poem in the walkthrough comment.
-  poem: true
-  # Post review details on each review. Additionally, post a review status when a review is skipped in certain cases.
+  # poem is noise.
+  poem: false
+  # "Fortune" text while reviewing is noise.
+  in_progress_fortune: false
+  # Post a status note (incl. when a review is skipped).
   review_status: true
-  # Generate walkthrough in a markdown collapsible section.
+  # Walkthrough shown expanded (matches existing xrpl.js choice).
   collapse_walkthrough: false
-  # Abort the in-progress review if the pull request is closed or merged.
+  # Auto sequence diagrams are low-value filler on SDK PRs.
+  sequence_diagrams: false
+  # Cancel an in-progress review if the PR closes/merges.
   abort_on_close: true
-  auto_review:
-    # Automatic Review | Automatic code review
+  # Flag spam / low-effort PRs on public repos.
+  slop_detection:
     enabled: true
-    # Review draft PRs/MRs.
+  auto_review:
+    # Auto-review every PR.
+    enabled: true
+    # Don't review drafts contributors are still iterating on.
     drafts: false
-    # Ignore reviewing if the title of the pull request contains any of these keywords (case-insensitive).
+    # Skip dependency/release bumps.
     ignore_title_keywords:
-      - build(
+      - "build("
+  tools:
+    # Grammar/spell nits on comments and prose are false-positive noise.
+    languagetool:
+      enabled: false
+
 chat:
-  # Enable the bot to reply automatically without requiring the user to tag it.
+  # Let contributors ask follow-ups without @-mentioning the bot.
   auto_reply: true
+  # No ASCII/emoji art.
+  art: false
+  # Required for external (non-org) contributors to interact with the bot.
+  allow_non_org_members: true
+
+knowledge_base:
+  # Give the bot our XRPL-specific review grounding.
+  # applyTo: "**" makes .ai-review/instructions.md apply repo-wide (a guideline file
+  # otherwise scopes only to its own directory).
+  code_guidelines:
+    filePatterns:
+      - files: ".ai-review/instructions.md"
+        applyTo: "**"


### PR DESCRIPTION
## Summary

Adds a `.ai-review/instructions.md` file that the AI code reviewer reads before reviewing a pull request. It gives the reviewer context about how this codebase actually works, so its comments reflect xrpl-py's real conventions instead of generic Python advice. This is a review-guidance file only: it changes no code and no runtime behavior, and it does not affect CI or block merges.

## Why

The reviewer is general-purpose. Without repo context it tends to miss the pitfalls that are specific to a financial SDK and, worse, flag intentional idioms as if they were bugs. This file encodes the things a new senior reviewer would need to know before commenting on xrpl-py, for example:

- XRP amounts are integer drop strings, not decimals, and Decimal math is scoped to specific contexts.
- `definitions.json` and the transaction models are generated from rippled, so a hand-edit is usually the finding.
- Models are strict: `from_dict` rejects unknown keys by design.
- The sync API is a hand-maintained wrapper over the async implementation, with no automated parity check, so one-sided edits drift silently.
- Signing has XRPL-specific settings and domain-separation prefixes where a wrong value fails only on-ledger.

It also tells the reviewer which patterns are deliberate and should not be flagged (for example the genesis test account in integration tests, and the async/sync test harness).

## What's in it

A short, high-signal list grouped by area:

- Amounts and numbers
- Binary serialization and the Number type
- Generated code (definitions.json and transaction models)
- Transaction models and validation
- Cryptography and signing
- Sync/async parity
- Client and response handling
- Test conventions (idioms not to flag)
- Contributor conventions

The file is intentionally small so it fits the reviewer's context budget.

## How it was built and checked

- Derived from a scan of the codebase plus a review of what human reviewers have historically commented on in xrpl-py pull requests.
- Every rule was validated against the current code on `main`: each cited file and symbol was opened and confirmed.
- A separate verification pass re-checked each rule for accuracy and for false-positive safety (would a reviewer applying it literally flag correct code?), with an independent second review confirming each change. Rules that could cause false positives were narrowed or dropped.

## Notes for reviewers

- This is guidance, not policy. You can edit it through the normal PR process, and the reviewer will pick up the change.
- No package behavior changes, so no CHANGELOG entry is included.
- This mirrors the equivalent file added to xrpl.js, so review guidance stays consistent across the XRPL SDKs.
