### PR TITLE
fix: reject incomplete hex bytes in MPT metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [[Unreleased]]
 
+### Fixed
+
+- Return a hex-format validation message instead of raising `ValueError` when `validate_mptoken_metadata` receives an odd-length hex string.
+- Reject odd-length `mptoken_metadata` with `XRPLModelException` in `MPTokenIssuanceCreate`, `MPTokenIssuanceSet`, and `VaultCreate` before serialization.
+
 ## [[5.1.0]]
 
 ### Added

--- a/tests/unit/models/test_utils.py
+++ b/tests/unit/models/test_utils.py
@@ -52,6 +52,29 @@ class TestUtils(TestCase):
 
 
 class TestMPTokenMetadataValidation(TestCase):
+    def test_rejects_incomplete_hex_bytes(self):
+        for metadata_hex in ("A", "abc", "7B0", str_to_hex('{"t":"USD"}')[:-1]):
+            with self.subTest(metadata_hex=metadata_hex):
+                self.assertEqual(
+                    ["MPTokenMetadata must be in hex format."],
+                    validate_mptoken_metadata(metadata_hex),
+                )
+
+    def test_rejects_non_hex_characters(self):
+        for metadata_hex in ("ZZ", "0x1234", "7B 7D"):
+            with self.subTest(metadata_hex=metadata_hex):
+                self.assertEqual(
+                    ["MPTokenMetadata must be in hex format."],
+                    validate_mptoken_metadata(metadata_hex),
+                )
+
+    def test_invalid_encoded_content_returns_validation_messages(self):
+        for metadata_hex in ("", "FF", str_to_hex("not json")):
+            with self.subTest(metadata_hex=metadata_hex):
+                messages = validate_mptoken_metadata(metadata_hex)
+                self.assertEqual(1, len(messages))
+                self.assertIn("not properly formatted as JSON", messages[0])
+
     def test_mptoken_metadata_validation_messages(self):
         test_file = os.path.join(
             os.path.dirname(__file__), "mptoken-metadata-validation-fixtures.json"

--- a/tests/unit/models/transactions/test_mptoken_issuance_create.py
+++ b/tests/unit/models/transactions/test_mptoken_issuance_create.py
@@ -15,6 +15,13 @@ _ACCOUNT = "r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ"
 
 
 class TestMPTokenIssuanceCreate(TestCase):
+    def test_odd_length_metadata_is_rejected(self):
+        for metadata in ("A", "abc", "7B0"):
+            with self.subTest(metadata=metadata):
+                with self.assertRaises(XRPLModelException) as error:
+                    MPTokenIssuanceCreate(account=_ACCOUNT, mptoken_metadata=metadata)
+                self.assertIn("mptoken_metadata", str(error.exception))
+
     def test_tx_is_valid(self):
         mptoken_metadata = {
             "ticker": "TBILL",

--- a/tests/unit/models/transactions/test_mptoken_issuance_set.py
+++ b/tests/unit/models/transactions/test_mptoken_issuance_set.py
@@ -251,6 +251,9 @@ class TestMPTokenIssuanceSet(TestCase):
         cases = [
             ("FF" * 1025, "Metadata must be a hex string less than 1024 bytes"),
             ("not_hex_string", "Metadata must be a valid hex string"),
+            ("A", "Metadata must be a valid hex string"),
+            ("abc", "Metadata must be a valid hex string"),
+            ("7B0", "Metadata must be a valid hex string"),
         ]
         for metadata, message in cases:
             with self.subTest(message=message):

--- a/tests/unit/models/transactions/test_vault_create.py
+++ b/tests/unit/models/transactions/test_vault_create.py
@@ -11,6 +11,17 @@ _ACCOUNT = "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW"
 
 
 class TestVaultCreate(TestCase):
+    def test_odd_length_metadata_is_rejected(self):
+        for metadata in ("A", "abc", "7B0"):
+            with self.subTest(metadata=metadata):
+                with self.assertRaises(XRPLModelException) as error:
+                    VaultCreate(
+                        account=_ACCOUNT,
+                        asset=IssuedCurrency(currency="USD", issuer=_ACCOUNT),
+                        mptoken_metadata=metadata,
+                    )
+                self.assertIn("mptoken_metadata", str(error.exception))
+
     def test_valid(self):
         tx = VaultCreate(
             account=_ACCOUNT,

--- a/xrpl/models/transactions/mptoken_issuance_create.py
+++ b/xrpl/models/transactions/mptoken_issuance_create.py
@@ -182,6 +182,7 @@ class MPTokenIssuanceCreate(Transaction):
         if self.mptoken_metadata is not None and (
             len(self.mptoken_metadata) == 0
             or len(self.mptoken_metadata) > MAX_MPTOKEN_METADATA_LENGTH
+            or len(self.mptoken_metadata) % 2
             or not HEX_REGEX.fullmatch(self.mptoken_metadata)
         ):
             errors["mptoken_metadata"] = (

--- a/xrpl/models/transactions/mptoken_issuance_set.py
+++ b/xrpl/models/transactions/mptoken_issuance_set.py
@@ -297,7 +297,9 @@ class MPTokenIssuanceSet(Transaction):
                     "Metadata must be a hex string less than 1024 bytes "
                     "(alternatively, 2048 hex characters)."
                 )
-            elif not HEX_REGEX.fullmatch(self.mptoken_metadata):
+            elif len(self.mptoken_metadata) % 2 or not HEX_REGEX.fullmatch(
+                self.mptoken_metadata
+            ):
                 errors["mptoken_metadata"] = "Metadata must be a valid hex string"
             else:
                 # Lazy import to avoid circular dependency

--- a/xrpl/models/transactions/vault_create.py
+++ b/xrpl/models/transactions/vault_create.py
@@ -115,6 +115,7 @@ class VaultCreate(Transaction):
         if self.mptoken_metadata is not None and (
             len(self.mptoken_metadata) == 0
             or len(self.mptoken_metadata) > MAX_MPTOKEN_METADATA_LENGTH
+            or len(self.mptoken_metadata) % 2
             or not HEX_REGEX.fullmatch(self.mptoken_metadata)
         ):
             errors["mptoken_metadata"] = (

--- a/xrpl/utils/mptoken_metadata.py
+++ b/xrpl/utils/mptoken_metadata.py
@@ -348,7 +348,7 @@ def validate_mptoken_metadata(input_hex: str) -> List[str]:
     """
     validation_messages: List[str] = []
 
-    if bool(HEX_REGEX.fullmatch(input_hex)) is False:
+    if len(input_hex) % 2 or not HEX_REGEX.fullmatch(input_hex):
         validation_messages.append("MPTokenMetadata must be in hex format.")
         return validation_messages
 


### PR DESCRIPTION
## High Level Overview of Change

Reject odd-length MPT metadata at the hex-format boundary. The public validator returns its usual validation-message list, while the three transaction models reject incomplete hex bytes with `XRPLModelException`.

### Context of Change

`HEX_REGEX` checks characters but accepts strings such as `"A"` and `"abc"`. Those reach `bytes.fromhex` through `hex_to_str`, raising a plain `ValueError` that escapes `validate_mptoken_metadata` instead of returning a list.

The utility fix needs matching checks in `MPTokenIssuanceCreate`, `MPTokenIssuanceSet`, and `VaultCreate`: otherwise malformed hex would pass model validation with only an XLS-89 warning and fail later during serialization. This keeps invalid byte encoding distinct from advisory metadata-schema warnings. Empty-string metadata removal in `MPTokenIssuanceSet` is unchanged, and the shared regex is deliberately left alone.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests

### Did you update CHANGELOG.md?

- [x] Yes

## Test Plan

- Regression tests cover one-character, lowercase, and truncated JSON hex inputs; non-hex characters; and the three transaction-model callers.
- The utility cases reproduced the uncaught `ValueError` on the original code. The model tests also caught the warning-only acceptance when only the utility was fixed.
- `python -m unittest discover -s tests/unit -q`: 1,074 tests run, 3 skipped, no failures.
- `python -m flake8 xrpl tests`: passes with the configured plugins.
- Black checks on the changed Python files: pass.

All checks were local. No ledger, faucet, wallet, or network integration tests were run.
